### PR TITLE
housekeeping: don't publish splat.wpf. it doesn't exist anymore

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -49,7 +49,7 @@ var nugetVersion = gitVersion.NuGetVersion;
 
 // Artifacts
 var artifactDirectory = "./artifacts/";
-var packageWhitelist = new[] { "Splat", "Splat.WPF" };
+var packageWhitelist = new[] { "Splat" };
 
 ///////////////////////////////////////////////////////////////////////////////
 // SETUP / TEARDOWN


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

bugfix for #159 

**What is the current behavior? (You can also link to an open issue here)**

Attempts to publish package that isn't generated.

**What is the new behavior (if this is a feature change)?**


No longer publishes invalid packages.
**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Missed this in last PR as publish workflow doesn't execute until merging.