### PR TITLE
Library registration for service location

### DIFF
--- a/Splat/ServiceLocation.cs
+++ b/Splat/ServiceLocation.cs
@@ -15,9 +15,12 @@ namespace Splat
         static Locator()
         {
             var r = new ModernDependencyResolver();
-            r.InitializeSplat();
-
             dependencyResolver = r;
+
+            RegisterResolverCallbackChanged(() => {
+                if (Locator.CurrentMutable == null) return;
+                Locator.CurrentMutable.InitializeSplat();
+            });
         }
 
         /// <summary>


### PR DESCRIPTION
For libraries that want to base themselves on Splat's service locator, making sure your types are registered properly is annoyingly difficult, and ends up pushing the problem to the user, where today, if you set the locator in your app with RxUI and Akavache, you now have to run:

``` cs
Locator.CurrentMutable = new MyCoolLocator();
Locator.CurrentMutable.InitializeSplat();
Locator.CurrentMutable.InitializeReactiveUI();
Locator.CurrentMutable.InitializeAkavache();
```

Instead, this PR adds a way for libraries to get called back when they have a new resolver to set up:

``` cs
RegisterResolverCallbackChanged(() => {
    if (Locator.CurrentMutable == null) return;
    Locator.CurrentMutable.InitializeSplat();
});
```

You'd call this in either a static constructor of your library (if you can), or in a [Module Initializer](http://einaregilsson.com/module-initializers-in-csharp/) if you really want to be sure. 
