### PR TITLE
Fix make MsBuild.Sdk.Extras declaration consistent with the 1.6 way o…

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -18,10 +18,6 @@
     <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="all" />
   </ItemGroup>
   
-  <ItemGroup>
-    <PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.41" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" /> 
   </ItemGroup>

--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -14,8 +14,4 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'MonoAndroid80'">
     <DefineConstants>$(DefineConstants);MONO;ANDROID</DefineConstants>
   </PropertyGroup>
-  
-  <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0.16299' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform " Version="6.0.8" />
-  </ItemGroup>
 </Project>

--- a/src/Splat/Splat.csproj
+++ b/src/Splat/Splat.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>net461;uap10.0.16299;MonoAndroid80;Xamarin.iOS10;Xamarin.Mac20;netstandard2.0</TargetFrameworks>
     <AssemblyName>Splat</AssemblyName>
@@ -64,6 +64,4 @@
     <Compile Include="Platforms\PlatformModeDetector.cs" />
     <Compile Include="Platforms\TypeForwardedSystemDrawing.cs" />
   </ItemGroup>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 </Project>

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,5 @@
+{
+    "msbuild-sdks": {
+        "MSBuild.Sdk.Extras": "1.6.41"
+    }
+}


### PR DESCRIPTION
…f doing things

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fixes the MSBuild.Sdk.Extras to match the style recommended.

**What is the current behavior? (You can also link to an open issue here)**
To use PackageReference not not the SDK references.


**What is the new behavior (if this is a feature change)?**
Now we have a global.json file with the version, and the project now references the MSBuild SDK Reference.


**What might this PR break?**
Nothing.
