### PR TITLE
Load to WriteableBitmap instead of BitmapImage on WinRT

### DIFF
--- a/Splat/WinRT/Bitmaps.cs
+++ b/Splat/WinRT/Bitmaps.cs
@@ -17,8 +17,7 @@ namespace Splat
     {
         public async Task<IBitmap> Load(Stream sourceStream, float? desiredWidth, float? desiredHeight)
         {
-            using (var rwStream = new InMemoryRandomAccessStream())
-            {
+            using (var rwStream = new InMemoryRandomAccessStream()) {
                 await sourceStream.CopyToAsync(rwStream.AsStreamForWrite());
 
                 var decoder = await BitmapDecoder.CreateAsync(rwStream);
@@ -33,8 +32,7 @@ namespace Splat
                 var pixels = pixelData.DetachPixelData();
 
                 WriteableBitmap bmp = new WriteableBitmap((int)decoder.OrientedPixelWidth, (int)decoder.OrientedPixelHeight);
-                using (var bmpStream = bmp.PixelBuffer.AsStream())
-                {
+                using (var bmpStream = bmp.PixelBuffer.AsStream()) {
                     bmpStream.Seek(0, SeekOrigin.Begin);
                     bmpStream.Write(pixels, 0, (int)bmpStream.Length);
                     return (IBitmap) new WriteableBitmapImageBitmap(bmp);


### PR DESCRIPTION
BitmapImage is close to useless if any kind of manipulation needs to be done, especially since it's pretty much a one-way trip for the source stream. That's just my opinion though, if BitmapImage is still a better choice then I'd like to suggest #15.
