### PR TITLE
feature: bump monoandroid to 8.0

### DIFF
--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -11,7 +11,7 @@
    <PropertyGroup Condition="'$(TargetFramework)' == 'Xamarin.Mac20'">
     <DefineConstants>$(DefineConstants);MONO;COCOA</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid70'">
+  <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid80'">
     <DefineConstants>$(DefineConstants);MONO;ANDROID</DefineConstants>
   </PropertyGroup>
   

--- a/src/Splat/Splat.csproj
+++ b/src/Splat/Splat.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;uap10.0.16299;MonoAndroid70;Xamarin.iOS10;Xamarin.Mac20;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;uap10.0.16299;MonoAndroid80;Xamarin.iOS10;Xamarin.Mac20;netstandard2.0</TargetFrameworks>
     <AssemblyName>Splat</AssemblyName>
     <RootNamespace>Splat</RootNamespace>
     <Authors>Paul Betts</Authors>
@@ -58,7 +58,7 @@
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid70'">  
+  <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid80'">  
     <Compile Include="Platforms\Android\**\*.cs" />
 
     <Compile Include="Platforms\PlatformModeDetector.cs" />


### PR DESCRIPTION
fixes #179

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

drop monoandroid70 in favour of 80

**What is the current behavior? (You can also link to an open issue here)**



**What is the new behavior (if this is a feature change)?**



**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

