### PR TITLE
feature: Add support for IsXxxEnabled properties to IFullLogger

### DIFF
--- a/src/Splat/Logging.cs
+++ b/src/Splat/Logging.cs
@@ -25,6 +25,12 @@ namespace Splat
 
     public interface IFullLogger : ILogger
     {
+        bool IsDebugEnabled { get; }
+        bool IsInfoEnabled { get; }
+        bool IsWarnEnabled { get; }
+        bool IsErrorEnabled { get; }
+        bool IsFatalEnabled { get; }
+        
         void Debug<T>(T value);
         void Debug<T>(IFormatProvider formatProvider, T value);
         void DebugException([Localizable(false)] string message, Exception exception);
@@ -233,6 +239,12 @@ namespace Splat
             sfArgs[2] = args;
             return (string) stringFormat.Invoke(null, sfArgs);
         }
+        
+        public bool IsDebugEnabled => Level <= LogLevel.Debug;
+        public bool IsInfoEnabled => Level <= LogLevel.Info;
+        public bool IsWarnEnabled => Level <= LogLevel.Warn;
+        public bool IsErrorEnabled => Level <= LogLevel.Error;
+        public bool IsFatalEnabled => Level <= LogLevel.Fatal;
 
         public void Debug<T>(T value)
         {


### PR DESCRIPTION
This is based on @kentcb work. Updated to work with latest Splat.

This also fixes #109

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Adds data members to the IFullLogger to be able to tell what our current logging level is.

**What is the current behavior? (You can also link to an open issue here)**
Not to have access to that information after access.


**What is the new behavior (if this is a feature change)?**
Have the members.


**What might this PR break?**
No-one really. 
