### PR TITLE
Commit to apply Tizen to Splat for the first time

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,5 @@
 @echo off
-tools\nuget\nuget.exe install Cake -OutputDirectory tools -ExcludeVersion -Version 0.30.0
+tools\nuget\nuget.exe install Cake -OutputDirectory tools -ExcludeVersion -Version 0.31.0
 
 tools\Cake\Cake.exe build.cake --target=%1 
 

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -1,7 +1,7 @@
 <Project>  
   <PropertyGroup>
     <Copyright>Copyright (c) .NET Foundation and Contributors</Copyright>
-    <PackageLicenseUrl>https://opensource.org/licenses/mit</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/reactiveui/splat/</PackageProjectUrl>
     <PackageIconUrl>http://f.cl.ly/items/1307401C3x2g3F2p2Z36/Logo.png</PackageIconUrl>
     <Authors>.NET Foundation and Contributors</Authors>
@@ -20,11 +20,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.33" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.3.38" PrivateAssets="all" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" /> 
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" /> 
   </ItemGroup>
  </Project>
  

--- a/src/Splat/Platforms/Tizen/BitmapHelper.cs
+++ b/src/Splat/Platforms/Tizen/BitmapHelper.cs
@@ -1,0 +1,22 @@
+namespace Splat
+{
+    public class BitmapHelper
+    {
+        /*
+            Since tizen does not have a constructor that creates an empty image object, 
+            it creates an empty image with the size of 100*100 pixels below when creating the default constructor.
+        */
+        public static byte[] EmptyImageBinary
+        {
+            get
+            {               
+                return new byte[] {
+                    137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 100, 0, 0, 0, 100, 8, 2, 0, 0, 0, 255, 128, 2, 3, 0, 0, 0, 1, 115, 82, 71, 66, 0, 174, 206, 28, 233, 0, 0, 0, 4,
+                    103, 65, 77, 65, 0, 0, 177, 143, 11, 252, 97, 5, 0, 0, 0, 9, 112, 72, 89, 115, 0, 0, 14, 195, 0, 0, 14, 195, 1, 199, 111, 168, 100, 0, 0, 0, 52, 73, 68, 65, 84, 120, 94, 237, 193, 1, 13, 0, 0, 0,
+                    194, 160, 247, 79, 109, 14, 55, 32, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 27, 53, 117, 148, 0, 1, 4, 253, 190, 98, 0, 0, 0,
+                    0, 73, 69, 78, 68, 174, 66, 96, 130
+                };
+            }
+        }
+    }
+}

--- a/src/Splat/Platforms/Tizen/Bitmaps.cs
+++ b/src/Splat/Platforms/Tizen/Bitmaps.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Tizen.Multimedia.Util;
+
+namespace Splat
+{
+    class PlatformBitmapLoader : IBitmapLoader
+    {
+        public IBitmap Create(float width, float height)
+        {
+            TizenBitmap bitmap = new TizenBitmap(BitmapHelper.EmptyImageBinary);
+            return bitmap;
+        }
+
+        public Task<IBitmap> Load(Stream sourceStream, float? desiredWidth, float? desiredHeight)
+        {
+            return Task.Run(() =>
+            {
+                var ret = new TizenBitmap();
+                ret.SetImage(((MemoryStream)sourceStream).ToArray(), desiredWidth, desiredHeight);
+                return (IBitmap)ret;
+            });
+        }
+
+        public Task<IBitmap> LoadFromResource(string source, float? desiredWidth, float? desiredHeight)
+        {            
+            return Task.Run(() =>
+            {
+                var ret = new TizenBitmap();
+                ret.SetImage(source, desiredWidth, desiredHeight);
+                return (IBitmap)ret;
+            });
+        }        
+    }
+
+    class TizenBitmap : IBitmap
+    {
+        internal BitmapFrame inner;
+
+        public TizenBitmap()
+        {
+            inner = null;
+        }
+
+        public TizenBitmap(byte[] image)
+        {
+            this.inner = GetBitmapFrame(image); ;
+        }
+
+        public TizenBitmap(BitmapFrame image)
+        {
+            this.inner = image;
+        }
+
+        public void Dispose()
+        {
+            inner = null;
+        }
+
+        public float Width
+        {
+            get { return inner == null ? 0 : inner.Size.Width; }
+        }
+
+        public float Height
+        {
+            get { return inner == null ? 0 : inner.Size.Height; }
+        }
+
+        public void SetImage(string image, float? desiredWidth, float? desiredHeight)
+        {
+            inner = null;
+            inner = GetBitmapFrame(File.ReadAllBytes(image));
+        }
+
+        public void SetImage(byte[] image, float? desiredWidth, float? desiredHeight)
+        {
+            inner = null;
+            inner = GetBitmapFrame(image);
+        }
+
+        private BitmapFrame GetBitmapFrame(byte[] imageBuffer)
+        {
+            BitmapFrame result = null;
+            List<ImageDecoder> decoderList = new List<ImageDecoder>{
+                new JpegDecoder(), new PngDecoder(), new BmpDecoder(), new GifDecoder()
+            };
+            foreach (var decoder in decoderList)
+            {
+                try
+                {
+                    result = (decoder.DecodeAsync(imageBuffer).Result).First();
+                    break;
+                }
+                catch (Tizen.Multimedia.FileFormatException)
+                {
+                    continue;
+                }
+            }
+            return result;            
+        }    
+
+        public Task Save(CompressedBitmapFormat format, float quality, Stream target)
+        {
+            ImageEncoder encoder = null;
+            int qualityPercent = (int)(100 * quality);
+            switch (format)
+            {
+                case CompressedBitmapFormat.Jpeg:
+                    encoder = new JpegEncoder();
+                    ((JpegEncoder)encoder).Quality = qualityPercent;
+                    break;
+                case CompressedBitmapFormat.Png:
+                    encoder = new PngEncoder();
+                    if (qualityPercent == 100) ((PngEncoder)encoder).Compression = PngCompression.None;
+                    else if (qualityPercent < 10) ((PngEncoder)encoder).Compression = PngCompression.Level1;
+                    else ((PngEncoder)encoder).Compression = (PngCompression)(qualityPercent / 10);
+                    break;
+            }
+            encoder.SetResolution(new Tizen.Multimedia.Size((int)Width, (int)Height));
+            return encoder.EncodeAsync(inner.Buffer, target);
+        }
+    }
+
+    public static class BitmapMixins
+    {
+        public static IBitmap FromNative(this BitmapFrame This)
+        {
+            return new TizenBitmap(This);
+        }
+        public static BitmapFrame ToNative(this IBitmap This)
+        {
+            return ((TizenBitmap)This).inner;
+        }
+    }
+}

