### PR TITLE
feature: Added Splat.SimpleInjector

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -78,12 +78,14 @@ var packageWhitelist = new[]
 { 
     "Splat",
     "Splat.Autofac",
+    "Splat.SimpleInjector",
 };
 
 var packageTestWhitelist = new[]
 {
-    "Splat.Tests", 
+    "Splat.Tests",
     "Splat.Autofac.Tests",
+    "Splat.SimpleInjector.Tests",
 };
 
 var testFrameworks = new[] { "netcoreapp2.1", "net472" };

--- a/src/Splat.Autofac/SplatAutofacExtensions.cs
+++ b/src/Splat.Autofac/SplatAutofacExtensions.cs
@@ -10,7 +10,7 @@ namespace Splat.Autofac
     /// <summary>
     /// Extension methods for the Autofac adapter.
     /// </summary>
-    public static class SplatAutofacExtension
+    public static class SplatAutofacExtensions
     {
         /// <summary>
         /// Initializes an instance of <see cref="AutofacDependencyResolver"/> that overrides the default <see cref="Locator"/>.

--- a/src/Splat.SimpleInjector.Tests/DependencyResolverTests.cs
+++ b/src/Splat.SimpleInjector.Tests/DependencyResolverTests.cs
@@ -1,0 +1,67 @@
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+using Shouldly;
+using SimpleInjector;
+using Splat.SimpleInjector;
+using Xunit;
+
+namespace Splat.Simplnjector
+{
+    /// <summary>
+    /// Tests to show the <see cref="SimpleInjectorDependencyResolver"/> works correctly.
+    /// </summary>
+    public class DependencyResolverTests
+    {
+        /// <summary>
+        /// Simples the injector dependency resolver should resolve a view model.
+        /// </summary>
+        [Fact]
+        public void SimpleInjectorDependencyResolver_Should_Resolve_View_Model()
+        {
+            var container = new Container();
+            container.Register<ViewModel>();
+            container.UseSimpleInjectorDependencyResolver();
+
+            var viewModel = Locator.Current.GetService(typeof(ViewModel));
+
+            viewModel.ShouldNotBeNull();
+            viewModel.ShouldBeOfType<ViewModel>();
+        }
+
+        /// <summary>
+        /// Simples the injector dependency resolver should resolve a view.
+        /// </summary>
+        [Fact]
+        public void SimpleInjectorDependencyResolver_Should_Resolve_View()
+        {
+            var container = new Container();
+            container.Register<IViewFor<ViewModel>, View>();
+            container.UseSimpleInjectorDependencyResolver();
+
+            var view = Locator.Current.GetService(typeof(IViewFor<ViewModel>));
+
+            view.ShouldNotBeNull();
+            view.ShouldBeOfType<View>();
+        }
+
+        /// <summary>
+        /// Simples the injector dependency resolver should resolve the screen.
+        /// </summary>
+        [Fact]
+        public void SimpleInjectorDependencyResolver_Should_Resolve_Screen()
+        {
+            var container = new Container();
+            container.RegisterSingleton<IScreen, MockScreen>();
+            container.UseSimpleInjectorDependencyResolver();
+
+            var screen = Locator.Current.GetService(typeof(IScreen));
+
+            screen.ShouldNotBeNull();
+            screen.ShouldBeOfType<MockScreen>();
+        }
+    }
+}

--- a/src/Splat.SimpleInjector.Tests/MockScreen.cs
+++ b/src/Splat.SimpleInjector.Tests/MockScreen.cs
@@ -1,0 +1,14 @@
+using ReactiveUI;
+
+namespace Splat.Simplnjector
+{
+    /// <summary>
+    /// Mock screen.
+    /// </summary>
+    /// <seealso cref="ReactiveUI.IScreen" />
+    public class MockScreen : IScreen
+    {
+        /// <inheritdoc />
+        public RoutingState Router { get; }
+    }
+}

--- a/src/Splat.SimpleInjector.Tests/Splat.SimpleInjector.Tests.csproj
+++ b/src/Splat.SimpleInjector.Tests/Splat.SimpleInjector.Tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp2.1;net472</TargetFrameworks>
+
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);1591;CA1707;SA1633</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SimpleInjector" Version="4.4.3" />
+    <PackageReference Include="ReactiveUI" Version="9.8.15" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Splat.SimpleInjector\Splat.SimpleInjector.csproj" />
+    <ProjectReference Include="..\Splat\Splat.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/src/Splat.SimpleInjector.Tests/View.cs
+++ b/src/Splat.SimpleInjector.Tests/View.cs
@@ -1,0 +1,26 @@
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using ReactiveUI;
+
+namespace Splat.Simplnjector
+{
+    /// <summary>
+    /// View.
+    /// </summary>
+    /// <seealso cref="ReactiveUI.IViewFor{Splat.Simplnjector.ViewModel}" />
+    public class View : IViewFor<ViewModel>
+    {
+        /// <inheritdoc />
+        object IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (ViewModel)value;
+        }
+
+        /// <inheritdoc />
+        public ViewModel ViewModel { get; set; }
+    }
+}

--- a/src/Splat.SimpleInjector.Tests/ViewModel.cs
+++ b/src/Splat.SimpleInjector.Tests/ViewModel.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Splat.Simplnjector
+{
+    /// <summary>
+    /// View Model.
+    /// </summary>
+    public class ViewModel
+    {
+    }
+}

