### PR TITLE
feature: Added ILogger Write method with type information

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,16 @@ steps:
     COVERALLS_TOKEN: $(COVERALLS_TOKEN)
     ArtifactDirectory: $(System.DefaultWorkingDirectory)\Artifacts
 
+- task: PublishTestResults@2
+  inputs:
+    testResultsFormat: 'JUnit' # Options: JUnit, NUnit, VSTest, xUnit
+    testResultsFiles: '**/testresults-*.trx' 
+    searchFolder: artifacts/tests/' # Optional
+    #mergeTestResults: false # Optional
+    #testRunTitle: # Optional
+    #buildPlatform: # Optional
+    #buildConfiguration: # Optional
+    #publishRunAttachments: true # Optional    
 - task: CopyFiles@2
   inputs:
     Contents: 'artifacts/packages/*.nupkg'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,9 +25,9 @@ steps:
     COVERALLS_TOKEN: $(COVERALLS_TOKEN)
     ArtifactDirectory: $(System.DefaultWorkingDirectory)\Artifacts
 
-- task: PublishTestResults@2
+- task: Publish Test Results@2
   inputs:
-    testResultsFormat: 'JUnit' # Options: JUnit, NUnit, VSTest, xUnit
+    testResultsFormat: 'TRX' # Options: JUnit, NUnit, VSTest, xUnit
     testResultsFiles: '**/testresults-*.trx' 
     searchFolder: $(System.DefaultWorkingDirectory)\Artifacts\tests' # Optional
     #mergeTestResults: false # Optional

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,6 @@ steps:
   env:
     SIGNCLIENT_SECRET: $(SignClientSecret)
     SIGNCLIENT_USER: $(SignClientUser)
-    VSTS_ACCESS_TOKEN: $(System.AccessToken)
     COVERALLS_TOKEN: $(COVERALLS_TOKEN)
     ArtifactDirectory: $(System.DefaultWorkingDirectory)\Artifacts
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,14 +28,9 @@ steps:
 - task: PublishTestResults@2
   displayName: Publish Test Results
   inputs:
-    testResultsFormat: 'TRX' # Options: JUnit, NUnit, VSTest, xUnit, TRX
     testResultsFiles: '**/testresults-*.trx' 
-    searchFolder: '$(System.DefaultWorkingDirectory)\artifacts\tests' # Optional
-    #mergeTestResults: false # Optional
-    #testRunTitle: # Optional
-    #buildPlatform: # Optional
-    #buildConfiguration: # Optional
-    #publishRunAttachments: true # Optional    
+    searchFolder: '$(System.DefaultWorkingDirectory)\artifacts\tests'
+
 - task: CopyFiles@2
   inputs:
     Contents: 'artifacts/packages/*.nupkg'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ steps:
   inputs:
     testResultsFormat: 'JUnit' # Options: JUnit, NUnit, VSTest, xUnit
     testResultsFiles: '**/testresults-*.trx' 
-    searchFolder: artifacts/tests/' # Optional
+    searchFolder: $(System.DefaultWorkingDirectory)\Artifacts\tests' # Optional
     #mergeTestResults: false # Optional
     #testRunTitle: # Optional
     #buildPlatform: # Optional

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,6 +28,7 @@ steps:
 - task: PublishTestResults@2
   displayName: Publish Test Results
   inputs:
+    testResultsFormat: 'VSTest'
     testResultsFiles: '**/testresults-*.trx' 
     searchFolder: '$(System.DefaultWorkingDirectory)\artifacts\tests'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,9 +28,9 @@ steps:
 - task: PublishTestResults@2
   displayName: Publish Test Results
   inputs:
-    testResultsFormat: 'TRX' # Options: JUnit, NUnit, VSTest, xUnit
+    testResultsFormat: 'TRX' # Options: JUnit, NUnit, VSTest, xUnit, TRX
     testResultsFiles: '**/testresults-*.trx' 
