### PR TITLE
Include assembly info in portable.

### DIFF
--- a/Splat/Splat-Portable.csproj
+++ b/Splat/Splat-Portable.csproj
@@ -37,7 +37,6 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->
-    <Folder Include="Properties\" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyFinder.cs" />
@@ -55,6 +54,7 @@
     <Compile Include="ModeDetector.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RectangleExtensions.cs" />
     <Compile Include="ReflectionStubs.cs" />
     <Compile Include="SizeExtensions.cs" />


### PR DESCRIPTION
Bait and switch only works if the version number of the PCL is the same as the platforms projects. Apparently the `AssemblyInfo.cs` class was not included in Splats PCL.
