### PR TITLE
Fixed the ignoring of the alpha channel in WinRT (not ideal)

### DIFF
--- a/Splat/WinRT/Bitmaps.cs
+++ b/Splat/WinRT/Bitmaps.cs
@@ -33,7 +33,7 @@ namespace Splat
                         InterpolationMode = BitmapInterpolationMode.Fant
                     };
 
-                    var pixelData = await decoder.GetPixelDataAsync(decoder.BitmapPixelFormat, decoder.BitmapAlphaMode, transform, ExifOrientationMode.RespectExifOrientation, ColorManagementMode.ColorManageToSRgb);
+                    var pixelData = await decoder.GetPixelDataAsync(decoder.BitmapPixelFormat, BitmapAlphaMode.Premultiplied, transform, ExifOrientationMode.RespectExifOrientation, ColorManagementMode.ColorManageToSRgb);
                     var pixels = pixelData.DetachPixelData();
 
                     var bmp = new WriteableBitmap((int)transform.ScaledWidth, (int)transform.ScaledHeight);


### PR DESCRIPTION
Not ideal, because it hardcodes `Premultiplied`, when the image format's alpha could potentially be `Straight`. However, this is still better than `Ignore` as it was before. It was because  `decoder.BitmapAlphaMode` would return Ignore since Microsoft just sets it to Ignore regardless of format.

http://social.msdn.microsoft.com/Forums/windowsapps/en-US/454e63bf-46f8-43b3-b8bd-d9280fb49d40/how-to-get-the-right-alpha-mode-when-editing-an-image-using-bitmapdecoder?forum=winappswithcsharp
