### PR TITLE
Update View and ViewModel mocks for SimpleInjector tests.

### DIFF
--- a/src/Splat.SimpleInjector.Tests/View.cs
+++ b/src/Splat.SimpleInjector.Tests/View.cs
@@ -13,6 +13,14 @@ namespace Splat.Simplnjector
     /// <seealso cref="ReactiveUI.IViewFor{Splat.Simplnjector.ViewModel}" />
     public class View : IViewFor<ViewModel>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="View"/> class.
+        /// </summary>
+        public View()
+        {
+            this.Bind(ViewModel, x => x.Text, x => x.Text);
+        }
+
         /// <inheritdoc />
         object IViewFor.ViewModel
         {
@@ -22,5 +30,10 @@ namespace Splat.Simplnjector
 
         /// <inheritdoc />
         public ViewModel ViewModel { get; set; }
+
+        /// <summary>
+        /// Gets or sets text. TextBox.Text for example.
+        /// </summary>
+        public string Text { get; set; }
     }
 }

--- a/src/Splat.SimpleInjector.Tests/ViewModel.cs
+++ b/src/Splat.SimpleInjector.Tests/ViewModel.cs
@@ -3,12 +3,24 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using ReactiveUI;
+
 namespace Splat.Simplnjector
 {
     /// <summary>
     /// View Model.
     /// </summary>
-    public class ViewModel
+    public class ViewModel : ReactiveObject
     {
+        private string _text;
+
+        /// <summary>
+        /// Gets or sets text.
+        /// </summary>
+        public string Text
+        {
+            get => _text;
+            set => this.RaiseAndSetIfChanged(ref _text, value);
+        }
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This change add one binding to mocks, that start RxApp initialization.

**What is the current behavior? (You can also link to an open issue here)**

#233 

**What is the new behavior (if this is a feature change)?**



**What might this PR break?**

Breaks all current tests in Splat.SimpleInjector.Tests project.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

SimpleInjectorDependencyResolver not works in real apps. 
I made a pull request #239 with changes to View and ViewModel classes to start initialization of RxApp and all tests fails.

After some investigations i found this issues:
1. [The container is locked after the first call to resolve](https://simpleinjector.readthedocs.io/en/latest/decisions.html#the-container-is-locked-after-the-first-call-to-resolve) but ReactiveUI invoke all registrations after RxApp.EnsureInitialized(). This can be fixed by not getting instace of MainWindow from container. If there are no other solutions, we should add this workaround to documentation.
```csharp
    //var window = (MainWindow)container.GetInstance<IViewFor<MainViewModel>>();
    var window = new MainWindow();
    window.ViewModel = container.GetInstance<MainViewModel>();
    window.Show();
```

2. SimpleInjector support multiple registrations for same interface only through [Collection.Register](https://simpleinjector.readthedocs.io/en/latest/using.html#collections). We can't register [this lines](https://github.com/reactiveui/ReactiveUI/blob/ea99102c37bbbf2567c0193e558d1ef9402fdaed/src/ReactiveUI/Registration/Registrations.cs#L23-L25) using _container.Register() method.

https://github.com/reactiveui/splat/blob/d27b0b48e71d38402c8e224b25e2dfff2daef875/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs#L38

I don't have any workarounds for second issue. Can we use this DI container with ReactiveUI?

_Originally posted by @chuuddo in https://github.com/reactiveui/splat/issues/233#issuecomment-456362486_