### PR TITLE
fix: Add ContainerBuilder update to AutofacDependencyResolver

### DIFF
--- a/src/Splat.Autofac.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Autofac.Tests/DependencyResolverTests.cs
@@ -88,17 +88,16 @@ namespace Splat.Autofac.Tests
         }
 
         /// <summary>
-        /// Shoulds the register Reactive UI binding type converters.
+        /// Shoulds register ReactiveUI binding type converters.
         /// </summary>
         [Fact]
         public void AutofacDependencyResolver_Should_Register_ReactiveUI_BindingTypeConverters()
         {
+            // Invoke RxApp which initializes the ReactiveUI platform.
+            var scheduler = RxApp.MainThreadScheduler;
             var builder = new ContainerBuilder();
-            var scheduler = RxApp.MainThreadScheduler; // invoke RxApp static constructor
             var container = builder.Build();
-            var resolver = new AutofacDependencyResolver(container);
-            resolver.InitializeReactiveUI();
-            Locator.Current = resolver;
+            Locator.Current = new AutofacDependencyResolver(container);
 
             var converters = container.Resolve<IEnumerable<IBindingTypeConverter>>().ToList();
 
@@ -108,17 +107,16 @@ namespace Splat.Autofac.Tests
         }
 
         /// <summary>
-        /// Shoulds the register Reactive UI creates command bindings.
+        /// Shoulds register ReactiveUI creates command bindings.
         /// </summary>
         [Fact]
         public void AutofacDependencyResolver_Should_Register_ReactiveUI_CreatesCommandBinding()
         {
+            // Invoke RxApp which initializes the ReactiveUI platform.
+            var scheduler = RxApp.MainThreadScheduler;
             var builder = new ContainerBuilder();
-            var scheduler = RxApp.MainThreadScheduler; // invoke RxApp static constructor
             var container = builder.Build();
-            var resolver = new AutofacDependencyResolver(container);
-            resolver.InitializeReactiveUI();
-            Locator.Current = resolver;
+            Locator.Current = new AutofacDependencyResolver(container);
 
             var converters = container.Resolve<IEnumerable<ICreatesCommandBinding>>().ToList();
 

--- a/src/Splat.Autofac.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Autofac.Tests/DependencyResolverTests.cs
@@ -3,6 +3,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Collections.Generic;
+using System.Linq;
 using Autofac;
 using ReactiveUI;
 using Shouldly;
@@ -83,6 +85,46 @@ namespace Splat.Autofac.Tests
 
             screen.ShouldNotBeNull();
             screen.ShouldBeOfType<MockScreen>();
+        }
+
+        /// <summary>
+        /// Shoulds the register Reactive UI binding type converters.
+        /// </summary>
+        [Fact]
+        public void AutofacDependencyResolver_Should_Register_ReactiveUI_BindingTypeConverters()
+        {
+            var builder = new ContainerBuilder();
+            var scheduler = RxApp.MainThreadScheduler; // invoke RxApp static constructor
+            var container = builder.Build();
+            var resolver = new AutofacDependencyResolver(container);
+            resolver.InitializeReactiveUI();
+            Locator.Current = resolver;
+
+            var converters = container.Resolve<IEnumerable<IBindingTypeConverter>>().ToList();
+
+            converters.ShouldNotBeNull();
+            converters.ShouldContain(x => x.GetType() == typeof(StringConverter));
+            converters.ShouldContain(x => x.GetType() == typeof(EqualityTypeConverter));
+        }
+
+        /// <summary>
+        /// Shoulds the register Reactive UI creates command bindings.
+        /// </summary>
+        [Fact]
+        public void AutofacDependencyResolver_Should_Register_ReactiveUI_CreatesCommandBinding()
+        {
+            var builder = new ContainerBuilder();
+            var scheduler = RxApp.MainThreadScheduler; // invoke RxApp static constructor
+            var container = builder.Build();
+            var resolver = new AutofacDependencyResolver(container);
+            resolver.InitializeReactiveUI();
+            Locator.Current = resolver;
+
+            var converters = container.Resolve<IEnumerable<ICreatesCommandBinding>>().ToList();
+
+            converters.ShouldNotBeNull();
+            converters.ShouldContain(x => x.GetType() == typeof(CreatesCommandBindingViaEvent));
+            converters.ShouldContain(x => x.GetType() == typeof(CreatesCommandBindingViaCommandParameter));
         }
     }
 }

--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Autofac;
 using Autofac.Core;
@@ -70,6 +71,7 @@ namespace Splat.Autofac
         /// <param name="factory">The factory function which generates our object.</param>
         /// <param name="serviceType">The type which is used for the registration.</param>
         /// <param name="contract">A optional contract value which will indicates to only generate the value if this contract is specified.</param>
+        [SuppressMessage("Design", "CS0168: Obsolete method call", Justification = "Needed for container generation")]
         public virtual void Register(Func<object> factory, Type serviceType, string contract = null)
         {
             var builder = new ContainerBuilder();
@@ -82,9 +84,7 @@ namespace Splat.Autofac
                 builder.Register(x => factory()).Named(contract, serviceType).AsImplementedInterfaces();
             }
 
-#pragma warning disable CS0618 // Type or member is obsolete
             builder.Update(_container);
-#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>

--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -81,6 +81,10 @@ namespace Splat.Autofac
             {
                 builder.Register(x => factory()).Named(contract, serviceType).AsImplementedInterfaces();
             }
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            builder.Update(_container);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fixes issue with Splat.Autofac not updating the container after new registrations.

Related to: #233 

**What is the current behavior? (You can also link to an open issue here)**

It currently won't properly interact with ReactiveUI platform registrations.

**What is the new behavior (if this is a feature change)?**

The container will update correctly and resolve ReactiveUI dependencies.

**What might this PR break?**

Nothing.

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

