### PR TITLE
Improve WrappingFullLogger flexibility by extracting out the prefix logic into a separate class

### DIFF
--- a/Splat/Logging.cs
+++ b/Splat/Logging.cs
@@ -110,7 +110,7 @@ namespace Splat
                     throw new Exception("Couldn't find an ILogger. This should never happen, your dependency resolver is probably broken.");
                 }
 
-                return new WrappingFullLogger(ret, type);
+                return new WrappingFullLogger(new WrappingPrefixLogger(ret, type), type);
             }, 64);
         }
 
@@ -165,6 +165,28 @@ namespace Splat
         public LogLevel Level { get; set; }
     }
 
+    public class WrappingPrefixLogger : ILogger
+    {
+        readonly ILogger _inner;
+        readonly string prefix;
+
+        public WrappingPrefixLogger(ILogger inner, Type callingType)
+        {
+            _inner = inner;
+            prefix = String.Format(CultureInfo.InvariantCulture, "{0}: ", callingType.Name);
+        }
+
+        public LogLevel Level
+        {
+            get { return _inner.Level; }
+            set { _inner.Level = value; }
+        }
+
+        public void Write([Localizable(false)]string message, LogLevel logLevel)
+        {
+            _inner.Write(prefix + message, logLevel);
+        }
+    }
 
     /*    
      * LogHost / Logging Mixin
@@ -220,13 +242,11 @@ namespace Splat
     public class WrappingFullLogger : IFullLogger
     {
         readonly ILogger _inner;
-        readonly string prefix;
         readonly MethodInfo stringFormat;
 
         public WrappingFullLogger(ILogger inner, Type callingType)
         {
             _inner = inner;
-            prefix = String.Format(CultureInfo.InvariantCulture, "{0}: ", callingType.Name);
 
             stringFormat = typeof (String).GetMethod("Format", new[] {typeof (IFormatProvider), typeof (string), typeof (object[])});
             Contract.Requires(inner != null);
@@ -244,316 +264,341 @@ namespace Splat
 
         public void Debug<T>(T value)
         {
-            _inner.Write(prefix + value, LogLevel.Debug);
+            if (value == null)
+            {
+                return;
+            }
+
+            _inner.Write(value.ToString(), LogLevel.Debug);
         }
 
         public void Debug<T>(IFormatProvider formatProvider, T value)
         {
-            _inner.Write(String.Format(formatProvider, "{0}{1}", prefix, value), LogLevel.Debug);
+            _inner.Write(String.Format(formatProvider, "{0}", value), LogLevel.Debug);
         }
 
         public void DebugException(string message, Exception exception)
         {
-            _inner.Write(String.Format("{0}{1}: {2}", prefix, message, exception), LogLevel.Debug);
+            _inner.Write(String.Format("{0}: {1}", message, exception), LogLevel.Debug);
         }
 
         public void Debug(IFormatProvider formatProvider, string message, params object[] args)
         {
             var result = InvokeStringFormat(formatProvider, message, args);
 
-            _inner.Write(prefix + result, LogLevel.Debug);
+            _inner.Write(result, LogLevel.Debug);
         }
 
 
         public void Debug(string message)
         {
-            _inner.Write(prefix + message, LogLevel.Debug);
+            _inner.Write(message, LogLevel.Debug);
         }
 
         public void Debug(string message, params object[] args)
         {
             var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
-            _inner.Write(prefix + result, LogLevel.Debug);
+            _inner.Write(result, LogLevel.Debug);
         }
 
         public void Debug<TArgument>(IFormatProvider formatProvider, string message, TArgument argument)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument), LogLevel.Debug);
+            _inner.Write(String.Format(formatProvider, message, argument), LogLevel.Debug);
         }
 
         public void Debug<TArgument>(string message, TArgument argument)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Debug);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Debug);
         }
 
         public void Debug<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2), LogLevel.Debug);
+            _inner.Write(String.Format(formatProvider, message, argument1, argument2), LogLevel.Debug);
         }
 
         public void Debug<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Debug);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Debug);
         }
 
         public void Debug<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Debug);
+            _inner.Write(String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Debug);
         }
 
         public void Debug<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Debug);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Debug);
         }
 
         public void Info<T>(T value)
         {
-            _inner.Write(prefix + value, LogLevel.Info);
+            if (value == null)
+            {
+                return;
+            }
+
+            _inner.Write(value.ToString(), LogLevel.Info);
         }
 
         public void Info<T>(IFormatProvider formatProvider, T value)
         {
-            _inner.Write(String.Format(formatProvider, "{0}{1}", prefix, value), LogLevel.Info);
+            _inner.Write(String.Format(formatProvider, "{0}", value), LogLevel.Info);
         }
 
         public void InfoException(string message, Exception exception)
         {
-            _inner.Write(String.Format("{0}{1}: {2}", prefix, message, exception), LogLevel.Info);
+            _inner.Write(String.Format("{0}: {1}", message, exception), LogLevel.Info);
         }
 
         public void Info(IFormatProvider formatProvider, string message, params object[] args)
         {
             var result = InvokeStringFormat(formatProvider, message, args);
-            _inner.Write(prefix + result, LogLevel.Info);
+            _inner.Write(result, LogLevel.Info);
         }
 
         public void Info(string message)
         {
-            _inner.Write(prefix + message, LogLevel.Info);
+            _inner.Write(message, LogLevel.Info);
         }
 
         public void Info(string message, params object[] args)
         {
             var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
-            _inner.Write(prefix + result, LogLevel.Info);
+            _inner.Write(result, LogLevel.Info);
         }
 
         public void Info<TArgument>(IFormatProvider formatProvider, string message, TArgument argument)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument), LogLevel.Info);
+            _inner.Write(String.Format(formatProvider, message, argument), LogLevel.Info);
         }
 
         public void Info<TArgument>(string message, TArgument argument)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Info);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Info);
         }
 
         public void Info<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2), LogLevel.Info);
+            _inner.Write(String.Format(formatProvider, message, argument1, argument2), LogLevel.Info);
         }
 
         public void Info<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Info);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Info);
         }
 
         public void Info<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Info);
+            _inner.Write(String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Info);
         }
 
         public void Info<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Info);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Info);
         }
 
         public void Warn<T>(T value)
         {
-            _inner.Write(prefix + value, LogLevel.Warn);
+            if (value == null)
+            {
+                return;
+            }
+
+            _inner.Write(value.ToString(), LogLevel.Warn);
         }
 
         public void Warn<T>(IFormatProvider formatProvider, T value)
         {
-            _inner.Write(String.Format(formatProvider, "{0}{1}", prefix, value), LogLevel.Warn);
+            _inner.Write(String.Format(formatProvider, "{0}", value), LogLevel.Warn);
         }
 
         public void WarnException(string message, Exception exception)
         {
-            _inner.Write(String.Format("{0}{1}: {2}", prefix, message, exception), LogLevel.Warn);
+            _inner.Write(String.Format("{0}: {1}", message, exception), LogLevel.Warn);
         }
 
         public void Warn(IFormatProvider formatProvider, string message, params object[] args)
         {
             var result = InvokeStringFormat(formatProvider, message, args);
-            _inner.Write(prefix + result, LogLevel.Warn);
+            _inner.Write(result, LogLevel.Warn);
         }
 
         public void Warn(string message)
         {
-            _inner.Write(prefix + message, LogLevel.Warn);
+            _inner.Write(message, LogLevel.Warn);
         }
 
         public void Warn(string message, params object[] args)
         {
             var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
-            _inner.Write(prefix + result, LogLevel.Warn);
+            _inner.Write(result, LogLevel.Warn);
         }
 
         public void Warn<TArgument>(IFormatProvider formatProvider, string message, TArgument argument)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument), LogLevel.Warn);
+            _inner.Write(String.Format(formatProvider, message, argument), LogLevel.Warn);
         }
 
         public void Warn<TArgument>(string message, TArgument argument)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Warn);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Warn);
         }
 
         public void Warn<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2), LogLevel.Warn);
+            _inner.Write(String.Format(formatProvider, message, argument1, argument2), LogLevel.Warn);
         }
 
         public void Warn<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Warn);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Warn);
         }
 
         public void Warn<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Warn);
+            _inner.Write(String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Warn);
         }
 
         public void Warn<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Warn);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Warn);
         }
 
 
         public void Error<T>(T value)
         {
-            _inner.Write(prefix + value, LogLevel.Error);
+            if (value == null)
+            {
+                return;
+            }
+
+            _inner.Write(value.ToString(), LogLevel.Error);
         }
 
         public void Error<T>(IFormatProvider formatProvider, T value)
         {
-            _inner.Write(String.Format(formatProvider, "{0}{1}", prefix, value), LogLevel.Error);
+            _inner.Write(String.Format(formatProvider, "{0}", value), LogLevel.Error);
         }
 
         public void ErrorException(string message, Exception exception)
         {
-            _inner.Write(String.Format("{0}{1}: {2}", prefix, message, exception), LogLevel.Error);
+            _inner.Write(String.Format("{0}: {1}", message, exception), LogLevel.Error);
         }
 
         public void Error(IFormatProvider formatProvider, string message, params object[] args)
         {
             var result = InvokeStringFormat(formatProvider, message, args);
-            _inner.Write(prefix + result, LogLevel.Error);
+            _inner.Write(result, LogLevel.Error);
         }
 
         public void Error(string message)
         {
-            _inner.Write(prefix + message, LogLevel.Error);
+            _inner.Write(message, LogLevel.Error);
         }
 
         public void Error(string message, params object[] args)
         {
             var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
-            _inner.Write(prefix + result, LogLevel.Error);
+            _inner.Write(result, LogLevel.Error);
         }
 
         public void Error<TArgument>(IFormatProvider formatProvider, string message, TArgument argument)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument), LogLevel.Error);
+            _inner.Write(String.Format(formatProvider, message, argument), LogLevel.Error);
         }
 
         public void Error<TArgument>(string message, TArgument argument)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Error);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Error);
         }
 
         public void Error<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2), LogLevel.Error);
+            _inner.Write(String.Format(formatProvider, message, argument1, argument2), LogLevel.Error);
         }
 
         public void Error<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Error);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Error);
         }
 
         public void Error<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Error);
+            _inner.Write(String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Error);
         }
 
         public void Error<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Error);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Error);
         }
 
 
         public void Fatal<T>(T value)
         {
-            _inner.Write(prefix + value, LogLevel.Fatal);
+            if (value == null)
+            {
+                return;
+            }
+
+            _inner.Write(value.ToString(), LogLevel.Fatal);
         }
 
         public void Fatal<T>(IFormatProvider formatProvider, T value)
         {
-            _inner.Write(String.Format(formatProvider, "{0}{1}", prefix, value), LogLevel.Fatal);
+            _inner.Write(String.Format(formatProvider, "{0}", value), LogLevel.Fatal);
         }
 
         public void FatalException(string message, Exception exception)
         {
-            _inner.Write(String.Format("{0}{1}: {2}", prefix, message, exception), LogLevel.Fatal);
+            _inner.Write(String.Format("{0}: {1}", message, exception), LogLevel.Fatal);
         }
 
         public void Fatal(IFormatProvider formatProvider, string message, params object[] args)
         {
             var result = InvokeStringFormat(formatProvider, message, args);
-            _inner.Write(prefix + result, LogLevel.Fatal);
+            _inner.Write(result, LogLevel.Fatal);
         }
 
         public void Fatal(string message)
         {
-            _inner.Write(prefix + message, LogLevel.Fatal);
+            _inner.Write(message, LogLevel.Fatal);
         }
 
         public void Fatal(string message, params object[] args)
         {
             var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
-            _inner.Write(prefix + result, LogLevel.Fatal);
+            _inner.Write(result, LogLevel.Fatal);
         }
 
         public void Fatal<TArgument>(IFormatProvider formatProvider, string message, TArgument argument)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument), LogLevel.Fatal);
+            _inner.Write(String.Format(formatProvider, message, argument), LogLevel.Fatal);
         }
 
         public void Fatal<TArgument>(string message, TArgument argument)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Fatal);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Fatal);
         }
 
         public void Fatal<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2), LogLevel.Fatal);
+            _inner.Write(String.Format(formatProvider, message, argument1, argument2), LogLevel.Fatal);
         }
 
         public void Fatal<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Fatal);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Fatal);
         }
 
         public void Fatal<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _inner.Write(prefix + String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Fatal);
+            _inner.Write(String.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Fatal);
         }
 
         public void Fatal<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
-            _inner.Write(prefix + String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Fatal);
+            _inner.Write(String.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Fatal);
         }
 
         public void Write([Localizable(false)] string message, LogLevel logLevel)


### PR DESCRIPTION
This PR fixes #106 by extracting the prefix logic currently contained with `WrappingFullLogger` into a separate class. Thus, client code can opt out of log message prefixes whilst still leveraging the `WrappingFullLogger` to obtain an implementation of `IFullLogger`.

Note that PR #107 provides an alternate solution to the problem, but I much prefer this option.
