### PR TITLE
Performance enhancements to AppKit bitmaps

### DIFF
--- a/Splat/Cocoa/Bitmaps.cs
+++ b/Splat/Cocoa/Bitmaps.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Drawing;
 
 #if UIKIT
 using MonoTouch.UIKit;
@@ -76,7 +77,7 @@ namespace Splat
 
                 var props = format == CompressedBitmapFormat.Png ? 
                     new NSDictionary() : 
-                    new NSDictionary(new NSNumber(quality), AppKitConstants.NSImageCompressionFactor);
+                    new NSDictionary(new NSNumber(quality), new NSString("NSImageCompressionFactor"));
 
                 var type = format == CompressedBitmapFormat.Png ? NSBitmapImageFileType.Png : NSBitmapImageFileType.Jpeg;
 


### PR DESCRIPTION
From @jonlipsky, via Email:

<hr/>

I did notice one thing in your implementation of Cocoa for Xamarin.Mac, where you could get around a 100x performance improvement by changing the implementation.  Specifically, you're doing the following currently:

``` cs
var imageRep = (NSBitmapImageRep)NSBitmapImageRep.ImageRepFromData(inner.AsTiff());
```

If you change this to the following, it performs better (especially with larger bitmaps):

``` cs
var rect = new RectangleF ();
var cgimage = image.AsCGImage (ref rect, null,null);
var imageRep = new NSBitmapImageRep(cgimage);
```

When I was first building TouchDraw, I benchmarked the different ways to do this, and at the time, using a 300k image, the CGImage approach was 122 times faster.  I just re-ran my benchmark and got similar results, so it still holds true.

Also, one other minor improvement you may want to make.  Right now, you have the following line for creating the dictionary for JPEG output:

``` cs
new NSDictionary(new NSNumber(quality), new NSString("NSImageCompressionFactor"));
```

There's actually a constant available for the NSImageCompressionFactor available in the framework.  It's minor, but it's one less wrapped object that needs to be created.  You could replace that with this:

``` cs
dictionary = new NSDictionary(new NSNumber(quality), AppKitConstants.NSImageCompressionFactor);
```
