### PR TITLE
fix: MSBuild.Extras was mistakenly adding incorrect framework references

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.3.1" PrivateAssets="All" />
+    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.41" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fix

**What is the current behavior? (You can also link to an open issue here)**

Older versions of MSBuild.Extras was mistakenly adding incorrect framework references. See https://github.com/reactiveui/splat/issues/187

**What is the new behavior (if this is a feature change)?**

Upgraded to latest version of MSBuild.Extras

**What might this PR break?**


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Fixes https://github.com/reactiveui/splat/issues/187