--- a/src/Splat/Splat.csproj
+++ b/src/Splat/Splat.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>net461;uap10.0.16299;MonoAndroid81;Xamarin.iOS10;Xamarin.Mac20;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;uap10.0.16299;MonoAndroid81;Xamarin.iOS10;Xamarin.Mac20;tizen40;netstandard2.0</TargetFrameworks>
     <AssemblyName>Splat</AssemblyName>
     <RootNamespace>Splat</RootNamespace>
     <Authors>Paul Betts</Authors>
@@ -14,7 +14,7 @@
     <None Include="Colors\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
@@ -22,7 +22,7 @@
     <Compile Include="Platforms\ReflectionStubs.cs" />    
   </ItemGroup>  
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461'">  
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">  
     <Compile Include="Platforms\net461\**\*.cs" />
 
     <Compile Include="Platforms\TypeForwardedSystemDrawing.cs" />
@@ -36,13 +36,13 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'uap10.0.16299'">  
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('uap')) ">  
     <Compile Include="Platforms\WinRT\**\*.cs" />
     <Compile Include="Platforms\ReflectionStubs.cs" />
     <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'Xamarin.iOS10'">  
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.iOS')) ">  
     <Compile Include="Platforms\Cocoa\**\*.cs" />
     <Compile Include="Platforms\TypeForwardedSystemDrawing.cs" />
     <Compile Include="Platforms\PlatformModeDetector.cs" />
@@ -50,18 +50,23 @@
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'Xamarin.Mac20'">  
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('Xamarin.Mac')) ">  
     <Compile Include="Platforms\Cocoa\**\*.cs" />
     <Compile Include="Platforms\PlatformModeDetector.cs" />
     
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid81'">  
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">  
     <Compile Include="Platforms\Android\**\*.cs" />
     <Compile Include="Platforms\PlatformModeDetector.cs" />
     <Compile Include="Platforms\TypeForwardedSystemDrawing.cs" />
 
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
+
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('tizen')) ">
+    <Compile Include="Platforms\Tizen\**\*.cs" />
+    <Compile Include="Platforms\PlatformModeDetector.cs" />
+  </ItemGroup>  
 </Project>

--- a/src/global.json
+++ b/src/global.json
@@ -1,5 +1,5 @@
 {
     "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "1.6.41"
+        "MSBuild.Sdk.Extras": "1.6.65"
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Added the Tizen profile for the first time.


**What is the current behavior? (You can also link to an open issue here)**
Tizen has been added to Xamarin, but it is currently not available for Tizen development with Splat.


**What is the new behavior (if this is a feature change)?**
Added a Tizen Profile to Splat to make it available to developers.


**What might this PR break?**
Works independently of other Profiles.


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
This patch includes basic Splat functionality.
However, because the implemented Tizen Profile does not allow for the image to be transformed, the options fused with it do not work.