-    searchFolder: $(System.DefaultWorkingDirectory)\Artifacts\tests' # Optional
+    searchFolder: '$(System.DefaultWorkingDirectory)\artifacts\tests' # Optional
     #mergeTestResults: false # Optional
     #testRunTitle: # Optional
     #buildPlatform: # Optional

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,8 @@ steps:
     COVERALLS_TOKEN: $(COVERALLS_TOKEN)
     ArtifactDirectory: $(System.DefaultWorkingDirectory)\Artifacts
 
-- task: Publish Test Results@2
+- task: PublishTestResults@2
+  displayName: Publish Test Results
   inputs:
     testResultsFormat: 'TRX' # Options: JUnit, NUnit, VSTest, xUnit
     testResultsFiles: '**/testresults-*.trx' 

--- a/build.cake
+++ b/build.cake
@@ -200,6 +200,8 @@ Task("RunUnitTests")
                 NoBuild = true,
                 Framework = testFramework,
                 Configuration = configuration,
+                ResultsDirectory = testsArtifactDirectory,
+                Logger = $"trx;LogFileName=testresults-{testFramework}.trx",
                 // TestAdapterPath = GetDirectories("./tools/xunit.runner.console*/**/net472").FirstOrDefault(),        
             };
 

--- a/build.ps1
+++ b/build.ps1
@@ -40,7 +40,7 @@ Param(
     [string]$Target,
     [string]$Configuration,
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
-    [string]$Verbosity = "Diagnostic",
+    [string]$Verbosity,
     [switch]$ShowDescription,
     [Alias("WhatIf", "Noop")]
     [switch]$DryRun,

--- a/build.ps1
+++ b/build.ps1
@@ -40,7 +40,7 @@ Param(
     [string]$Target,
     [string]$Configuration,
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
-    [string]$Verbosity,
+    [string]$Verbosity = "Diagnostic",
     [switch]$ShowDescription,
     [Alias("WhatIf", "Noop")]
     [switch]$DryRun,

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(IsTestProject)">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.0-preview-20181205-02" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Xunit.StaFact" Version="0.3.13" />

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -26,7 +26,6 @@
   <ItemGroup Condition="$(IsTestProject)">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="Xunit.StaFact" Version="0.3.13" />
     <PackageReference Include="Shouldly" Version=" 3.0.2" />
@@ -51,7 +50,7 @@
 
   <ItemGroup>
     <PackageReference Include="stylecop.analyzers" Version="1.1.1-beta.61" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.3" PrivateAssets="all" />
     <PackageReference Include="Roslynator.Analyzers" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
@@ -35,6 +35,7 @@ namespace Splat
         public DebugLogger() { }
         public Splat.LogLevel Level { get; set; }
         public void Write(string message, Splat.LogLevel logLevel) { }
+        public void Write(string message, System.Type type, Splat.LogLevel logLevel) { }
     }
     public class DefaultLogManager : Splat.ILogManager
     {
@@ -103,7 +104,9 @@ namespace Splat
         void Debug<T>(System.IFormatProvider formatProvider, T value);
         void Debug(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Debug([System.ComponentModel.LocalizableAttribute(false)] string message);
+        void Debug<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Debug([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
+        void Debug<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Debug<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
@@ -115,7 +118,9 @@ namespace Splat
         void Error<T>(System.IFormatProvider formatProvider, T value);
         void Error(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Error([System.ComponentModel.LocalizableAttribute(false)] string message);
+        void Error<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Error([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
+        void Error<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Error<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
@@ -127,7 +132,9 @@ namespace Splat
         void Fatal<T>(System.IFormatProvider formatProvider, T value);
         void Fatal(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Fatal([System.ComponentModel.LocalizableAttribute(false)] string message);
+        void Fatal<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Fatal([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
+        void Fatal<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Fatal<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
@@ -139,7 +146,9 @@ namespace Splat
         void Info<T>(System.IFormatProvider formatProvider, T value);
         void Info(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Info([System.ComponentModel.LocalizableAttribute(false)] string message);
+        void Info<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Info([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
+        void Info<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Info<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
@@ -151,7 +160,9 @@ namespace Splat
         void Warn<T>(System.IFormatProvider formatProvider, T value);
         void Warn(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Warn([System.ComponentModel.LocalizableAttribute(false)] string message);
+        void Warn<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Warn([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
+        void Warn<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Warn<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
@@ -164,6 +175,7 @@ namespace Splat
     {
         Splat.LogLevel Level { get; set; }
         void Write([System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel);
+        void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel);
     }
     public interface ILogManager
     {
@@ -426,6 +438,7 @@ namespace Splat
         public NullLogger() { }
         public Splat.LogLevel Level { get; set; }
         public void Write(string message, Splat.LogLevel logLevel) { }
+        public void Write(string message, System.Type type, Splat.LogLevel logLevel) { }
     }
     public class PlatformBitmapLoader : Splat.IBitmapLoader
     {
@@ -545,7 +558,9 @@ namespace Splat
         public void Debug<T>(System.IFormatProvider formatProvider, T value) { }
         public void Debug(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Debug(string message) { }
+        public void Debug<T>(string message) { }
         public void Debug(string message, params object[] args) { }
+        public void Debug<T>(string message, params object[] args) { }
         public void Debug<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
         public void Debug<TArgument>(string message, TArgument argument) { }
         public void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
@@ -557,7 +572,9 @@ namespace Splat
         public void Error<T>(System.IFormatProvider formatProvider, T value) { }
         public void Error(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Error(string message) { }
+        public void Error<T>(string message) { }
         public void Error(string message, params object[] args) { }
+        public void Error<T>(string message, params object[] args) { }
         public void Error<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
         public void Error<TArgument>(string message, TArgument argument) { }
         public void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
@@ -569,7 +586,9 @@ namespace Splat
         public void Fatal<T>(System.IFormatProvider formatProvider, T value) { }
         public void Fatal(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Fatal(string message) { }
+        public void Fatal<T>(string message) { }
         public void Fatal(string message, params object[] args) { }
+        public void Fatal<T>(string message, params object[] args) { }
         public void Fatal<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
         public void Fatal<TArgument>(string message, TArgument argument) { }
         public void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
@@ -581,7 +600,9 @@ namespace Splat
         public void Info<T>(System.IFormatProvider formatProvider, T value) { }
         public void Info(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Info(string message) { }
+        public void Info<T>(string message) { }
         public void Info(string message, params object[] args) { }
+        public void Info<T>(string message, params object[] args) { }
         public void Info<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
         public void Info<TArgument>(string message, TArgument argument) { }
         public void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
@@ -593,7 +614,9 @@ namespace Splat
         public void Warn<T>(System.IFormatProvider formatProvider, T value) { }
         public void Warn(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Warn(string message) { }
+        public void Warn<T>(string message) { }
         public void Warn(string message, params object[] args) { }
+        public void Warn<T>(string message, params object[] args) { }
         public void Warn<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
         public void Warn<TArgument>(string message, TArgument argument) { }
         public void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
@@ -602,5 +625,6 @@ namespace Splat
         public void Warn<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public void WarnException(string message, System.Exception exception) { }
         public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
 }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
@@ -24,6 +24,7 @@ namespace Splat
         public DebugLogger() { }
         public Splat.LogLevel Level { get; set; }
         public void Write(string message, Splat.LogLevel logLevel) { }
+        public void Write(string message, System.Type type, Splat.LogLevel logLevel) { }
     }
     public class DefaultLogManager : Splat.ILogManager
     {
@@ -92,7 +93,9 @@ namespace Splat
         void Debug<T>(System.IFormatProvider formatProvider, T value);
         void Debug(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Debug([System.ComponentModel.LocalizableAttribute(false)] string message);
+        void Debug<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Debug([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
+        void Debug<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Debug<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
@@ -104,7 +107,9 @@ namespace Splat
         void Error<T>(System.IFormatProvider formatProvider, T value);
         void Error(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Error([System.ComponentModel.LocalizableAttribute(false)] string message);
+        void Error<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Error([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
+        void Error<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Error<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
@@ -116,7 +121,9 @@ namespace Splat
         void Fatal<T>(System.IFormatProvider formatProvider, T value);
         void Fatal(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Fatal([System.ComponentModel.LocalizableAttribute(false)] string message);
+        void Fatal<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Fatal([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
+        void Fatal<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Fatal<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
@@ -128,7 +135,9 @@ namespace Splat
         void Info<T>(System.IFormatProvider formatProvider, T value);
         void Info(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Info([System.ComponentModel.LocalizableAttribute(false)] string message);
+        void Info<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Info([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
+        void Info<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Info<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
@@ -140,7 +149,9 @@ namespace Splat
         void Warn<T>(System.IFormatProvider formatProvider, T value);
         void Warn(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Warn([System.ComponentModel.LocalizableAttribute(false)] string message);
+        void Warn<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Warn([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
+        void Warn<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Warn<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
@@ -153,6 +164,7 @@ namespace Splat
     {
         Splat.LogLevel Level { get; set; }
         void Write([System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel);
+        void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel);
     }
     public interface ILogManager
     {
@@ -415,6 +427,7 @@ namespace Splat
         public NullLogger() { }
         public Splat.LogLevel Level { get; set; }
         public void Write(string message, Splat.LogLevel logLevel) { }
+        public void Write(string message, System.Type type, Splat.LogLevel logLevel) { }
     }
     public class static PointMathExtensions
     {
@@ -497,7 +510,9 @@ namespace Splat
         public void Debug<T>(System.IFormatProvider formatProvider, T value) { }
         public void Debug(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Debug(string message) { }
+        public void Debug<T>(string message) { }
         public void Debug(string message, params object[] args) { }
+        public void Debug<T>(string message, params object[] args) { }
         public void Debug<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
         public void Debug<TArgument>(string message, TArgument argument) { }
         public void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
@@ -509,7 +524,9 @@ namespace Splat
         public void Error<T>(System.IFormatProvider formatProvider, T value) { }
         public void Error(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Error(string message) { }
+        public void Error<T>(string message) { }
         public void Error(string message, params object[] args) { }
+        public void Error<T>(string message, params object[] args) { }
         public void Error<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
         public void Error<TArgument>(string message, TArgument argument) { }
         public void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
@@ -521,7 +538,9 @@ namespace Splat
         public void Fatal<T>(System.IFormatProvider formatProvider, T value) { }
         public void Fatal(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Fatal(string message) { }
+        public void Fatal<T>(string message) { }
         public void Fatal(string message, params object[] args) { }
+        public void Fatal<T>(string message, params object[] args) { }
         public void Fatal<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
         public void Fatal<TArgument>(string message, TArgument argument) { }
         public void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
@@ -533,7 +552,9 @@ namespace Splat
         public void Info<T>(System.IFormatProvider formatProvider, T value) { }
         public void Info(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Info(string message) { }
+        public void Info<T>(string message) { }
         public void Info(string message, params object[] args) { }
+        public void Info<T>(string message, params object[] args) { }
         public void Info<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
         public void Info<TArgument>(string message, TArgument argument) { }
         public void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
@@ -545,7 +566,9 @@ namespace Splat
         public void Warn<T>(System.IFormatProvider formatProvider, T value) { }
         public void Warn(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Warn(string message) { }
+        public void Warn<T>(string message) { }
         public void Warn(string message, params object[] args) { }
+        public void Warn<T>(string message, params object[] args) { }
         public void Warn<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
         public void Warn<TArgument>(string message, TArgument argument) { }
         public void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
@@ -554,5 +577,6 @@ namespace Splat
         public void Warn<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public void WarnException(string message, System.Exception exception) { }
         public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
 }

--- a/src/Splat.Tests/Mocks/TextLogger.cs
+++ b/src/Splat.Tests/Mocks/TextLogger.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Splat.Tests.Mocks
+{
+    /// <summary>
+    /// A <see cref="TextWriter"/> implementation of <see cref="ILogger"/> for testing.
+    /// </summary>
+    /// <seealso cref="Splat.ILogger" />
+    public class TextLogger : ILogger, IDisposable
+    {
+        private readonly StringBuilder _stringBuilder;
+        private TextWriter _writer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextLogger"/> class.
+        /// </summary>
+        public TextLogger()
+        {
+            _stringBuilder = new StringBuilder();
+
+            _writer = new StringWriter(_stringBuilder);
+        }
+
+        /// <summary>
+        /// Gets the value of the text writer.
+        /// </summary>
+        public string Value => _stringBuilder.ToString();
+
+        /// <inheritdoc />
+        public LogLevel Level { get; set; }
+
+        /// <inheritdoc />
+        public void Write(string message, LogLevel logLevel)
+        {
+            _writer.WriteLine(message);
+        }
+
+        /// <inheritdoc />
+        public void Write(string message, Type type, LogLevel logLevel)
+        {
+            _writer.WriteLine($"{type.Name}: {message}");
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (_writer != null)
+                {
+                    _writer.Dispose();
+                    _writer = null;
+                }
+            }
+        }
+    }
+}

--- a/src/Splat.Tests/WrappingFullLoggerTests.cs
+++ b/src/Splat.Tests/WrappingFullLoggerTests.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Splat.Tests.Mocks;
+using Xunit;
+
+namespace Splat.Tests
+{
+    /// <summary>
+    /// Tests that verify the wrapping full logger is working.
+    /// </summary>
+    public class WrappingFullLoggerTests
+    {
+        /// <summary>
+        /// Test to make sure the message writes.
+        /// </summary>
+        [Fact]
+        public void Write_Should_Write_Message()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger, typeof(DummyObjectClass1));
+
+            logger.Write("This is a test.", LogLevel.Debug);
+
+            Assert.Equal("This is a test.\r\n", textLogger.Value);
+        }
+
+        /// <summary>
+        /// Test to make sure the type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Write_Should_Write_Message_And_Type()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger, typeof(DummyObjectClass1));
+
+            logger.Write("This is a test.", typeof(DummyObjectClass1), LogLevel.Debug);
+
+            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test.\r\n", textLogger.Value);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Debug_With_Generic_Type_Should_Write_Message_And_Type()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger, typeof(DummyObjectClass1));
+
+            logger.Debug<DummyObjectClass1>("This is a test.");
+
+            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test.\r\n", textLogger.Value);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Debug_With_Generic_Type_Should_Write_Message_And_Type_Provided()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger, typeof(DummyObjectClass1));
+
+            logger.Debug<DummyObjectClass2>("This is a test.");
+
+            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test.\r\n", textLogger.Value);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Info_With_Generic_Type_Should_Write_Message_And_Type()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger, typeof(DummyObjectClass1));
+
+            logger.Info<DummyObjectClass1>("This is a test.");
+
+            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test.\r\n", textLogger.Value);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Info_With_Generic_Type_Should_Write_Message_And_Type_Provided()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger, typeof(DummyObjectClass1));
+
+            logger.Info<DummyObjectClass2>("This is a test.");
+
+            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test.\r\n", textLogger.Value);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Warn_With_Generic_Type_Should_Write_Message_And_Type()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger, typeof(DummyObjectClass1));
+
+            logger.Warn<DummyObjectClass1>("This is a test.");
+
+            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test.\r\n", textLogger.Value);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Warn_With_Generic_Type_Should_Write_Message_And_Type_Provided()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger, typeof(DummyObjectClass1));
+
+            logger.Warn<DummyObjectClass2>("This is a test.");
+
+            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test.\r\n", textLogger.Value);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Error_With_Generic_Type_Should_Write_Message_And_Type()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger, typeof(DummyObjectClass1));
+
+            logger.Error<DummyObjectClass1>("This is a test.");
+
+            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test.\r\n", textLogger.Value);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Error_With_Generic_Type_Should_Write_Message_And_Type_Provided()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger, typeof(DummyObjectClass1));
+
+            logger.Error<DummyObjectClass2>("This is a test.");
+
+            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test.\r\n", textLogger.Value);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Fatal_With_Generic_Type_Should_Write_Message_And_Type()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger, typeof(DummyObjectClass1));
+
+            logger.Fatal<DummyObjectClass1>("This is a test.");
+
+            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test.\r\n", textLogger.Value);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Fatal_With_Generic_Type_Should_Write_Message_And_Type_Provided()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger, typeof(DummyObjectClass1));
+
+            logger.Fatal<DummyObjectClass2>("This is a test.");
+
+            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test.\r\n", textLogger.Value);
+        }
+    }
+}

--- a/src/Splat/Logging/DebugLogger.cs
+++ b/src/Splat/Logging/DebugLogger.cs
@@ -8,6 +8,8 @@
 // the call to Debug.WriteLine will not be in the release binary
 #define DEBUG
 
+using System;
+
 namespace Splat
 {
     /// <summary>
@@ -27,6 +29,17 @@ namespace Splat
             }
 
             System.Diagnostics.Debug.WriteLine(message);
+        }
+
+        /// <inheritdoc />
+        public void Write(string message, Type type, LogLevel logLevel)
+        {
+            if ((int)logLevel < (int)Level)
+            {
+                return;
+            }
+
+            System.Diagnostics.Debug.WriteLine(message, type.Name);
         }
     }
 }

--- a/src/Splat/Logging/IFullLogger.cs
+++ b/src/Splat/Logging/IFullLogger.cs
@@ -83,11 +83,26 @@ namespace Splat
         void Debug([Localizable(false)] string message);
 
         /// <summary>
+        /// Emits a message to the debug log.
+        /// </summary>
+        /// <typeparam name="T">The calling type.</typeparam>
+        /// <param name="message">A non-localizable message to send to the log.</param>
+        void Debug<T>([Localizable(false)] string message);
+
+        /// <summary>
         /// Emits a message using formatting to the debug log.
         /// </summary>
         /// <param name="message">A non-localizable message to emit to the log which includes the standard formatting tags.</param>
         /// <param name="args">The arguments for formatting purposes.</param>
         void Debug([Localizable(false)] string message, params object[] args);
+
+        /// <summary>
+        /// Emits a message using formatting to the debug log.
+        /// </summary>
+        /// <typeparam name="T">The calling type.</typeparam>
+        /// <param name="message">A non-localizable message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="args">The arguments for formatting purposes.</param>
+        void Debug<T>([Localizable(false)] string message, params object[] args);
 
         /// <summary>
         /// Emits a message using formatting to the debug log.
@@ -193,11 +208,26 @@ namespace Splat
         void Info([Localizable(false)] string message);
 
         /// <summary>
+        /// Emits a message to the info log.
+        /// </summary>
+        /// <typeparam name="T">The calling type.</typeparam>
+        /// <param name="message">A non-localizable message to send to the log.</param>
+        void Info<T>([Localizable(false)] string message);
+
+        /// <summary>
         /// Emits a message using formatting to the info log.
         /// </summary>
         /// <param name="message">A non-localizable message to emit to the log which includes the standard formatting tags.</param>
         /// <param name="args">The arguments for formatting purposes.</param>
         void Info([Localizable(false)] string message, params object[] args);
+
+        /// <summary>
+        /// Emits a message using formatting to the info log.
+        /// </summary>
+        /// <typeparam name="T">The calling type.</typeparam>
+        /// <param name="message">A non-localizable message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="args">The arguments for formatting purposes.</param>
+        void Info<T>([Localizable(false)] string message, params object[] args);
 
         /// <summary>
         /// Emits a message using formatting to the info log.
@@ -303,11 +333,26 @@ namespace Splat
         void Warn([Localizable(false)] string message);
 
         /// <summary>
+        /// Emits a message to the warning log.
+        /// </summary>
+        /// <typeparam name="T">The calling type.</typeparam>
+        /// <param name="message">A non-localizable message to send to the log.</param>
+        void Warn<T>([Localizable(false)] string message);
+
+        /// <summary>
         /// Emits a message using formatting to the warning log.
         /// </summary>
         /// <param name="message">A non-localizable message to emit to the log which includes the standard formatting tags.</param>
         /// <param name="args">The arguments for formatting purposes.</param>
         void Warn([Localizable(false)] string message, params object[] args);
+
+        /// <summary>
+        /// Emits a message using formatting to the warning log.
+        /// </summary>
+        /// <typeparam name="T">The calling type.</typeparam>
+        /// <param name="message">A non-localizable message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="args">The arguments for formatting purposes.</param>
+        void Warn<T>([Localizable(false)] string message, params object[] args);
 
         /// <summary>
         /// Emits a message using formatting to the warning log.
@@ -413,11 +458,26 @@ namespace Splat
         void Error([Localizable(false)] string message);
 
         /// <summary>
+        /// Emits a message to the error log.
+        /// </summary>
+        /// <typeparam name="T">The calling type.</typeparam>
+        /// <param name="message">A non-localizable message to send to the log.</param>
+        void Error<T>([Localizable(false)] string message);
+
+        /// <summary>
         /// Emits a message using formatting to the error log.
         /// </summary>
         /// <param name="message">A non-localizable message to emit to the log which includes the standard formatting tags.</param>
         /// <param name="args">The arguments for formatting purposes.</param>
         void Error([Localizable(false)] string message, params object[] args);
+
+        /// <summary>
+        /// Emits a message using formatting to the error log.
+        /// </summary>
+        /// <typeparam name="T">The calling type.</typeparam>
+        /// <param name="message">A non-localizable message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="args">The arguments for formatting purposes.</param>
+        void Error<T>([Localizable(false)] string message, params object[] args);
 
         /// <summary>
         /// Emits a message using formatting to the error log.
@@ -523,11 +583,26 @@ namespace Splat
         void Fatal([Localizable(false)] string message);
 
         /// <summary>
+        /// Emits a message to the fatal log.
+        /// </summary>
+        /// <typeparam name="T">The calling type.</typeparam>
+        /// <param name="message">A non-localizable message to send to the log.</param>
+        void Fatal<T>([Localizable(false)] string message);
+
+        /// <summary>
         /// Emits a message using formatting to the fatal log.
         /// </summary>
         /// <param name="message">A non-localizable message to emit to the log which includes the standard formatting tags.</param>
         /// <param name="args">The arguments for formatting purposes.</param>
         void Fatal([Localizable(false)] string message, params object[] args);
+
+        /// <summary>
+        /// Emits a message using formatting to the fatal log.
+        /// </summary>
+        /// <typeparam name="T">The calling type.</typeparam>
+        /// <param name="message">A non-localizable message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="args">The arguments for formatting purposes.</param>
+        void Fatal<T>([Localizable(false)] string message, params object[] args);
 
         /// <summary>
         /// Emits a message using formatting to the fatal log.

--- a/src/Splat/Logging/ILogger.cs
+++ b/src/Splat/Logging/ILogger.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using System.ComponentModel;
 
 namespace Splat
@@ -23,5 +24,13 @@ namespace Splat
         /// <param name="message">The message to write.</param>
         /// <param name="logLevel">The severity level of the log message.</param>
         void Write([Localizable(false)] string message, LogLevel logLevel);
+
+        /// <summary>
+        /// Writes a messge to the target.
+        /// </summary>
+        /// <param name="message">The message.</param>
+        /// <param name="type">The type.</param>
+        /// <param name="logLevel">The log level.</param>
+        void Write([Localizable(false)] string message, [Localizable(false)] Type type, LogLevel logLevel);
     }
 }

--- a/src/Splat/Logging/NullLogger.cs
+++ b/src/Splat/Logging/NullLogger.cs
@@ -3,6 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
+
 namespace Splat
 {
     /// <summary>
@@ -15,6 +17,11 @@ namespace Splat
 
         /// <inheritdoc />
         public void Write(string message, LogLevel logLevel)
+        {
+        }
+
+        /// <inheritdoc />
+        public void Write(string message, Type type, LogLevel logLevel)
         {
         }
     }

--- a/src/Splat/Logging/WrappingFullLogger.cs
+++ b/src/Splat/Logging/WrappingFullLogger.cs
@@ -38,8 +38,8 @@ namespace Splat
         /// <inheritdoc />
         public LogLevel Level
         {
-            get { return _inner.Level; }
-            set { _inner.Level = value; }
+            get => _inner.Level;
+            set => _inner.Level = value;
         }
 
         /// <inheritdoc />
@@ -90,10 +90,23 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Debug<T>(string message)
+        {
+            _inner.Write(message, typeof(T), LogLevel.Debug);
+        }
+
+        /// <inheritdoc />
         public void Debug(string message, params object[] args)
         {
             var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
             _inner.Write(_prefix + result, LogLevel.Debug);
+        }
+
+        /// <inheritdoc />
+        public void Debug<T>(string message, params object[] args)
+        {
+            var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
+            _inner.Write(result, typeof(T), LogLevel.Debug);
         }
 
         /// <inheritdoc />
@@ -164,10 +177,23 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Info<T>(string message)
+        {
+            _inner.Write(message, typeof(T), LogLevel.Info);
+        }
+
+        /// <inheritdoc />
         public void Info(string message, params object[] args)
         {
             var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
             _inner.Write(_prefix + result, LogLevel.Info);
+        }
+
+        /// <inheritdoc />
+        public void Info<T>(string message, params object[] args)
+        {
+            var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
+            _inner.Write(result, typeof(T), LogLevel.Info);
         }
 
         /// <inheritdoc />
@@ -238,10 +264,23 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Warn<T>(string message)
+        {
+            _inner.Write(message, typeof(T), LogLevel.Warn);
+        }
+
+        /// <inheritdoc />
         public void Warn(string message, params object[] args)
         {
             var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
             _inner.Write(_prefix + result, LogLevel.Warn);
+        }
+
+        /// <inheritdoc />
+        public void Warn<T>(string message, params object[] args)
+        {
+            var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
+            _inner.Write(result, typeof(T), LogLevel.Warn);
         }
 
         /// <inheritdoc />
@@ -312,10 +351,23 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Error<T>(string message)
+        {
+            _inner.Write(message, typeof(T), LogLevel.Error);
+        }
+
+        /// <inheritdoc />
         public void Error(string message, params object[] args)
         {
             var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
             _inner.Write(_prefix + result, LogLevel.Error);
+        }
+
+        /// <inheritdoc />
+        public void Error<T>(string message, params object[] args)
+        {
+            var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
+            _inner.Write(result, typeof(T), LogLevel.Error);
         }
 
         /// <inheritdoc />
@@ -386,10 +438,23 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Fatal<T>(string message)
+        {
+            _inner.Write(message, typeof(T), LogLevel.Fatal);
+        }
+
+        /// <inheritdoc />
         public void Fatal(string message, params object[] args)
         {
             var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
             _inner.Write(_prefix + result, LogLevel.Fatal);
+        }
+
+        /// <inheritdoc />
+        public void Fatal<T>(string message, params object[] args)
+        {
+            var result = InvokeStringFormat(CultureInfo.InvariantCulture, message, args);
+            _inner.Write(result, typeof(T), LogLevel.Fatal);
         }
 
         /// <inheritdoc />
@@ -432,6 +497,12 @@ namespace Splat
         public void Write([Localizable(false)] string message, LogLevel logLevel)
         {
             _inner.Write(message, logLevel);
+        }
+
+        /// <inheritdoc />
+        public void Write([Localizable(false)] string message, [Localizable(false)] Type type, LogLevel logLevel)
+        {
+            _inner.Write(message, type, logLevel);
         }
 
         private string InvokeStringFormat(IFormatProvider formatProvider, string message, object[] args)


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Resolves: #186 

**What is the current behavior? (You can also link to an open issue here)**

Currently the type is prefixed on a message string.

**What is the new behavior (if this is a feature change)?**

`ILogger` now has a method signature that takes the type.  The `WrappingFullLogger` can now call a write method that passes in the type.

**What might this PR break?**

Logging?

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

