### PR TITLE
Fix: UWP bitmap loader exception

### DIFF
--- a/src/Splat/Platforms/Android/Bitmaps/DrawableBitmap.cs
+++ b/src/Splat/Platforms/Android/Bitmaps/DrawableBitmap.cs
@@ -4,10 +4,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Android.Graphics.Drawables;

--- a/src/Splat/Platforms/Android/Bitmaps/PlatformBitmapLoader.cs
+++ b/src/Splat/Platforms/Android/Bitmaps/PlatformBitmapLoader.cs
@@ -7,7 +7,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Android.App;
 using Android.Graphics;

--- a/src/Splat/Platforms/Android/Colors/SplatColorExtensions.cs
+++ b/src/Splat/Platforms/Android/Colors/SplatColorExtensions.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Android.Graphics;
 
 namespace Splat

--- a/src/Splat/Platforms/Android/Maths/PointExtensions.cs
+++ b/src/Splat/Platforms/Android/Maths/PointExtensions.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using Android.Graphics;
 
 namespace Splat

--- a/src/Splat/Platforms/Android/Maths/RectExtensions.cs
+++ b/src/Splat/Platforms/Android/Maths/RectExtensions.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using Android.Graphics;
 
 namespace Splat

--- a/src/Splat/Platforms/Cocoa/Bitmaps/CocoaBitmap.cs
+++ b/src/Splat/Platforms/Cocoa/Bitmaps/CocoaBitmap.cs
@@ -3,7 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Splat/Platforms/Tizen/Bitmaps/BitmapMixins.cs
+++ b/src/Splat/Platforms/Tizen/Bitmaps/BitmapMixins.cs
@@ -3,11 +3,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Tizen.Multimedia.Util;
 
 namespace Splat

--- a/src/Splat/Platforms/Tizen/Bitmaps/TizenBitmap.cs
+++ b/src/Splat/Platforms/Tizen/Bitmaps/TizenBitmap.cs
@@ -3,11 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Tizen.Multimedia.Util;
 

--- a/src/Splat/Platforms/WinRT/Bitmaps/BitmapImageBitmap.cs
+++ b/src/Splat/Platforms/WinRT/Bitmaps/BitmapImageBitmap.cs
@@ -4,11 +4,8 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.UI.Xaml.Media.Imaging;

--- a/src/Splat/Platforms/WinRT/Bitmaps/BitmapMixins.cs
+++ b/src/Splat/Platforms/WinRT/Bitmaps/BitmapMixins.cs
@@ -5,7 +5,7 @@
 
 using Windows.UI.Xaml.Media.Imaging;
 
-namespace Splat.Platforms.WinRT.Bitmaps
+namespace Splat
 {
     /// <summary>
     /// Extension methods to assist with dealing with Bitmaps.

--- a/src/Splat/Platforms/WinRT/Bitmaps/DispatcherMixin.cs
+++ b/src/Splat/Platforms/WinRT/Bitmaps/DispatcherMixin.cs
@@ -4,9 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Windows.UI.Core;
 

--- a/src/Splat/Platforms/WinRT/Bitmaps/PlatformBitmapLoader.cs
+++ b/src/Splat/Platforms/WinRT/Bitmaps/PlatformBitmapLoader.cs
@@ -4,16 +4,12 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
-using System.Text;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
 using Windows.Graphics.Imaging;
 using Windows.Storage;
-using Windows.Storage.Streams;
 using Windows.UI.Core;
 using Windows.UI.Xaml.Media.Imaging;
 
@@ -29,14 +25,10 @@ namespace Splat
         {
             return GetDispatcher().RunTaskAsync(async () =>
             {
-                using (var rwStream = new InMemoryRandomAccessStream())
+                using (var randomAccessStream = sourceStream.AsRandomAccessStream())
                 {
-                    var writer = rwStream.AsStreamForWrite();
-                    await sourceStream.CopyToAsync(writer).ConfigureAwait(true);
-                    await writer.FlushAsync().ConfigureAwait(true);
-                    rwStream.Seek(0);
-
-                    var decoder = await BitmapDecoder.CreateAsync(rwStream);
+                    randomAccessStream.Seek(0);
+                    var decoder = await BitmapDecoder.CreateAsync(randomAccessStream);
 
                     int targetWidth = (int)(desiredWidth ?? decoder.OrientedPixelWidth);
                     int targetHeight = (int)(desiredHeight ?? decoder.OrientedPixelHeight);


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
fixes #203 for both native and Xamarin.Forms UWP projects.


**What is the current behavior? (You can also link to an open issue here)**
Throws an exception on the line: `var decoder = await BitmapDecoder.CreateAsync(rwStream);`


**What is the new behavior (if this is a feature change)?**
Loads the bitmap (doesn't throw an exception)


**What might this PR break?**
Nothing


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

