### PR TITLE
Level mapping using Dictionary instead of delegate-capture

### DIFF
--- a/src/Splat.NLog/NLogLogger.cs
+++ b/src/Splat.NLog/NLogLogger.cs
@@ -15,13 +15,13 @@ namespace Splat.NLog
     [DebuggerDisplay("Name={_inner.Name} Level={Level}")]
     public sealed class NLogLogger : ILogger
     {
-        private static readonly Dictionary<LogLevel, global::NLog.LogLevel> _levelMapping = new Dictionary<LogLevel, global::NLog.LogLevel>()
+        private static readonly Dictionary<int, global::NLog.LogLevel> _levelMapping = new Dictionary<int, global::NLog.LogLevel>()
         {
-            { LogLevel.Debug, global::NLog.LogLevel.Debug },
-            { LogLevel.Info, global::NLog.LogLevel.Info },
-            { LogLevel.Warn, global::NLog.LogLevel.Warn },
-            { LogLevel.Error, global::NLog.LogLevel.Error },
-            { LogLevel.Fatal, global::NLog.LogLevel.Fatal },
+            { (int)LogLevel.Debug, global::NLog.LogLevel.Debug },
+            { (int)LogLevel.Info, global::NLog.LogLevel.Info },
+            { (int)LogLevel.Warn, global::NLog.LogLevel.Warn },
+            { (int)LogLevel.Error, global::NLog.LogLevel.Error },
+            { (int)LogLevel.Fatal, global::NLog.LogLevel.Fatal },
         };
 
         private readonly global::NLog.ILogger _inner;
@@ -85,7 +85,7 @@ namespace Splat.NLog
 
         private static global::NLog.LogLevel SplatLogLevelToNLogLevel(LogLevel logLevel)
         {
-            return _levelMapping[logLevel];
+            return _levelMapping[(int)logLevel];
         }
     }
 }

--- a/src/Splat.NLog/NLogLogger.cs
+++ b/src/Splat.NLog/NLogLogger.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
 
 namespace Splat.NLog
 {
@@ -16,13 +15,13 @@ namespace Splat.NLog
     [DebuggerDisplay("Name={_inner.Name} Level={Level}")]
     public sealed class NLogLogger : ILogger
     {
-        private static readonly KeyValuePair<LogLevel, global::NLog.LogLevel>[] _mappings = new[]
+        private static readonly Dictionary<LogLevel, global::NLog.LogLevel> _levelMapping = new Dictionary<LogLevel, global::NLog.LogLevel>()
         {
-            new KeyValuePair<LogLevel, global::NLog.LogLevel>(LogLevel.Debug, global::NLog.LogLevel.Debug),
-            new KeyValuePair<LogLevel, global::NLog.LogLevel>(LogLevel.Info, global::NLog.LogLevel.Info),
-            new KeyValuePair<LogLevel, global::NLog.LogLevel>(LogLevel.Warn, global::NLog.LogLevel.Warn),
-            new KeyValuePair<LogLevel, global::NLog.LogLevel>(LogLevel.Error, global::NLog.LogLevel.Error),
-            new KeyValuePair<LogLevel, global::NLog.LogLevel>(LogLevel.Fatal, global::NLog.LogLevel.Fatal)
+            { LogLevel.Debug, global::NLog.LogLevel.Debug },
+            { LogLevel.Info, global::NLog.LogLevel.Info },
+            { LogLevel.Warn, global::NLog.LogLevel.Warn },
+            { LogLevel.Error, global::NLog.LogLevel.Error },
+            { LogLevel.Fatal, global::NLog.LogLevel.Fatal },
         };
 
         private readonly global::NLog.ILogger _inner;
@@ -86,7 +85,7 @@ namespace Splat.NLog
 
         private static global::NLog.LogLevel SplatLogLevelToNLogLevel(LogLevel logLevel)
         {
-            return _mappings.First(x => x.Key == logLevel).Value;
+            return _levelMapping[logLevel];
         }
     }
 }

