### PR TITLE
feature: Add logger extensions that only fire when LogLevel is correct

### DIFF
--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
@@ -64,6 +64,24 @@ namespace Splat
         public static void UnregisterCurrent<T>(this Splat.IMutableDependencyResolver resolver, string contract = null) { }
         public static System.IDisposable WithResolver(this Splat.IDependencyResolver resolver, bool suppressResolverCallback = True) { }
     }
+    public class static FullLoggerExtensions
+    {
+        public static void Debug(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Debug<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void DebugException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Error(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Error<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void ErrorException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Fatal(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Fatal<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void FatalException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Info(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Info<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void InfoException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Warn(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Warn<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void WarnException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+    }
     public class FuncDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, System.IDisposable
     {
         public FuncDependencyResolver(System.Func<System.Type, string, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object>, System.Type, string> register = null, System.Action<System.Type, string> unregisterCurrent = null, System.Action<System.Type, string> unregisterAll = null, System.IDisposable toDispose = null) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
@@ -53,6 +53,24 @@ namespace Splat
         public static void UnregisterCurrent<T>(this Splat.IMutableDependencyResolver resolver, string contract = null) { }
         public static System.IDisposable WithResolver(this Splat.IDependencyResolver resolver, bool suppressResolverCallback = True) { }
     }
+    public class static FullLoggerExtensions
+    {
+        public static void Debug(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Debug<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void DebugException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Error(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Error<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void ErrorException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Fatal(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Fatal<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void FatalException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Info(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Info<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void InfoException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Warn(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Warn<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void WarnException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+    }
     public class FuncDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, System.IDisposable
     {
         public FuncDependencyResolver(System.Func<System.Type, string, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object>, System.Type, string> register = null, System.Action<System.Type, string> unregisterCurrent = null, System.Action<System.Type, string> unregisterAll = null, System.IDisposable toDispose = null) { }

--- a/src/Splat.Tests/Logging/FullLoggerExtensionsTests.cs
+++ b/src/Splat.Tests/Logging/FullLoggerExtensionsTests.cs
@@ -1,0 +1,228 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Splat.Tests.Mocks;
+using Xunit;
+
+namespace Splat.Tests.Logging
+{
+    /// <summary>
+    /// Tests that check the functionality of the <see cref="FullLoggerExtensions"/> class.
+    /// </summary>
+    public class FullLoggerExtensionsTests
+    {
+        /// <summary>
+        /// Test to make sure the debug emits nothing when not enabled.
+        /// </summary>
+        [Fact]
+        public void Debug_Disabled_Should_Not_Emit()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger);
+            var invoked = false;
+            logger.Level = LogLevel.Fatal;
+
+            logger.Debug<DummyObjectClass1>(
+                () =>
+                {
+                    invoked = true;
+                    return "This is a test.";
+                });
+
+            Assert.Null(textLogger.Value);
+            Assert.Null(textLogger.PassedTypes.FirstOrDefault());
+            Assert.False(invoked);
+        }
+
+        /// <summary>
+        /// Test to make sure the debug emits something when enabled.
+        /// </summary>
+        [Fact]
+        public void Debug_Enabled_Should_Emit()
+        {
+            var textLogger = new TextLogger();
+            bool invoked = false;
+            var logger = new WrappingFullLogger(textLogger);
+            logger.Level = LogLevel.Debug;
+
+            logger.Debug<DummyObjectClass1>(
+                () =>
+                {
+                    invoked = true;
+                    return "This is a test.";
+                });
+
+            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
+            Assert.True(invoked);
+        }
+
+        /// <summary>
+        /// Test to make sure the Info emits nothing when not enabled.
+        /// </summary>
+        [Fact]
+        public void Info_Disabled_Should_Not_Emit()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger);
+            var invoked = false;
+            logger.Level = LogLevel.Fatal;
+
+            logger.Info<DummyObjectClass1>(
+                () =>
+                {
+                    invoked = true;
+                    return "This is a test.";
+                });
+
+            Assert.Null(textLogger.Value);
+            Assert.Null(textLogger.PassedTypes.FirstOrDefault());
+            Assert.False(invoked);
+        }
+
+        /// <summary>
+        /// Test to make sure the Info emits something when enabled.
+        /// </summary>
+        [Fact]
+        public void Info_Enabled_Should_Emit()
+        {
+            var textLogger = new TextLogger();
+            bool invoked = false;
+            var logger = new WrappingFullLogger(textLogger);
+            logger.Level = LogLevel.Debug;
+
+            logger.Info<DummyObjectClass1>(
+                () =>
+                {
+                    invoked = true;
+                    return "This is a test.";
+                });
+
+            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
+            Assert.True(invoked);
+        }
+
+        /// <summary>
+        /// Test to make sure the Warn emits nothing when not enabled.
+        /// </summary>
+        [Fact]
+        public void Warn_Disabled_Should_Not_Emit()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger);
+            var invoked = false;
+            logger.Level = LogLevel.Fatal;
+
+            logger.Warn<DummyObjectClass1>(
+                () =>
+                {
+                    invoked = true;
+                    return "This is a test.";
+                });
+
+            Assert.Null(textLogger.Value);
+            Assert.Null(textLogger.PassedTypes.FirstOrDefault());
+            Assert.False(invoked);
+        }
+
+        /// <summary>
+        /// Test to make sure the Warn emits something when enabled.
+        /// </summary>
+        [Fact]
+        public void Warn_Enabled_Should_Emit()
+        {
+            var textLogger = new TextLogger();
+            bool invoked = false;
+            var logger = new WrappingFullLogger(textLogger);
+            logger.Level = LogLevel.Debug;
+
+            logger.Warn<DummyObjectClass1>(
+                () =>
+                {
+                    invoked = true;
+                    return "This is a test.";
+                });
+
+            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
+            Assert.True(invoked);
+        }
+
+        /// <summary>
+        /// Test to make sure the Error emits nothing when not enabled.
+        /// </summary>
+        [Fact]
+        public void Error_Disabled_Should_Not_Emit()
+        {
+            var textLogger = new TextLogger();
+            var logger = new WrappingFullLogger(textLogger);
+            var invoked = false;
+            logger.Level = LogLevel.Fatal;
+
+            logger.Error<DummyObjectClass1>(
+                () =>
+                {
+                    invoked = true;
+                    return "This is a test.";
+                });
+
+            Assert.Null(textLogger.Value);
+            Assert.Null(textLogger.PassedTypes.FirstOrDefault());
+            Assert.False(invoked);
+        }
+
+        /// <summary>
+        /// Test to make sure the Error emits something when enabled.
+        /// </summary>
+        [Fact]
+        public void Error_Enabled_Should_Emit()
+        {
+            var textLogger = new TextLogger();
+            bool invoked = false;
+            var logger = new WrappingFullLogger(textLogger);
+            logger.Level = LogLevel.Debug;
+
+            logger.Error<DummyObjectClass1>(
+                () =>
+                {
+                    invoked = true;
+                    return "This is a test.";
+                });
+
+            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
+            Assert.True(invoked);
+        }
+
+        /// <summary>
+        /// Test to make sure the Fatal emits something when enabled.
+        /// </summary>
+        [Fact]
+        public void Fatal_Enabled_Should_Emit()
+        {
+            var textLogger = new TextLogger();
+            bool invoked = false;
+            var logger = new WrappingFullLogger(textLogger);
+            logger.Level = LogLevel.Fatal;
+
+            logger.Fatal<DummyObjectClass1>(
+                () =>
+                {
+                    invoked = true;
+                    return "This is a test.";
+                });
+
+            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
+            Assert.True(invoked);
+        }
+    }
+}

--- a/src/Splat.Tests/Logging/WrappingFullLoggerTests.cs
+++ b/src/Splat.Tests/Logging/WrappingFullLoggerTests.cs
@@ -14,7 +14,7 @@ using Xunit;
 namespace Splat.Tests.Logging
 {
     /// <summary>
-    /// Tests that verify the wrapping full logger is working.
+    /// Tests that verify the <see cref="WrappingFullLogger"/> class.
     /// </summary>
     public class WrappingFullLoggerTests
     {

--- a/src/Splat.Tests/Mocks/TextLogger.cs
+++ b/src/Splat.Tests/Mocks/TextLogger.cs
@@ -16,24 +16,22 @@ namespace Splat.Tests.Mocks
     /// <seealso cref="Splat.ILogger" />
     public class TextLogger : ILogger, IDisposable
     {
-        private readonly StringBuilder _stringBuilder;
-        private TextWriter _writer;
-        private List<Type> _types = new List<Type>();
+        private readonly Lazy<StringBuilder> _stringBuilder = new Lazy<StringBuilder>();
+        private readonly List<Type> _types = new List<Type>();
+        private Lazy<TextWriter> _writer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TextLogger"/> class.
         /// </summary>
         public TextLogger()
         {
-            _stringBuilder = new StringBuilder();
-
-            _writer = new StringWriter(_stringBuilder);
+            _writer = new Lazy<TextWriter>(() => new StringWriter(_stringBuilder.Value));
         }
 
         /// <summary>
         /// Gets the value of the text writer.
         /// </summary>
-        public string Value => _stringBuilder.ToString();
+        public string Value => _stringBuilder.IsValueCreated ? _stringBuilder.Value.ToString() : null;
 
         /// <summary>
         /// Gets the passed types.
@@ -46,13 +44,13 @@ namespace Splat.Tests.Mocks
         /// <inheritdoc />
         public void Write(string message, LogLevel logLevel)
         {
-            _writer.WriteLine(message);
+            _writer.Value.WriteLine(message);
         }
 
         /// <inheritdoc />
         public void Write(string message, Type type, LogLevel logLevel)
         {
-            _writer.WriteLine(message);
+            _writer.Value.WriteLine(message);
             _types.Add(type);
         }
 
@@ -73,7 +71,7 @@ namespace Splat.Tests.Mocks
             {
                 if (_writer != null)
                 {
-                    _writer.Dispose();
+                    _writer.Value.Dispose();
                     _writer = null;
                 }
             }

--- a/src/Splat/Logging/FullLoggerExtensions.cs
+++ b/src/Splat/Logging/FullLoggerExtensions.cs
@@ -1,0 +1,220 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Splat
+{
+    /// <summary>
+    /// Provides extension methods to the <see cref="IFullLogger"/> interface.
+    /// </summary>
+    public static class FullLoggerExtensions
+    {
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Debug is enabled.
+        /// </summary>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Debug logging is enabled.</param>
+        public static void Debug(this IFullLogger logger, Func<string> function)
+        {
+            if (logger.IsDebugEnabled)
+            {
+                logger.Debug(function.Invoke());
+            }
+        }
+
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Debug is enabled.
+        /// </summary>
+        /// <typeparam name="T">The type of object we are logging about.</typeparam>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Debug logging is enabled.</param>
+        public static void Debug<T>(this IFullLogger logger, Func<string> function)
+        {
+            if (logger.IsDebugEnabled)
+            {
+                logger.Debug<T>(function.Invoke());
+            }
+        }
+
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Debug is enabled.
+        /// </summary>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Debug logging is enabled.</param>
+        /// <param name="exception">A exception to log about.</param>
+        public static void DebugException(this IFullLogger logger, Func<string> function, Exception exception)
+        {
+            if (logger.IsDebugEnabled)
+            {
+                logger.Debug(function.Invoke(), exception);
+            }
+        }
+
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Debug is enabled.
+        /// </summary>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Debug logging is enabled.</param>
+        public static void Info(this IFullLogger logger, Func<string> function)
+        {
+            if (logger.IsInfoEnabled)
+            {
+                logger.Info(function.Invoke());
+            }
+        }
+
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Debug is enabled.
+        /// </summary>
+        /// <typeparam name="T">The type of object we are logging about.</typeparam>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Debug logging is enabled.</param>
+        public static void Info<T>(this IFullLogger logger, Func<string> function)
+        {
+            if (logger.IsInfoEnabled)
+            {
+                logger.Info<T>(function.Invoke());
+            }
+        }
+
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Info is enabled.
+        /// </summary>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Info logging is enabled.</param>
+        /// <param name="exception">A exception to log about.</param>
+        public static void InfoException(this IFullLogger logger, Func<string> function, Exception exception)
+        {
+            if (logger.IsInfoEnabled)
+            {
+                logger.Info(function.Invoke(), exception);
+            }
+        }
+
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Warn is enabled.
+        /// </summary>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Warn logging is enabled.</param>
+        public static void Warn(this IFullLogger logger, Func<string> function)
+        {
+            if (logger.IsWarnEnabled)
+            {
+                logger.Warn(function.Invoke());
+            }
+        }
+
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Warn is enabled.
+        /// </summary>
+        /// <typeparam name="T">The type of object we are logging about.</typeparam>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Warn logging is enabled.</param>
+        public static void Warn<T>(this IFullLogger logger, Func<string> function)
+        {
+            if (logger.IsWarnEnabled)
+            {
+                logger.Warn<T>(function.Invoke());
+            }
+        }
+
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Warn is enabled.
+        /// </summary>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Warn logging is enabled.</param>
+        /// <param name="exception">A exception to log about.</param>
+        public static void WarnException(this IFullLogger logger, Func<string> function, Exception exception)
+        {
+            if (logger.IsWarnEnabled)
+            {
+                logger.Warn(function.Invoke(), exception);
+            }
+        }
+
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Error is enabled.
+        /// </summary>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Error logging is enabled.</param>
+        public static void Error(this IFullLogger logger, Func<string> function)
+        {
+            if (logger.IsErrorEnabled)
+            {
+                logger.Error(function.Invoke());
+            }
+        }
+
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Error is enabled.
+        /// </summary>
+        /// <typeparam name="T">The type of object we are logging about.</typeparam>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Error logging is enabled.</param>
+        public static void Error<T>(this IFullLogger logger, Func<string> function)
+        {
+            if (logger.IsErrorEnabled)
+            {
+                logger.Error<T>(function.Invoke());
+            }
+        }
+
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Error is enabled.
+        /// </summary>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Error logging is enabled.</param>
+        /// <param name="exception">A exception to log about.</param>
+        public static void ErrorException(this IFullLogger logger, Func<string> function, Exception exception)
+        {
+            if (logger.IsErrorEnabled)
+            {
+                logger.ErrorException(function.Invoke(), exception);
+            }
+        }
+
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Fatal is enabled.
+        /// </summary>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Fatal logging is enabled.</param>
+        public static void Fatal(this IFullLogger logger, Func<string> function)
+        {
+            if (logger.IsFatalEnabled)
+            {
+                logger.Fatal(function.Invoke());
+            }
+        }
+
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Fatal is enabled.
+        /// </summary>
+        /// <typeparam name="T">The type of object we are logging about.</typeparam>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Fatal logging is enabled.</param>
+        public static void Fatal<T>(this IFullLogger logger, Func<string> function)
+        {
+            if (logger.IsFatalEnabled)
+            {
+                logger.Fatal<T>(function.Invoke());
+            }
+        }
+
+        /// <summary>
+        /// Sends the value provided by the provided delegate, only if Fatal is enabled.
+        /// </summary>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="function">The function to evaluate if Fatal logging is enabled.</param>
+        /// <param name="exception">A exception to log about.</param>
+        public static void FatalException(this IFullLogger logger, Func<string> function, Exception exception)
+        {
+            if (logger.IsFatalEnabled)
+            {
+                logger.ErrorException(function.Invoke(), exception);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is a new feature that will allow the user to pass a Func<string> into a set of extension methods.

These Func<string> will only fire if the LogLevel of the IFullLogger is sufficient to run them. 

This allows you to avoid firing Debug logic for example when Fatal is enabled.

Inspired by the Splat.Contrib library by @dpvreony