### PR TITLE
Make the WinRT PlatformBitmapLoader public

### DIFF
--- a/Splat/WinRT/Bitmaps.cs
+++ b/Splat/WinRT/Bitmaps.cs
@@ -13,7 +13,7 @@ using Windows.UI.Core;
 
 namespace Splat
 {
-    class PlatformBitmapLoader : IBitmapLoader
+    public class PlatformBitmapLoader : IBitmapLoader
     {
         public async Task<IBitmap> Load(Stream sourceStream, float? desiredWidth, float? desiredHeight)
         {


### PR DESCRIPTION
otherwise BitmapMixins is inaccessible