--- a/src/Splat.Serilog/SerilogLogger.cs
+++ b/src/Splat.Serilog/SerilogLogger.cs
@@ -15,13 +15,13 @@ namespace Splat.Serilog
     /// <remarks><seealso cref="ILogger" /></remarks>
     public sealed class SerilogLogger : ILogger
     {
-        private static readonly Dictionary<LogLevel, LogEventLevel> _levelMapping = new Dictionary<LogLevel, LogEventLevel>()
+        private static readonly Dictionary<int, LogEventLevel> _levelMapping = new Dictionary<int, LogEventLevel>()
         {
-            { LogLevel.Debug, LogEventLevel.Debug },
-            { LogLevel.Info, LogEventLevel.Information },
-            { LogLevel.Warn, LogEventLevel.Warning },
-            { LogLevel.Error, LogEventLevel.Error },
-            { LogLevel.Fatal, LogEventLevel.Fatal },
+            { (int)LogLevel.Debug, LogEventLevel.Debug },
+            { (int)LogLevel.Info, LogEventLevel.Information },
+            { (int)LogLevel.Warn, LogEventLevel.Warning },
+            { (int)LogLevel.Error, LogEventLevel.Error },
+            { (int)LogLevel.Fatal, LogEventLevel.Fatal },
         };
 
         private readonly global::Serilog.ILogger _inner;
@@ -85,7 +85,7 @@ namespace Splat.Serilog
 
         private static LogEventLevel SplatLogLevelToSerilogLevel(LogLevel logLevel)
         {
-            return _levelMapping[logLevel];
+            return _levelMapping[(int)logLevel];
         }
     }
 }

--- a/src/Splat.Serilog/SerilogLogger.cs
+++ b/src/Splat.Serilog/SerilogLogger.cs
@@ -5,7 +5,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Serilog.Events;
 
 namespace Splat.Serilog
@@ -16,13 +15,13 @@ namespace Splat.Serilog
     /// <remarks><seealso cref="ILogger" /></remarks>
     public sealed class SerilogLogger : ILogger
     {
-        private static readonly KeyValuePair<LogLevel, LogEventLevel>[] _mappings = new[]
+        private static readonly Dictionary<LogLevel, LogEventLevel> _levelMapping = new Dictionary<LogLevel, LogEventLevel>()
         {
-            new KeyValuePair<LogLevel, LogEventLevel>(LogLevel.Debug, LogEventLevel.Debug),
-            new KeyValuePair<LogLevel, LogEventLevel>(LogLevel.Info, LogEventLevel.Information),
-            new KeyValuePair<LogLevel, LogEventLevel>(LogLevel.Warn, LogEventLevel.Warning),
-            new KeyValuePair<LogLevel, LogEventLevel>(LogLevel.Error, LogEventLevel.Error),
-            new KeyValuePair<LogLevel, LogEventLevel>(LogLevel.Fatal, LogEventLevel.Fatal)
+            { LogLevel.Debug, LogEventLevel.Debug },
+            { LogLevel.Info, LogEventLevel.Information },
+            { LogLevel.Warn, LogEventLevel.Warning },
+            { LogLevel.Error, LogEventLevel.Error },
+            { LogLevel.Fatal, LogEventLevel.Fatal },
         };
 
         private readonly global::Serilog.ILogger _inner;
@@ -38,27 +37,7 @@ namespace Splat.Serilog
         }
 
         /// <inheritdoc />
-        public LogLevel Level
-        {
-            get
-            {
-                foreach (var mapping in _mappings)
-                {
-                    if (_inner.IsEnabled(mapping.Value))
-                    {
-                        return mapping.Key;
-                    }
-                }
-
-                // Default to Fatal, it should always be enabled anyway.
-                return LogLevel.Fatal;
-            }
-
-            set
-            {
-                // Do nothing. set is going soon anyway.
-            }
-        }
+        public LogLevel Level { get; set; }
 
         /// <inheritdoc />
         public void Write(string message, LogLevel logLevel)
@@ -106,7 +85,7 @@ namespace Splat.Serilog
 
         private static LogEventLevel SplatLogLevelToSerilogLevel(LogLevel logLevel)
         {
-            return _mappings.First(x => x.Key == logLevel).Value;
+            return _levelMapping[logLevel];
         }
     }
 }

--- a/src/Splat/Logging/ILogger.cs
+++ b/src/Splat/Logging/ILogger.cs
@@ -34,7 +34,7 @@ namespace Splat
         void Write(Exception exception, [Localizable(false)] string message, LogLevel logLevel);
 
         /// <summary>
-        /// Writes a messge to the target.
+        /// Writes a message to the target.
         /// </summary>
         /// <param name="message">The message.</param>
         /// <param name="type">The type.</param>
@@ -42,7 +42,7 @@ namespace Splat
         void Write([Localizable(false)] string message, [Localizable(false)] Type type, LogLevel logLevel);
 
         /// <summary>
-        /// Writes a messge to the target.
+        /// Writes a message to the target.
         /// </summary>
         /// <param name="exception">The exception that occured.</param>
         /// <param name="message">The message.</param>


### PR DESCRIPTION
Fixed NLog + Serilog so not performing delegate-capture when doing LogLevel-mapping.

Changed Serilog to have the same Level-property-behavior as log4net + NLog (Skip overhead from enumerating array twice for every logevent).