### PR TITLE
fix: Fix unit test detector not running on UWP

### DIFF
--- a/src/Splat/Splat.csproj
+++ b/src/Splat/Splat.csproj
@@ -40,6 +40,7 @@
   <ItemGroup Condition=" $(TargetFramework.StartsWith('uap')) ">  
     <Compile Include="Platforms\WinRT\**\*.cs" />
     <Compile Include="Platforms\ReflectionStubs.cs" />
+    <Compile Include="Platforms\PlatformModeDetector.cs" />
     <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This fixes #155 

* Added the VisualStudio.TestPlatform assemblies to our detector
* Made the detector get added to our UWP build
* Fix a bug with the Task code where it would use the TaskScheduler.Current, which is unpredictable. Now it goes off to a new task pool thread.
* The unit test checker wasn't case insensitive when it needed to be.