### PR TITLE
housekeeping: unpin version number in gitversion

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,4 +1,3 @@
-next-version: 3.0.0
 assembly-versioning-scheme: None
 branches:
   master:


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Housekeeping

**What is the current behavior? (You can also link to an open issue here)**

next-version was pinned to 3.0.0 as part of that release. This is no longer required and would have been ignored anyway. This is general cleanup.