### PR TITLE
feature: add ActionLogger which takes a user given action

### DIFF
--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
@@ -3,6 +3,13 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
 namespace Splat
 {
+    public class ActionLogger : Splat.ILogger
+    {
+        public ActionLogger(System.Action<string, Splat.LogLevel> writeNoType, System.Action<string, System.Type, Splat.LogLevel> writeWithType) { }
+        public Splat.LogLevel Level { get; set; }
+        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
     public class static BitmapLoader
     {
         public static Splat.IBitmapLoader Current { get; set; }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
@@ -3,6 +3,13 @@
 [assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace Splat
 {
+    public class ActionLogger : Splat.ILogger
+    {
+        public ActionLogger(System.Action<string, Splat.LogLevel> writeNoType, System.Action<string, System.Type, Splat.LogLevel> writeWithType) { }
+        public Splat.LogLevel Level { get; set; }
+        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
     public class static BitmapLoader
     {
         public static Splat.IBitmapLoader Current { get; set; }

--- a/src/Splat.Tests/Logging/ActionLoggerTests.cs
+++ b/src/Splat.Tests/Logging/ActionLoggerTests.cs
@@ -1,0 +1,325 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Splat.Tests.Mocks;
+using Xunit;
+
+namespace Splat.Tests.Logging
+{
+    /// <summary>
+    /// Tests associated with the <see cref="ActionLogger"/> class.
+    /// </summary>
+    public class ActionLoggerTests
+    {
+        /// <summary>
+        /// Test to make sure the message writes.
+        /// </summary>
+        [Fact]
+        public void Write_Should_Emit_Message()
+        {
+            string passedMessage = null;
+            LogLevel? passedLevel = null;
+
+            var logger = new ActionLogger(
+                (message, level) =>
+                {
+                    passedMessage = message;
+                    passedLevel = level;
+                },
+                null);
+
+            var fullLogger = new WrappingFullLogger(logger);
+
+            fullLogger.Write("This is a test.", LogLevel.Debug);
+
+            Assert.Equal("This is a test.", passedMessage);
+            Assert.Equal(LogLevel.Debug, passedLevel);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Debug_With_Generic_Type_Should_Emit_Message_And_Type()
+        {
+            string passedMessage = null;
+            LogLevel? passedLevel = null;
+            Type passedType = null;
+
+            var logger = new ActionLogger(
+                null,
+                (message, type, level) =>
+                {
+                    passedMessage = message;
+                    passedType = type;
+                    passedLevel = level;
+                });
+
+            var fullLogger = new WrappingFullLogger(logger);
+
+            fullLogger.Debug<DummyObjectClass1>("This is a test.");
+
+            Assert.Equal("This is a test.", passedMessage);
+            Assert.Equal(LogLevel.Debug, passedLevel);
+            Assert.Equal(typeof(DummyObjectClass1), passedType);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Debug_With_Generic_Type_Should_Emit_Message_And_Type_Provided()
+        {
+            string passedMessage = null;
+            LogLevel? passedLevel = null;
+            Type passedType = null;
+
+            var logger = new ActionLogger(
+                null,
+                (message, type, level) =>
+                {
+                    passedMessage = message;
+                    passedType = type;
+                    passedLevel = level;
+                });
+
+            var fullLogger = new WrappingFullLogger(logger);
+
+            fullLogger.Debug<DummyObjectClass2>("This is a test.");
+
+            Assert.Equal("This is a test.", passedMessage);
+            Assert.Equal(LogLevel.Debug, passedLevel);
+            Assert.Equal(typeof(DummyObjectClass2), passedType);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Info_With_Generic_Type_Should_Emit_Message_And_Type()
+        {
+            string passedMessage = null;
+            LogLevel? passedLevel = null;
+            Type passedType = null;
+
+            var logger = new ActionLogger(
+                null,
+                (message, type, level) =>
+                {
+                    passedMessage = message;
+                    passedType = type;
+                    passedLevel = level;
+                });
+
+            var fullLogger = new WrappingFullLogger(logger);
+
+            fullLogger.Info<DummyObjectClass1>("This is a test.");
+
+            Assert.Equal("This is a test.", passedMessage);
+            Assert.Equal(LogLevel.Info, passedLevel);
+            Assert.Equal(typeof(DummyObjectClass1), passedType);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Info_With_Generic_Type_Should_Emit_Message_And_Type_Provided()
+        {
+            string passedMessage = null;
+            LogLevel? passedLevel = null;
+            Type passedType = null;
+
+            var logger = new ActionLogger(
+                null,
+                (message, type, level) =>
+                {
+                    passedMessage = message;
+                    passedType = type;
+                    passedLevel = level;
+                });
+
+            var fullLogger = new WrappingFullLogger(logger);
+
+            fullLogger.Info<DummyObjectClass2>("This is a test.");
+
+            Assert.Equal("This is a test.", passedMessage);
+            Assert.Equal(LogLevel.Info, passedLevel);
+            Assert.Equal(typeof(DummyObjectClass2), passedType);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Warn_With_Generic_Type_Should_Emit_Message_And_Type()
+        {
+            string passedMessage = null;
+            LogLevel? passedLevel = null;
+            Type passedType = null;
+
+            var logger = new ActionLogger(
+                null,
+                (message, type, level) =>
+                {
+                    passedMessage = message;
+                    passedType = type;
+                    passedLevel = level;
+                });
+
+            var fullLogger = new WrappingFullLogger(logger);
+
+            fullLogger.Warn<DummyObjectClass1>("This is a test.");
+
+            Assert.Equal("This is a test.", passedMessage);
+            Assert.Equal(LogLevel.Warn, passedLevel);
+            Assert.Equal(typeof(DummyObjectClass1), passedType);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Warn_With_Generic_Type_Should_Emit_Message_And_Type_Provided()
+        {
+            string passedMessage = null;
+            LogLevel? passedLevel = null;
+            Type passedType = null;
+
+            var logger = new ActionLogger(
+                null,
+                (message, type, level) =>
+                {
+                    passedMessage = message;
+                    passedType = type;
+                    passedLevel = level;
+                });
+
+            var fullLogger = new WrappingFullLogger(logger);
+
+            fullLogger.Warn<DummyObjectClass2>("This is a test.");
+
+            Assert.Equal("This is a test.", passedMessage);
+            Assert.Equal(LogLevel.Warn, passedLevel);
+            Assert.Equal(typeof(DummyObjectClass2), passedType);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Error_With_Generic_Type_Should_Emit_Message_And_Type()
+        {
+            string passedMessage = null;
+            LogLevel? passedLevel = null;
+            Type passedType = null;
+
+            var logger = new ActionLogger(
+                null,
+                (message, type, level) =>
+                {
+                    passedMessage = message;
+                    passedType = type;
+                    passedLevel = level;
+                });
+
+            var fullLogger = new WrappingFullLogger(logger);
+
+            fullLogger.Error<DummyObjectClass1>("This is a test.");
+
+            Assert.Equal("This is a test.", passedMessage);
+            Assert.Equal(LogLevel.Error, passedLevel);
+            Assert.Equal(typeof(DummyObjectClass1), passedType);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Error_With_Generic_Type_Should_Emit_Message_And_Type_Provided()
+        {
+            string passedMessage = null;
+            LogLevel? passedLevel = null;
+            Type passedType = null;
+
+            var logger = new ActionLogger(
+                null,
+                (message, type, level) =>
+                {
+                    passedMessage = message;
+                    passedType = type;
+                    passedLevel = level;
+                });
+
+            var fullLogger = new WrappingFullLogger(logger);
+
+            fullLogger.Error<DummyObjectClass2>("This is a test.");
+
+            Assert.Equal("This is a test.", passedMessage);
+            Assert.Equal(LogLevel.Error, passedLevel);
+            Assert.Equal(typeof(DummyObjectClass2), passedType);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Fatal_With_Generic_Type_Should_Emit_Message_And_Type()
+        {
+            string passedMessage = null;
+            LogLevel? passedLevel = null;
+            Type passedType = null;
+
+            var logger = new ActionLogger(
+                null,
+                (message, type, level) =>
+                {
+                    passedMessage = message;
+                    passedType = type;
+                    passedLevel = level;
+                });
+
+            var fullLogger = new WrappingFullLogger(logger);
+
+            fullLogger.Fatal<DummyObjectClass1>("This is a test.");
+
+            Assert.Equal("This is a test.", passedMessage);
+            Assert.Equal(LogLevel.Fatal, passedLevel);
+            Assert.Equal(typeof(DummyObjectClass1), passedType);
+        }
+
+        /// <summary>
+        /// Test to make sure the generic type parameter is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Fatal_With_Generic_Type_Should_Emit_Message_And_Type_Provided()
+        {
+            string passedMessage = null;
+            LogLevel? passedLevel = null;
+            Type passedType = null;
+
+            var logger = new ActionLogger(
+                null,
+                (message, type, level) =>
+                {
+                    passedMessage = message;
+                    passedType = type;
+                    passedLevel = level;
+                });
+
+            var fullLogger = new WrappingFullLogger(logger);
+
+            fullLogger.Fatal<DummyObjectClass2>("This is a test.");
+
+            Assert.Equal("This is a test.", passedMessage);
+            Assert.Equal(LogLevel.Fatal, passedLevel);
+            Assert.Equal(typeof(DummyObjectClass2), passedType);
+        }
+    }
+}

--- a/src/Splat.Tests/Logging/WrappingFullLoggerTests.cs
+++ b/src/Splat.Tests/Logging/WrappingFullLoggerTests.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -6,7 +11,7 @@ using System.Text;
 using Splat.Tests.Mocks;
 using Xunit;
 
-namespace Splat.Tests
+namespace Splat.Tests.Logging
 {
     /// <summary>
     /// Tests that verify the wrapping full logger is working.

--- a/src/Splat.Tests/Logging/WrappingPrefixLoggerTests.cs
+++ b/src/Splat.Tests/Logging/WrappingPrefixLoggerTests.cs
@@ -1,10 +1,15 @@
-﻿using System;
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Splat.Tests.Mocks;
 using Xunit;
 
-namespace Splat.Tests
+namespace Splat.Tests.Logging
 {
     /// <summary>
     /// Tests the <see cref="WrappingPrefixLogger"/> class.

--- a/src/Splat.Tests/Mocks/TextLogger.cs
+++ b/src/Splat.Tests/Mocks/TextLogger.cs
@@ -1,4 +1,9 @@
-﻿using System;
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;

--- a/src/Splat/Logging/ActionLogger.cs
+++ b/src/Splat/Logging/ActionLogger.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.ComponentModel;
+
+namespace Splat
+{
+    /// <summary>
+    /// A logger where you pass in Action delegates that will be invoked when the Write methods are invoked.
+    /// </summary>
+    public class ActionLogger : ILogger
+    {
+        private readonly Action<string, LogLevel> _writeNoType;
+        private readonly Action<string, Type, LogLevel> _writeWithType;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ActionLogger"/> class.
+        /// </summary>
+        /// <param name="writeNoType">A action which is called when the <see cref="Write(string, LogLevel)"/> is called.</param>
+        /// <param name="writeWithType">A action which is called when the <see cref="Write(string, Type, LogLevel)"/> is called.</param>
+        public ActionLogger(Action<string, LogLevel> writeNoType, Action<string, Type, LogLevel> writeWithType)
+        {
+            _writeNoType = writeNoType;
+            _writeWithType = writeWithType;
+        }
+
+        /// <inheritdoc />
+        public LogLevel Level { get; set; }
+
+        /// <inheritdoc />
+        public void Write([Localizable(false)] string message, LogLevel logLevel)
+        {
+            _writeNoType?.Invoke(message, logLevel);
+        }
+
+        /// <inheritdoc />
+        public void Write([Localizable(false)] string message, [Localizable(false)] Type type, LogLevel logLevel)
+        {
+            _writeWithType?.Invoke(message, type, logLevel);
+        }
+    }
+}


### PR DESCRIPTION
Add a ActionLogger.

This will take delegates that the user provides.

Useful for users who want to quickly implement interfaces with their own logging systems without having the worry about implementing an entire class. 