### PR TITLE
Make DebugLogger usable by not stripping Debug.WriteLine

### DIFF
--- a/src/Splat/DebugLogger.cs
+++ b/src/Splat/DebugLogger.cs
@@ -1,0 +1,20 @@
+﻿// Taken from https://github.com/aspnet/Logging/blob/dev/src/Microsoft.Extensions.Logging.Debug
+
+// We need to define the DEBUG symbol because we want the logger
+// to work even when this package is compiled on release. Otherwise,
+// the call to Debug.WriteLine will not be in the release binary
+#define DEBUG
+
+namespace Splat
+{
+    public class DebugLogger : ILogger
+    {
+        public void Write(string message, LogLevel logLevel)
+        {
+            if ((int)logLevel < (int)Level) return;
+            System.Diagnostics.Debug.WriteLine(message);
+        }
+
+        public LogLevel Level { get; set; }
+    }
+}

--- a/src/Splat/Logging.cs
+++ b/src/Splat/Logging.cs
@@ -4,7 +4,6 @@ using System.Reflection;
 using System.Globalization;
 using System.Text;
 using System.Threading;
-using System.Diagnostics;
 using System.Diagnostics.Contracts;
 
 namespace Splat
@@ -158,18 +157,6 @@ namespace Splat
         public void Write(string message, LogLevel logLevel) {}
         public LogLevel Level { get; set; }
     }
-
-    public class DebugLogger : ILogger
-    {
-        public void Write(string message, LogLevel logLevel)
-        {
-            if ((int)logLevel < (int)Level) return;
-            Debug.WriteLine(message);
-        }
-
-        public LogLevel Level { get; set; }
-    }
-
 
     /*    
      * LogHost / Logging Mixin


### PR DESCRIPTION
Fixes #46, #58
Closes #123

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
As noted in #46 and #58, `DebugLogger` does not write to the debug output as `Debug.WriteLine` is stripped out in release builds of ReactiveUI.Splat. 

ASPNet Core has a DebugLogger which works, so upon investigating, it was found that by including `#define DEBUG` in the source file, the compiler does not strip out the debug only functions. So this was copied over as shown in this PR.


**What is the current behavior? (You can also link to an open issue here)**
DebugLogger does nothing


**What is the new behavior (if this is a feature change)?**
DebugLogger writes to the debug output as intended


**What might this PR break?**
It *should* break nothing 😇 


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

