### PR TITLE
feature: Added Splat.Autofac

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -77,11 +77,13 @@ var packagesArtifactDirectory = artifactDirectory + "packages/";
 var packageWhitelist = new[] 
 { 
     "Splat",
+    "Splat.Autofac",
 };
 
 var packageTestWhitelist = new[]
 {
     "Splat.Tests", 
+    "Splat.Autofac.Tests",
 };
 
 var testFrameworks = new[] { "netcoreapp2.1", "net472" };

--- a/src/Splat.Autofac.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Autofac.Tests/DependencyResolverTests.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Autofac;
+using ReactiveUI;
+using Shouldly;
+using Xunit;
+
+namespace Splat.Autofac.Tests
+{
+    /// <summary>
+    /// Tests to show the <see cref="AutofacDependencyResolver"/> works correctly.
+    /// </summary>
+    public class DependencyResolverTests
+    {
+        /// <summary>
+        /// Shoulds the resolve views.
+        /// </summary>
+        [Fact]
+        public void AutofacDependencyResolver_Should_Resolve_Views()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ViewOne>().As<IViewFor<ViewModelOne>>();
+            builder.RegisterType<ViewTwo>().As<IViewFor<ViewModelTwo>>();
+            builder.Build().UseAutofacDependencyResolver();
+
+            var viewOne = Locator.Current.GetService(typeof(IViewFor<ViewModelOne>));
+            var viewTwo = Locator.Current.GetService(typeof(IViewFor<ViewModelTwo>));
+
+            viewOne.ShouldNotBeNull();
+            viewOne.ShouldBeOfType<ViewOne>();
+            viewTwo.ShouldNotBeNull();
+            viewTwo.ShouldBeOfType<ViewTwo>();
+        }
+
+        /// <summary>
+        /// Shoulds the resolve views.
+        /// </summary>
+        [Fact]
+        public void AutofacDependencyResolver_Should_Resolve_Named_View()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ViewTwo>().Named<IViewFor<ViewModelTwo>>("Other");
+            builder.Build().UseAutofacDependencyResolver();
+
+            var viewTwo = Locator.Current.GetService(typeof(IViewFor<ViewModelTwo>), "Other");
+
+            viewTwo.ShouldNotBeNull();
+            viewTwo.ShouldBeOfType<ViewTwo>();
+        }
+
+        /// <summary>
+        /// Shoulds the resolve view models.
+        /// </summary>
+        [Fact]
+        public void AutofacDependencyResolver_Should_Resolve_View_Models()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ViewModelOne>().AsSelf();
+            builder.RegisterType<ViewModelTwo>().AsSelf();
+            builder.Build().UseAutofacDependencyResolver();
+
+            var vmOne = Locator.Current.GetService<ViewModelOne>();
+            var vmTwo = Locator.Current.GetService<ViewModelTwo>();
+
+            vmOne.ShouldNotBeNull();
+            vmTwo.ShouldNotBeNull();
+        }
+
+        /// <summary>
+        /// Shoulds the resolve screen.
+        /// </summary>
+        [Fact]
+        public void AutofacDependencyResolver_Should_Resolve_Screen()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterType<MockScreen>().As<IScreen>().SingleInstance();
+            builder.Build().UseAutofacDependencyResolver();
+
+            var screen = Locator.Current.GetService<IScreen>();
+
+            screen.ShouldNotBeNull();
+            screen.ShouldBeOfType<MockScreen>();
+        }
+    }
+}

--- a/src/Splat.Autofac.Tests/Mocks/MockScreen.cs
+++ b/src/Splat.Autofac.Tests/Mocks/MockScreen.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+
+namespace Splat.Autofac.Tests
+{
+    /// <summary>
+    /// An <see cref="IScreen"/> implementation.
+    /// </summary>
+    /// <seealso cref="IScreen" />
+    public class MockScreen : IScreen
+    {
+        /// <summary>
+        /// Gets the Router associated with this Screen.
+        /// </summary>
+        public RoutingState Router { get; }
+    }
+}

--- a/src/Splat.Autofac.Tests/Mocks/ViewModelOne.cs
+++ b/src/Splat.Autofac.Tests/Mocks/ViewModelOne.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+
+namespace Splat.Autofac.Tests
+{
+    /// <summary>
+    /// View Model One.
+    /// </summary>
+    /// <seealso cref="ReactiveObject" />
+    /// <seealso cref="IRoutableViewModel" />
+    public class ViewModelOne : ReactiveObject, IRoutableViewModel
+    {
+        /// <inheritdoc />
+        public string UrlPathSegment { get; }
+
+        /// <inheritdoc />
+        public IScreen HostScreen { get; }
+    }
+}

