### PR TITLE
Bug Make Sourcelink use the Microsoft version.

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -19,7 +19,8 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">
-    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.8.0" PrivateAssets="All" /> 
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" /> 
   </ItemGroup>
  </Project>
  

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -19,7 +19,6 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" /> 
   </ItemGroup>
  </Project>


### PR DESCRIPTION
At the moment source link is not working in the project. This fixes that and matches the way Rx 4 where it does work properly.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Changes over to using the new Microsoft API sourcelink.


**What is the current behavior? (You can also link to an open issue here)**
Use a deprecated library which no longer is supported nor works.


**What is the new behavior (if this is a feature change)?**
Use the microsoft source link which does work.


**What might this PR break?**
Shouldn't.
