### PR TITLE
Adding new Delegate Logger

### DIFF
--- a/Splat/Logging.cs
+++ b/Splat/Logging.cs
@@ -173,15 +173,9 @@ namespace Splat
         public LogLevel Level { get; set; }
     }
 
-    public class DebugLogger : ILogger
+    public class DebugLogger : DelegateLogger
     {
-        public void Write(string message, LogLevel logLevel)
-        {
-            if ((int)logLevel < (int)Level) return;
-            Debug.WriteLine(message);
-        }
-
-        public LogLevel Level { get; set; }
+        public DebugLogger() : base((message, logLevel) => Debug.WriteLine(message)) { }
     }
 
 

--- a/Splat/Logging.cs
+++ b/Splat/Logging.cs
@@ -154,6 +154,25 @@ namespace Splat
         public LogLevel Level { get; set; }
     }
 
+    public class DelegateLogger : ILogger
+    {
+        public DelegateLogger(Action<string, LogLevel> logAction)
+        {
+            LogAction = logAction;
+        }
+
+        private Action<string, LogLevel> LogAction { get; set; }
+
+        public void Write(string message, LogLevel logLevel)
+        {
+            if ((int)logLevel < (int)Level) return;
+            if (LogAction == null) return;
+            LogAction(message, logLevel);
+        }
+
+        public LogLevel Level { get; set; }
+    }
+
     public class DebugLogger : ILogger
     {
         public void Write(string message, LogLevel logLevel)


### PR DESCRIPTION
The problem with the DebugLogger is that it only works when building the Splat library from source. When using Splat routinely (i.e. from NuGet) the DebugLogger does not actually log anything because the `Debug.WriteLine(...)` is ignored (due to the library being built in release, even if the referencing build is in Debug). By refactoring  DebugLogger into a super-classed DelegateLogger, we can now allow users of Splat to gain access to Debug.WriteLine.

To register a `Debug.WriteLine` logger, in your `AppBootstrapper` (or similar location) register the logger as follows (for example):

``` csharp
dependencyResolver.RegisterConstant(new DelegateLogger((message, logLevel) => Debug.WriteLine("[{0,-5}] {1}", logLevel, message)), typeof(ILogger));
```