--- a/src/Splat.Autofac.Tests/Mocks/ViewModelTwo.cs
+++ b/src/Splat.Autofac.Tests/Mocks/ViewModelTwo.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+
+namespace Splat.Autofac.Tests
+{
+    /// <summary>
+    /// View Model Two.
+    /// </summary>
+    /// <seealso cref="ReactiveObject" />
+    /// <seealso cref="IRoutableViewModel" />
+    public class ViewModelTwo : ReactiveObject, IRoutableViewModel
+    {
+        /// <inheritdoc />
+        public string UrlPathSegment { get; }
+
+        /// <inheritdoc />
+        public IScreen HostScreen { get; }
+    }
+}

--- a/src/Splat.Autofac.Tests/Mocks/ViewOne.cs
+++ b/src/Splat.Autofac.Tests/Mocks/ViewOne.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+
+namespace Splat.Autofac.Tests
+{
+    /// <summary>
+    /// View One.
+    /// </summary>
+    /// <seealso cref="ViewModelOne" />
+    public class ViewOne : IViewFor<ViewModelOne>
+    {
+        /// <inheritdoc />
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (ViewModelOne)value;
+        }
+
+        /// <inheritdoc />
+        public ViewModelOne ViewModel { get; set; }
+    }
+}

--- a/src/Splat.Autofac.Tests/Mocks/ViewTwo.cs
+++ b/src/Splat.Autofac.Tests/Mocks/ViewTwo.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+
+namespace Splat.Autofac.Tests
+{
+    /// <summary>
+    /// View Two.
+    /// </summary>
+    /// <seealso cref="ViewModelTwo" />
+    [ViewContract("Other")]
+    public class ViewTwo : IViewFor<ViewModelTwo>
+    {
+        /// <inheritdoc />
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (ViewModelTwo)value;
+        }
+
+        /// <inheritdoc />
+        public ViewModelTwo ViewModel { get; set; }
+    }
+}

--- a/src/Splat.Autofac.Tests/Splat.Autofac.Tests.csproj
+++ b/src/Splat.Autofac.Tests/Splat.Autofac.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);1591;CA1707;SA1633</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.8.1" />
+    <PackageReference Include="ReactiveUI" Version="9.8.15" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Splat.Autofac\Splat.Autofac.csproj" />
+    <ProjectReference Include="..\Splat\Splat.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/Splat.Autofac.Tests/xunit.runner.json
+++ b/src/Splat.Autofac.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "shadowCopy": false
+}

