### PR TITLE
Fix Jpeg quality calculation when saving Android bitmaps

### DIFF
--- a/src/Splat/Android/Bitmaps.cs
+++ b/src/Splat/Android/Bitmaps.cs
@@ -130,7 +130,7 @@ namespace Splat
         public Task Save(CompressedBitmapFormat format, float quality, Stream target)
         {
             var fmt = format == CompressedBitmapFormat.Jpeg ? Bitmap.CompressFormat.Jpeg : Bitmap.CompressFormat.Png;
-            return Task.Run(() => { inner.Compress(fmt, (int)quality * 100, target); });
+            return Task.Run(() => { inner.Compress(fmt, (int)(quality * 100), target); });
         }
 
         public void Dispose()


### PR DESCRIPTION
Currently the Jpeg compression quality is calculated by `(int)quality * 100`. The cast has higher precedence so the quality is always rounded down, in most cases resulting in a quality of 0.