### PR TITLE
LoadBitmap even if desiredHeight is not specified

### DIFF
--- a/src/Splat/Xaml/Bitmaps.cs
+++ b/src/Splat/Xaml/Bitmaps.cs
@@ -25,6 +25,8 @@ namespace Splat
                 withInit(ret, source => {
                     if (desiredWidth != null) {
                         source.DecodePixelWidth = (int)desiredWidth;
+                    }
+                    if (desiredHeight != null) {
                         source.DecodePixelHeight = (int)desiredHeight;
                     }
 
@@ -51,6 +53,8 @@ namespace Splat
                 withInit(ret, x => {
                     if (desiredWidth != null) {
                         x.DecodePixelWidth = (int)desiredWidth;
+                    }
+                    if (desiredHeight != null) {
                         x.DecodePixelHeight = (int)desiredHeight;
                     }
 


### PR DESCRIPTION
Closes #163

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
A NullReferenceException is thrown if we use Load or LoadFromResource methods without specifying desiredHeight parameter.

**What is the new behavior (if this is a feature change)?**
It allows to use Load and LoadFromResource methods without specifying desiredHeight parameter.

**What might this PR break?**
Nothing

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

