### PR TITLE
LoadBitmap even if desiredHeight is not specified

### DIFF
--- a/src/Splat/Platforms/net45/Bitmaps.cs
+++ b/src/Splat/Platforms/net45/Bitmaps.cs
@@ -21,6 +21,8 @@ namespace Splat
                     if (desiredWidth != null)
                     {
                         source.DecodePixelWidth = (int)desiredWidth;
+                    }
+                    if (desiredHeight != null) {
                         source.DecodePixelHeight = (int)desiredHeight;
                     }
                     source.StreamSource = sourceStream;
@@ -41,6 +43,8 @@ namespace Splat
                     if (desiredWidth != null)
                     {
                         x.DecodePixelWidth = (int)desiredWidth;
+                    }
+                    if (desiredHeight != null) {
                         x.DecodePixelHeight = (int)desiredHeight;
                     }
 


### PR DESCRIPTION
Closes #163

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Bug fix

**What is the current behavior? (You can also link to an open issue here)**
A NullReferenceException is thrown if we use Load or LoadFromResource methods without specifying desiredHeight parameter.

**What is the new behavior (if this is a feature change)?**
It allows to use Load and LoadFromResource methods without specifying desiredHeight parameter.

**What might this PR break?**
Nothing

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