--- a/src/Splat.SimpleInjector.Tests/xunit.runner.json
+++ b/src/Splat.SimpleInjector.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "shadowCopy": false
+}

--- a/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
+++ b/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using SimpleInjector;
+
+namespace Splat.SimpleInjector
+{
+    /// <summary>
+    /// Simple Injector implementation for <see cref="IMutableDependencyResolver"/>.
+    /// </summary>
+    /// <seealso cref="Splat.IMutableDependencyResolver" />
+    public class SimpleInjectorDependencyResolver : IMutableDependencyResolver
+    {
+        private Container _container;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SimpleInjectorDependencyResolver"/> class.
+        /// </summary>
+        /// <param name="container">The container.</param>
+        public SimpleInjectorDependencyResolver(Container container)
+        {
+            _container = container;
+        }
+
+        /// <inheritdoc />
+        public object GetService(Type serviceType, string contract = null) => _container.GetInstance(serviceType);
+
+        /// <inheritdoc />
+        public IEnumerable<object> GetServices(Type serviceType, string contract = null) =>
+            _container.GetAllInstances(serviceType);
+
+        /// <inheritdoc />
+        public void Register(Func<object> factory, Type serviceType, string contract = null) =>
+            _container.Register(serviceType, factory);
+
+        /// <inheritdoc />
+        public void UnregisterCurrent(Type serviceType, string contract = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void UnregisterAll(Type serviceType, string contract = null)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public IDisposable ServiceRegistrationCallback(Type serviceType, string contract, Action<IDisposable> callback)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes of the instance.
+        /// </summary>
+        /// <param name="disposing">Whether or not the instance is disposing.</param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _container?.Dispose();
+                _container = null;
+            }
+        }
+    }
+}

--- a/src/Splat.SimpleInjector/Splat.SimpleInjector.csproj
+++ b/src/Splat.SimpleInjector/Splat.SimpleInjector.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="SimpleInjector" Version="4.4.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Splat\Splat.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Splat.SimpleInjector/SplatSimpleInjectorExtensions.cs
+++ b/src/Splat.SimpleInjector/SplatSimpleInjectorExtensions.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using SimpleInjector;
+
+namespace Splat.SimpleInjector
+{
+    /// <summary>
+    /// Extension methods for the Autofac adapter.
+    /// </summary>
+    public static class SplatSimpleInjectorExtensions
+    {
+        /// <summary>
+        /// Initializes an instance of <see cref="SimpleInjectorDependencyResolver"/> that overrides the default <see cref="Locator"/>.
+        /// </summary>
+        /// <param name="container">Simple Injector container.</param>
+        public static void UseSimpleInjectorDependencyResolver(this Container container) =>
+            Locator.Current = new SimpleInjectorDependencyResolver(container);
+    }
+}

--- a/src/Splat.sln
+++ b/src/Splat.sln
@@ -13,9 +13,13 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Tests", "Splat.Tests\Splat.Tests.csproj", "{6CAD2584-AA69-4A36-8AD4-A90D040003CA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Splat.Autofac", "Splat.Autofac\Splat.Autofac.csproj", "{8447DF8A-882C-4CA8-A7FB-85D66F12D378}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Autofac", "Splat.Autofac\Splat.Autofac.csproj", "{8447DF8A-882C-4CA8-A7FB-85D66F12D378}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Splat.Autofac.Tests", "Splat.Autofac.Tests\Splat.Autofac.Tests.csproj", "{1D8068E4-7F85-4322-BC06-3D901F392CF1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Autofac.Tests", "Splat.Autofac.Tests\Splat.Autofac.Tests.csproj", "{1D8068E4-7F85-4322-BC06-3D901F392CF1}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.SimpleInjector", "Splat.SimpleInjector\Splat.SimpleInjector.csproj", "{5A21B576-374D-439E-9303-02A5B0256B26}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.SimpleInjector.Tests", "Splat.SimpleInjector.Tests\Splat.SimpleInjector.Tests.csproj", "{E85B3A4E-6ECA-4171-8605-55792187FAB4}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +43,14 @@ Global
 		{1D8068E4-7F85-4322-BC06-3D901F392CF1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1D8068E4-7F85-4322-BC06-3D901F392CF1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1D8068E4-7F85-4322-BC06-3D901F392CF1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A21B576-374D-439E-9303-02A5B0256B26}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A21B576-374D-439E-9303-02A5B0256B26}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A21B576-374D-439E-9303-02A5B0256B26}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A21B576-374D-439E-9303-02A5B0256B26}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E85B3A4E-6ECA-4171-8605-55792187FAB4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E85B3A4E-6ECA-4171-8605-55792187FAB4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E85B3A4E-6ECA-4171-8605-55792187FAB4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E85B3A4E-6ECA-4171-8605-55792187FAB4}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Adds and Simple Injector implementation of IMutableDepedencyResolver as an adapter to splat.

**What is the current behavior? (You can also link to an open issue here)**

There is no Simple Injector adapter for splat.

**What is the new behavior (if this is a feature change)?**

There is a Simple Injector adapter for splat.

**What might this PR break?**

Itself.

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Simple Injector doesn't support named instances by default.  I am not sure whether we should attempt a factory implementation to provide with this feature.
