### PR TITLE
Fix: Stop Splat.NLog adjusting loglevel config

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Locator.CurrentMutable.UseLog4NetWithWrappingFullLogger();
 
 ### NLog
 
-First configure log4net. For guidance see https://github.com/nlog/nlog/wiki/Tutorial and https://github.com/nlog/nlog/wiki/Configuration-file
+First configure NLog. For guidance see https://github.com/nlog/nlog/wiki/Tutorial and https://github.com/nlog/nlog/wiki/Configuration-file
 
 ```cs
 using Splat.NLog;

--- a/README.md
+++ b/README.md
@@ -150,6 +150,48 @@ this.Log().ErrorException("Tried to do a thing and failed", exception);
 For static methods, `LogHost.Default` can be used as the object to write a log
 entry for. 
 
+### Available logging adapters
+
+Splat has support for the following logging frameworks
+
+| Target | Package | NuGet |
+|---------|-------|
+| Debug | [Splat][SplatNuGet] | [![SplatBadge]][SplatNuGet] |
+| Log4Net | [Splat.Log4Net][SplatLog4NetNuGet] | Coming Soon! |
+| NLog | [Splat.NLog][SplatNLogNuGet] | Coming Soon! |
+| Serilog | [Splat.Serilog][SplatSerilogNuGet] | Coming Soon! |
+
+[SplatNuGet]: https://www.nuget.org/packages/Splat/
+[SplatBadge]: https://img.shields.io/nuget/v/Splat.svg
+[SplatLog4NetNuGet]: https://www.nuget.org/packages/Splat.Log4Net/
+[SplatLog4NetBadge]: https://img.shields.io/nuget/v/Splat.Log4Net.svg
+[SplatNLogNuGet]: https://www.nuget.org/packages/Splat.NLog/
+[SplatNLogBadge]: https://img.shields.io/nuget/v/Splat.NLog.svg
+[SplatSerilogNuGet]: https://www.nuget.org/packages/Splat.Serilog/
+[SplatSerilogBadge]: https://img.shields.io/nuget/v/Splat.Serilog.svg
+
+### Log4Net
+
+First configure Log4Net. For guidance see https://logging.apache.org/log4net/release/manual/configuration.html
+
+```cs
+using Splat.Log4Net;
+
+///  then in your service locator initialisation
+Locator.CurrentMutable.UseLog4NetWithWrappingFullLogger();
+```
+
+### NLog
+
+First configure log4net. For guidance see https://github.com/nlog/nlog/wiki/Tutorial and https://github.com/nlog/nlog/wiki/Configuration-file
+
+```cs
+using Splat.NLog;
+
+///  then in your service locator initialisation
+Locator.CurrentMutable.UseNLogWithWrappingFullLogger();
+```
+
 ## Using Cross-Platform Colors and Geometry
 
 ```cs

--- a/src/Splat.NLog/NLogLogger.cs
+++ b/src/Splat.NLog/NLogLogger.cs
@@ -16,7 +16,6 @@ namespace Splat.NLog
     public sealed class NLogLogger : ILogger
     {
         private readonly global::NLog.ILogger _inner;
-        private LogLevel _level;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NLogLogger"/> class.
@@ -29,45 +28,49 @@ namespace Splat.NLog
         }
 
         /// <inheritdoc />
-        public LogLevel Level
-        {
-            get => _level;
-
-            set
-            {
-                // would it be better for ILogger to have a readonly property?
-                // rather than a rather blunt way to adjust the level?
-                // another considerationwas i didn't want to add a dependency on System.Reactive
-                // up to you
-                _level = value;
-                foreach (var configurationLoggingRule in _inner.Factory.Configuration.LoggingRules)
-                {
-                    configurationLoggingRule.SetLoggingLevels(SplatLogLevelToNLogLevel(value), global::NLog.LogLevel.Fatal);
-                }
-            }
-        }
+        public LogLevel Level { get; set; }
 
         /// <inheritdoc />
         public void Write(string message, LogLevel logLevel)
         {
+            if ((int)logLevel < (int)Level)
+            {
+                return;
+            }
+
             _inner.Log(SplatLogLevelToNLogLevel(logLevel), message);
         }
 
         /// <inheritdoc />
         public void Write(Exception exception, string message, LogLevel logLevel)
         {
+            if ((int)logLevel < (int)Level)
+            {
+                return;
+            }
+
             _inner.Log(SplatLogLevelToNLogLevel(logLevel), exception, message);
         }
 
         /// <inheritdoc />
         public void Write(string message, Type type, LogLevel logLevel)
         {
+            if ((int)logLevel < (int)Level)
+            {
+                return;
+            }
+
             _inner.Log(SplatLogLevelToNLogLevel(logLevel), $"{type.Name}: {message}");
         }
 
         /// <inheritdoc />
         public void Write(Exception exception, string message, Type type, LogLevel logLevel)
         {
+            if ((int)logLevel < (int)Level)
+            {
+                return;
+            }
+
             _inner.Log(SplatLogLevelToNLogLevel(logLevel), exception, $"{type.Name}: {message}");
         }
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Fix for #245 
Adds some documentation to readme.md

**What is the current behavior? (You can also link to an open issue here)**

Adjusting ILogger.Level changes NLog config

**What is the new behavior (if this is a feature change)?**

Back to older behaviour the ILogger manager its own level independent of NLog

**What might this PR break?**

none

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

