### PR TITLE
Switch Splat to Profile259.

### DIFF
--- a/Splat/Splat-Portable.csproj
+++ b/Splat/Splat-Portable.csproj
@@ -21,14 +21,14 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\Portable-Net45+WinRT45+WP8\</OutputPath>
+    <OutputPath>bin\Debug\Portable-Net45+WinRT45+WP8+WPA81\</OutputPath>
     <DefineConstants>DEBUG;TRACE;PORTABLE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\Portable-Net45+WinRT45+WP8\</OutputPath>
+    <OutputPath>bin\Release\Portable-Net45+WinRT45+WP8+WPA81\</OutputPath>
     <DefineConstants>TRACE;PORTABLE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
This PR changes the portable profile to include WPA 8.1 (I have no idea what to call this. Windows Phone Runtime maybe?) support, similar to https://github.com/reactiveui/ReactiveUI/pull/552.
## Details

As @dsplaisted mentioned in http://www.twitter.com/dsplaisted/status/451487953483620352 Profile259 is the new Profile78. The only difference is that WCF is missing from Profile259. 
Since Splat is not using WCF anyway it makes sense to make the switch to ensure it can still be referenced by other PCLs that include WPA81.