--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Autofac;
+using Autofac.Core;
+
+namespace Splat.Autofac
+{
+    /// <summary>
+    /// Autofac implementation for <see cref="IMutableDependencyResolver"/>.
+    /// </summary>
+    public class AutofacDependencyResolver : IMutableDependencyResolver
+    {
+        private IContainer _container;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AutofacDependencyResolver"/> class.
+        /// </summary>
+        /// <param name="container">The container.</param>
+        public AutofacDependencyResolver(IContainer container)
+        {
+            _container = container;
+        }
+
+        /// <inheritdoc />
+        public virtual object GetService(Type serviceType, string contract = null)
+        {
+            try
+            {
+                return string.IsNullOrEmpty(contract)
+                    ? _container.Resolve(serviceType)
+                    : _container.ResolveNamed(contract, serviceType);
+            }
+            catch (DependencyResolutionException)
+            {
+                return null;
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual IEnumerable<object> GetServices(Type serviceType, string contract = null)
+        {
+            try
+            {
+                var enumerableType = typeof(IEnumerable<>).MakeGenericType(serviceType);
+                object instance = string.IsNullOrEmpty(contract)
+                    ? _container.Resolve(enumerableType)
+                    : _container.ResolveNamed(contract, enumerableType);
+                return ((IEnumerable)instance).Cast<object>();
+            }
+            catch (DependencyResolutionException)
+            {
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Register a function with the resolver which will generate a object
+        /// for the specified service type.
+        /// Optionally a contract can be registered which will indicate
+        /// that that registration will only work with that contract.
+        /// Most implementations will use a stack based approach to allow for multile items to be registered.
+        /// </summary>
+        /// <param name="factory">The factory function which generates our object.</param>
+        /// <param name="serviceType">The type which is used for the registration.</param>
+        /// <param name="contract">A optional contract value which will indicates to only generate the value if this contract is specified.</param>
+        public virtual void Register(Func<object> factory, Type serviceType, string contract = null)
+        {
+            var builder = new ContainerBuilder();
+            if (string.IsNullOrEmpty(contract))
+            {
+                builder.Register(x => factory()).As(serviceType).AsImplementedInterfaces();
+            }
+            else
+            {
+                builder.Register(x => factory()).Named(contract, serviceType).AsImplementedInterfaces();
+            }
+        }
+
+        /// <summary>
+        /// Unregisters the current item based on the specified type and contract.
+        /// https://stackoverflow.com/questions/5091101/is-it-possible-to-remove-an-existing-registration-from-autofac-container-builder.
+        /// </summary>
+        /// <param name="serviceType">The service type to unregister.</param>
+        /// <param name="contract">The optional contract value, which will only remove the value associated with the contract.</param>
+        /// <exception cref="System.NotImplementedException">This is not implemented by default.</exception>
+        /// <inheritdoc />
+        public virtual void UnregisterCurrent(Type serviceType, string contract = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Unregisters all the values associated with the specified type and contract.
+        /// https://stackoverflow.com/questions/5091101/is-it-possible-to-remove-an-existing-registration-from-autofac-container-builder.
+        /// </summary>
+        /// <param name="serviceType">The service type to unregister.</param>
+        /// <param name="contract">The optional contract value, which will only remove the value associated with the contract.</param>
+        /// <exception cref="System.NotImplementedException">This is not implemented by default.</exception>
+        /// <inheritdoc />
+        public virtual void UnregisterAll(Type serviceType, string contract = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public virtual IDisposable ServiceRegistrationCallback(Type serviceType, string contract, Action<IDisposable> callback)
+        {
+            // this method is not used by RxUI
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes of the instance.
+        /// </summary>
+        /// <param name="disposing">Whether or not the instance is disposing.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _container?.Dispose();
+                _container = null;
+            }
+        }
+    }
+}

--- a/src/Splat.Autofac/Splat.Autofac.csproj
+++ b/src/Splat.Autofac/Splat.Autofac.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.8.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Splat\Splat.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Splat.Autofac/SplatAutofacExtension.cs
+++ b/src/Splat.Autofac/SplatAutofacExtension.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Autofac;
+
+namespace Splat.Autofac
+{
+    /// <summary>
+    /// Extension methods for the Autofac adapter.
+    /// </summary>
+    public static class SplatAutofacExtension
+    {
+        /// <summary>
+        /// Initializes an instance of <see cref="AutofacDependencyResolver"/> that overrides the default <see cref="Locator"/>.
+        /// </summary>
+        /// <param name="container">Autofac container.</param>
+        public static void UseAutofacDependencyResolver(this IContainer container) =>
+            Locator.Current = new AutofacDependencyResolver(container);
+
+        /// <summary>
+        /// Initializes an instance of <see cref="AutofacDependencyResolver"/> that overrides the default <see cref="Locator"/>.
+        /// </summary>
+        /// <param name="containerBuilder">Autofac container builder.</param>
+        public static void UseAutofacDependencyResolver(this ContainerBuilder containerBuilder) =>
+            Locator.Current = new AutofacDependencyResolver(containerBuilder.Build());
+    }
+}

--- a/src/Splat.sln
+++ b/src/Splat.sln
@@ -13,6 +13,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Tests", "Splat.Tests\Splat.Tests.csproj", "{6CAD2584-AA69-4A36-8AD4-A90D040003CA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Splat.Autofac", "Splat.Autofac\Splat.Autofac.csproj", "{8447DF8A-882C-4CA8-A7FB-85D66F12D378}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Splat.Autofac.Tests", "Splat.Autofac.Tests\Splat.Autofac.Tests.csproj", "{1D8068E4-7F85-4322-BC06-3D901F392CF1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +31,14 @@ Global
 		{6CAD2584-AA69-4A36-8AD4-A90D040003CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6CAD2584-AA69-4A36-8AD4-A90D040003CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6CAD2584-AA69-4A36-8AD4-A90D040003CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8447DF8A-882C-4CA8-A7FB-85D66F12D378}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8447DF8A-882C-4CA8-A7FB-85D66F12D378}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8447DF8A-882C-4CA8-A7FB-85D66F12D378}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8447DF8A-882C-4CA8-A7FB-85D66F12D378}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1D8068E4-7F85-4322-BC06-3D901F392CF1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1D8068E4-7F85-4322-BC06-3D901F392CF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1D8068E4-7F85-4322-BC06-3D901F392CF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1D8068E4-7F85-4322-BC06-3D901F392CF1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
- Added a AutofacDependencyResolver adapter
- Added unit tests
- Added Splat.Autofac to build.cake

Related: #233 

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Adds and Autofac implementation of `IMutableDepedencyResolver` as an adapter to splat.

**What is the current behavior? (You can also link to an open issue here)**

There is no Autofac adapter for splat.

**What is the new behavior (if this is a feature change)?**

There is an Autofac adapter for splat.

**What might this PR break?**

Itself?_

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

