### PR TITLE
housekeeping: recrypt CI/CD secrets after moving repo to new github location

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,10 @@
     GITHUB_USERNAME:
       secure: 0Q9MvUId56SizmZwCf0cgg==
     GITHUB_TOKEN:
-      secure: R3xA9iMXfUUtFd3wuL38pcDa0/BjjpBvNcGShr5LRibZtBoOVSH47Jat75rwaGur
+      secure: ElDZgDnOX2sxb/c7ef4IhfseTL5Plkl/s/N7F3aE4LflxxO/Y0ru8DnKGmsFwrQ7
     NUGET_SOURCE: https://www.nuget.org/api/v2/package
     NUGET_APIKEY:
-      secure: 0g2AqQxgiAIFhqoJbbmEPrJa15Z8U5xYT6vQe43Gocuxbjw74hBAIKbU+Cj65UNd
+      secure: ELiBJuPIyjt3adBoySwp1ByTYk8IEUQSol07EzbDvOdhnxcSBmj3Itl4HPLtlbbG
   build_script:
   - ./build.cmd
   artifacts:
@@ -33,7 +33,7 @@
   environment:
     NUGET_SOURCE: https://www.myget.org/F/splat/api/v2/package
     NUGET_APIKEY:
-      secure: YP/3KxC2ffsuHNaolPXj66JVGzSjON9FcR2S2OEzn9c6SV14oPzUh1ySyeT+G+aA
+      secure: bws/D/nus12zFcbVqDfVbB/ye23dMyM/7g52dezibJ28FTjtjudwEWvm0Y4NHVfb
   build_script:
   - ./build.cmd
   artifacts:


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

housekeeping

**What is the current behavior? (You can also link to an open issue here)**

CI/CD will not work

**What is the new behavior (if this is a feature change)?**

CI/CD will work.

**What might this PR break?**

Nothing

**Other information**:

This may take multiple attempts.