### PR TITLE
housekeeping: change service locator interfaces to readonly and use setlocator

### DIFF
--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -16,9 +16,9 @@ using Autofac.Core;
 namespace Splat.Autofac
 {
     /// <summary>
-    /// Autofac implementation for <see cref="IMutableDependencyResolver"/>.
+    /// Autofac implementation for <see cref="IDependencyResolver"/>.
     /// </summary>
-    public class AutofacDependencyResolver : IMutableDependencyResolver
+    public class AutofacDependencyResolver : IDependencyResolver
     {
         private IContainer _container;
 

--- a/src/Splat.Autofac/SplatAutofacExtensions.cs
+++ b/src/Splat.Autofac/SplatAutofacExtensions.cs
@@ -17,13 +17,13 @@ namespace Splat.Autofac
         /// </summary>
         /// <param name="container">Autofac container.</param>
         public static void UseAutofacDependencyResolver(this IContainer container) =>
-            Locator.Current = new AutofacDependencyResolver(container);
+            Locator.SetLocator(new AutofacDependencyResolver(container));
 
         /// <summary>
         /// Initializes an instance of <see cref="AutofacDependencyResolver"/> that overrides the default <see cref="Locator"/>.
         /// </summary>
         /// <param name="containerBuilder">Autofac container builder.</param>
         public static void UseAutofacDependencyResolver(this ContainerBuilder containerBuilder) =>
-            Locator.Current = new AutofacDependencyResolver(containerBuilder.Build());
+            Locator.SetLocator(new AutofacDependencyResolver(containerBuilder.Build()));
     }
 }

--- a/src/Splat.DryIoc/DryIocDependencyResolver.cs
+++ b/src/Splat.DryIoc/DryIocDependencyResolver.cs
@@ -13,8 +13,8 @@ namespace Splat.DryIoc
     /// DryIoc implementation for <see cref="IMutableDependencyResolver"/>.
     /// https://bitbucket.org/dadhi/dryioc/wiki/Home.
     /// </summary>
-    /// <seealso cref="Splat.IMutableDependencyResolver" />
-    public class DryIocDependencyResolver : IMutableDependencyResolver
+    /// <seealso cref="Splat.IDependencyResolver" />
+    public class DryIocDependencyResolver : IDependencyResolver
     {
         private Container _container;
 

--- a/src/Splat.DryIoc/SplatDryIocExtensions.cs
+++ b/src/Splat.DryIoc/SplatDryIocExtensions.cs
@@ -20,6 +20,6 @@ namespace Splat.DryIoc
         /// </summary>
         /// <param name="container">The container.</param>
         public static void UseDryIocDependencyResolver(this Container container) =>
-            Locator.CurrentMutable = new DryIocDependencyResolver(container);
+            Locator.SetLocator(new DryIocDependencyResolver(container));
     }
 }

--- a/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
+++ b/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
@@ -12,8 +12,8 @@ namespace Splat.SimpleInjector
     /// <summary>
     /// Simple Injector implementation for <see cref="IMutableDependencyResolver"/>.
     /// </summary>
-    /// <seealso cref="Splat.IMutableDependencyResolver" />
-    public class SimpleInjectorDependencyResolver : IMutableDependencyResolver
+    /// <seealso cref="Splat.IDependencyResolver" />
+    public class SimpleInjectorDependencyResolver : IDependencyResolver
     {
         private Container _container;
 

--- a/src/Splat.SimpleInjector/SplatSimpleInjectorExtensions.cs
+++ b/src/Splat.SimpleInjector/SplatSimpleInjectorExtensions.cs
@@ -17,6 +17,6 @@ namespace Splat.SimpleInjector
         /// </summary>
         /// <param name="container">Simple Injector container.</param>
         public static void UseSimpleInjectorDependencyResolver(this Container container) =>
-            Locator.Current = new SimpleInjectorDependencyResolver(container);
+            Locator.SetLocator(new SimpleInjectorDependencyResolver(container));
     }
 }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
@@ -50,13 +50,13 @@ namespace Splat
     }
     public class DefaultLogManager : Splat.ILogManager
     {
-        public DefaultLogManager(Splat.IDependencyResolver dependencyResolver = null) { }
+        public DefaultLogManager(Splat.IReadonlyDependencyResolver dependencyResolver = null) { }
         public Splat.IFullLogger GetLogger(System.Type type) { }
     }
     public class static DependencyResolverMixins
     {
-        public static T GetService<T>(this Splat.IDependencyResolver resolver, string contract = null) { }
-        public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IDependencyResolver resolver, string contract = null) { }
+        public static T GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string contract = null) { }
+        public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string contract = null) { }
         public static void InitializeSplat(this Splat.IMutableDependencyResolver resolver) { }
         public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> factory, string contract = null) { }
         public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object value, System.Type serviceType, string contract = null) { }
@@ -86,7 +86,7 @@ namespace Splat
         public static void Warn<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
         public static void WarnException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
     }
-    public class FuncDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, System.IDisposable
+    public class FuncDependencyResolver : Splat.IMutableDependencyResolver
     {
         public FuncDependencyResolver(System.Func<System.Type, string, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object>, System.Type, string> register = null, System.Action<System.Type, string> unregisterCurrent = null, System.Action<System.Type, string> unregisterAll = null, System.IDisposable toDispose = null) { }
         public void Dispose() { }
@@ -115,11 +115,7 @@ namespace Splat
         System.Threading.Tasks.Task<Splat.IBitmap> Load(System.IO.Stream sourceStream, System.Nullable<float> desiredWidth, System.Nullable<float> desiredHeight);
         System.Threading.Tasks.Task<Splat.IBitmap> LoadFromResource(string source, System.Nullable<float> desiredWidth, System.Nullable<float> desiredHeight);
     }
-    public interface IDependencyResolver : System.IDisposable
-    {
-        object GetService(System.Type serviceType, string contract = null);
-        System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string contract = null);
-    }
+    public interface IDependencyResolver : Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable { }
     [System.Runtime.InteropServices.ComVisibleAttribute(false)]
     public interface IEnableLogger { }
     public interface IFullLogger : Splat.ILogger
@@ -217,12 +213,17 @@ namespace Splat
         System.Nullable<bool> InDesignMode();
         System.Nullable<bool> InUnitTestRunner();
     }
-    public interface IMutableDependencyResolver : Splat.IDependencyResolver, System.IDisposable
+    public interface IMutableDependencyResolver
     {
         void Register(System.Func<object> factory, System.Type serviceType, string contract = null);
         System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string contract, System.Action<System.IDisposable> callback);
         void UnregisterAll(System.Type serviceType, string contract = null);
         void UnregisterCurrent(System.Type serviceType, string contract = null);
+    }
+    public interface IReadonlyDependencyResolver
+    {
+        object GetService(System.Type serviceType, string contract = null);
+        System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string contract = null);
     }
     public enum KnownColor
     {
@@ -403,10 +404,11 @@ namespace Splat
     }
     public class static Locator
     {
-        public static Splat.IDependencyResolver Current { get; set; }
-        public static Splat.IMutableDependencyResolver CurrentMutable { get; set; }
+        public static Splat.IReadonlyDependencyResolver Current { get; }
+        public static Splat.IMutableDependencyResolver CurrentMutable { get; }
         public static bool AreResolverCallbackChangedNotificationsEnabled() { }
         public static System.IDisposable RegisterResolverCallbackChanged(System.Action callback) { }
+        public static void SetLocator(Splat.IDependencyResolver dependencyResolver) { }
         public static System.IDisposable SuppressResolverCallbackChangedNotifications() { }
     }
     public class LoggingException : System.Exception
@@ -450,7 +452,7 @@ namespace Splat
         public static bool InUnitTestRunner() { }
         public static void OverrideModeDetector(Splat.IModeDetector modeDetector) { }
     }
-    public class ModernDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, System.IDisposable
+    public class ModernDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
         public ModernDependencyResolver() { }
         protected ModernDependencyResolver(System.Collections.Generic.Dictionary<System.Tuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>> registry) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
@@ -39,13 +39,13 @@ namespace Splat
     }
     public class DefaultLogManager : Splat.ILogManager
     {
-        public DefaultLogManager(Splat.IDependencyResolver dependencyResolver = null) { }
+        public DefaultLogManager(Splat.IReadonlyDependencyResolver dependencyResolver = null) { }
         public Splat.IFullLogger GetLogger(System.Type type) { }
     }
     public class static DependencyResolverMixins
     {
-        public static T GetService<T>(this Splat.IDependencyResolver resolver, string contract = null) { }
-        public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IDependencyResolver resolver, string contract = null) { }
+        public static T GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string contract = null) { }
+        public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string contract = null) { }
         public static void InitializeSplat(this Splat.IMutableDependencyResolver resolver) { }
         public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> factory, string contract = null) { }
         public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object value, System.Type serviceType, string contract = null) { }
@@ -75,7 +75,7 @@ namespace Splat
         public static void Warn<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
         public static void WarnException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
     }
-    public class FuncDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, System.IDisposable
+    public class FuncDependencyResolver : Splat.IMutableDependencyResolver
     {
         public FuncDependencyResolver(System.Func<System.Type, string, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object>, System.Type, string> register = null, System.Action<System.Type, string> unregisterCurrent = null, System.Action<System.Type, string> unregisterAll = null, System.IDisposable toDispose = null) { }
         public void Dispose() { }
@@ -104,11 +104,7 @@ namespace Splat
         System.Threading.Tasks.Task<Splat.IBitmap> Load(System.IO.Stream sourceStream, System.Nullable<float> desiredWidth, System.Nullable<float> desiredHeight);
         System.Threading.Tasks.Task<Splat.IBitmap> LoadFromResource(string source, System.Nullable<float> desiredWidth, System.Nullable<float> desiredHeight);
     }
-    public interface IDependencyResolver : System.IDisposable
-    {
-        object GetService(System.Type serviceType, string contract = null);
-        System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string contract = null);
-    }
+    public interface IDependencyResolver : Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable { }
     [System.Runtime.InteropServices.ComVisibleAttribute(false)]
     public interface IEnableLogger { }
     public interface IFullLogger : Splat.ILogger
@@ -206,12 +202,17 @@ namespace Splat
         System.Nullable<bool> InDesignMode();
         System.Nullable<bool> InUnitTestRunner();
     }
-    public interface IMutableDependencyResolver : Splat.IDependencyResolver, System.IDisposable
+    public interface IMutableDependencyResolver
     {
         void Register(System.Func<object> factory, System.Type serviceType, string contract = null);
         System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string contract, System.Action<System.IDisposable> callback);
         void UnregisterAll(System.Type serviceType, string contract = null);
         void UnregisterCurrent(System.Type serviceType, string contract = null);
+    }
+    public interface IReadonlyDependencyResolver
+    {
+        object GetService(System.Type serviceType, string contract = null);
+        System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string contract = null);
     }
     public enum KnownColor
     {
@@ -392,10 +393,11 @@ namespace Splat
     }
     public class static Locator
     {
-        public static Splat.IDependencyResolver Current { get; set; }
-        public static Splat.IMutableDependencyResolver CurrentMutable { get; set; }
+        public static Splat.IReadonlyDependencyResolver Current { get; }
+        public static Splat.IMutableDependencyResolver CurrentMutable { get; }
         public static bool AreResolverCallbackChangedNotificationsEnabled() { }
         public static System.IDisposable RegisterResolverCallbackChanged(System.Action callback) { }
+        public static void SetLocator(Splat.IDependencyResolver dependencyResolver) { }
         public static System.IDisposable SuppressResolverCallbackChangedNotifications() { }
     }
     public class LoggingException : System.Exception
@@ -439,7 +441,7 @@ namespace Splat
         public static bool InUnitTestRunner() { }
         public static void OverrideModeDetector(Splat.IModeDetector modeDetector) { }
     }
-    public class ModernDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, System.IDisposable
+    public class ModernDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
         public ModernDependencyResolver() { }
         protected ModernDependencyResolver(System.Collections.Generic.Dictionary<System.Tuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>> registry) { }

--- a/src/Splat.Tests/LocatorTests.cs
+++ b/src/Splat.Tests/LocatorTests.cs
@@ -19,6 +19,143 @@ namespace Splat.Tests
     public class LocatorTests
     {
         /// <summary>
+        /// Tests if the registrations are not empty on no external registrations.
+        /// </summary>
+        [Fact]
+        public void InitializeSplat_RegistrationsNotEmptyNoRegistrations()
+        {
+            var logManager = Locator.Current.GetService(typeof(ILogManager));
+            var logger = Locator.Current.GetService(typeof(ILogger));
+
+            Assert.NotNull(logManager);
+            Assert.NotNull(logger);
+
+            Assert.IsType<DebugLogger>(logger);
+            Assert.IsType<DefaultLogManager>(logManager);
+        }
+
+        /// <summary>
+        /// Tests that if we use a contract it returns null entries for that type.
+        /// </summary>
+        [Fact]
+        public void InitializeSplat_ContractRegistrationsNullNoRegistration()
+        {
+            var logManager = Locator.Current.GetService(typeof(ILogManager), "test");
+            var logger = Locator.Current.GetService(typeof(ILogger), "test");
+
+            Assert.Null(logManager);
+            Assert.Null(logger);
+        }
+
+        /// <summary>
+        /// Tests using the extension methods that the retrieving of the default InitializeSplat() still work.
+        /// </summary>
+        [Fact]
+        public void InitializeSplat_ExtensionMethodsNotNull()
+        {
+            var logManager = Locator.Current.GetService<ILogManager>();
+            var logger = Locator.Current.GetService<ILogger>();
+
+            Assert.NotNull(logManager);
+            Assert.NotNull(logger);
+
+            Assert.IsType<DebugLogger>(logger);
+            Assert.IsType<DefaultLogManager>(logManager);
+        }
+
+        /// <summary>
+        /// Tests to make sure that the locator's fire the resolver changed notifications.
+        /// </summary>
+        [Fact]
+        public void WithoutSuppress_NotificationsHappen()
+        {
+            var originalLocator = Locator.Internal;
+
+            int numberNotifications = 0;
+            Action notificationAction = () => numberNotifications++;
+
+            Locator.RegisterResolverCallbackChanged(notificationAction);
+
+            Locator.SetLocator(new ModernDependencyResolver());
+            Locator.SetLocator(new ModernDependencyResolver());
+
+            // 2 for the changes, 1 for the callback being immediately called.
+            Assert.Equal(3, numberNotifications);
+
+            Locator.SetLocator(originalLocator);
+        }
+
+        /// <summary>
+        /// Tests to make sure that the locator's don't fire the resolver changed notifications if they are suppressed.
+        /// </summary>
+        [Fact]
+        public void WithSuppression_NotificationsDontHappen()
+        {
+            var originalLocator = Locator.Internal;
+
+            using (Locator.SuppressResolverCallbackChangedNotifications())
+            {
+                int numberNotifications = 0;
+                Action notificationAction = () => numberNotifications++;
+
+                Locator.RegisterResolverCallbackChanged(notificationAction);
+
+                Locator.SetLocator(new ModernDependencyResolver());
+                Locator.SetLocator(new ModernDependencyResolver());
+
+                Assert.Equal(0, numberNotifications);
+
+                Locator.SetLocator(originalLocator);
+            }
+        }
+
+        /// <summary>
+        /// Tests to make sure that the locator's don't fire the resolver changed notifications if we use WithResolver().
+        /// </summary>
+        [Fact]
+        public void WithResolver_NotificationsDontHappen()
+        {
+            int numberNotifications = 0;
+            Action notificationAction = () => numberNotifications++;
+
+            Locator.RegisterResolverCallbackChanged(notificationAction);
+
+            using (Locator.Internal.WithResolver())
+            {
+                using (Locator.Internal.WithResolver())
+                {
+                }
+            }
+
+            // 1 due to the fact the callback is called when we register.
+            Assert.Equal(1, numberNotifications);
+        }
+
+        /// <summary>
+        /// Tests to make sure that the locator's don't fire the resolver changed notifications if we use WithResolver().
+        /// </summary>
+        [Fact]
+        public void WithResolver_NotificationsNotSuppressedHappen()
+        {
+            int numberNotifications = 0;
+            Action notificationAction = () => numberNotifications++;
+
+            Locator.RegisterResolverCallbackChanged(notificationAction);
+
+            using (Locator.Internal.WithResolver(false))
+            {
+                using (Locator.Internal.WithResolver(false))
+                {
+                }
+            }
+
+            // 1 due to the fact the callback is called when we register.
+            // 2 for, 1 for change to resolver, 1 for change back
+            // 2 for, 1 for change to resolver, 1 for change back
+            Assert.Equal(5, numberNotifications);
+        }
+
+        /// <summary>
         /// Tests to make sure that the unregister all functions correctly.
         /// This is a test when there are values registered.
         /// </summary>

--- a/src/Splat.Tests/LocatorTests.cs
+++ b/src/Splat.Tests/LocatorTests.cs
@@ -24,8 +24,10 @@ namespace Splat.Tests
         [Fact]
         public void InitializeSplat_RegistrationsNotEmptyNoRegistrations()
         {
-            var logManager = Locator.Current.GetService(typeof(ILogManager));
-            var logger = Locator.Current.GetService(typeof(ILogger));
+            // this is using the internal constructor
+            var testLocator = new InternalLocator();
+            var logManager = testLocator.Current.GetService(typeof(ILogManager));
+            var logger = testLocator.Current.GetService(typeof(ILogger));
 
             Assert.NotNull(logManager);
             Assert.NotNull(logger);
@@ -40,8 +42,9 @@ namespace Splat.Tests
         [Fact]
         public void InitializeSplat_ContractRegistrationsNullNoRegistration()
         {
-            var logManager = Locator.Current.GetService(typeof(ILogManager), "test");
-            var logger = Locator.Current.GetService(typeof(ILogger), "test");
+            var testLocator = new InternalLocator();
+            var logManager = testLocator.Current.GetService(typeof(ILogManager), "test");
+            var logger = testLocator.Current.GetService(typeof(ILogger), "test");
 
             Assert.Null(logManager);
             Assert.Null(logger);
@@ -53,8 +56,9 @@ namespace Splat.Tests
         [Fact]
         public void InitializeSplat_ExtensionMethodsNotNull()
         {
-            var logManager = Locator.Current.GetService<ILogManager>();
-            var logger = Locator.Current.GetService<ILogger>();
+            var testLocator = new InternalLocator();
+            var logManager = testLocator.Current.GetService<ILogManager>();
+            var logger = testLocator.Current.GetService<ILogger>();
 
             Assert.NotNull(logManager);
             Assert.NotNull(logger);
@@ -69,20 +73,21 @@ namespace Splat.Tests
         [Fact]
         public void WithoutSuppress_NotificationsHappen()
         {
-            var originalLocator = Locator.Internal;
+            var testLocator = new InternalLocator();
+            var originalLocator = testLocator.Internal;
 
             int numberNotifications = 0;
             Action notificationAction = () => numberNotifications++;
 
-            Locator.RegisterResolverCallbackChanged(notificationAction);
+            testLocator.RegisterResolverCallbackChanged(notificationAction);
 
-            Locator.SetLocator(new ModernDependencyResolver());
-            Locator.SetLocator(new ModernDependencyResolver());
+            testLocator.SetLocator(new ModernDependencyResolver());
+            testLocator.SetLocator(new ModernDependencyResolver());
 
             // 2 for the changes, 1 for the callback being immediately called.
             Assert.Equal(3, numberNotifications);
 
-            Locator.SetLocator(originalLocator);
+            testLocator.SetLocator(originalLocator);
         }
 
         /// <summary>
@@ -91,21 +96,22 @@ namespace Splat.Tests
         [Fact]
         public void WithSuppression_NotificationsDontHappen()
         {
-            var originalLocator = Locator.Internal;
+            var testLocator = new InternalLocator();
+            var originalLocator = testLocator.Internal;
 
-            using (Locator.SuppressResolverCallbackChangedNotifications())
+            using (testLocator.SuppressResolverCallbackChangedNotifications())
             {
                 int numberNotifications = 0;
                 Action notificationAction = () => numberNotifications++;
 
-                Locator.RegisterResolverCallbackChanged(notificationAction);
+                testLocator.RegisterResolverCallbackChanged(notificationAction);
 
-                Locator.SetLocator(new ModernDependencyResolver());
-                Locator.SetLocator(new ModernDependencyResolver());
+                testLocator.SetLocator(new ModernDependencyResolver());
+                testLocator.SetLocator(new ModernDependencyResolver());
 
                 Assert.Equal(0, numberNotifications);
 
-                Locator.SetLocator(originalLocator);
+                testLocator.SetLocator(originalLocator);
             }
         }
 
@@ -118,11 +124,12 @@ namespace Splat.Tests
             int numberNotifications = 0;
             Action notificationAction = () => numberNotifications++;
 
-            Locator.RegisterResolverCallbackChanged(notificationAction);
+            var testLocator = new InternalLocator();
+            testLocator.RegisterResolverCallbackChanged(notificationAction);
 
-            using (Locator.Internal.WithResolver())
+            using (testLocator.Internal.WithResolver())
             {
-                using (Locator.Internal.WithResolver())
+                using (testLocator.Internal.WithResolver())
                 {
                 }
             }
@@ -140,11 +147,12 @@ namespace Splat.Tests
             int numberNotifications = 0;
             Action notificationAction = () => numberNotifications++;
 
-            Locator.RegisterResolverCallbackChanged(notificationAction);
+            var testLocator = new InternalLocator();
+            testLocator.RegisterResolverCallbackChanged(notificationAction);
 
-            using (Locator.Internal.WithResolver(false))
+            using (testLocator.Internal.WithResolver(false))
             {
-                using (Locator.Internal.WithResolver(false))
+                using (testLocator.Internal.WithResolver(false))
                 {
                 }
             }

--- a/src/Splat.Tests/LocatorTests.cs
+++ b/src/Splat.Tests/LocatorTests.cs
@@ -147,12 +147,11 @@ namespace Splat.Tests
             int numberNotifications = 0;
             Action notificationAction = () => numberNotifications++;
 
-            var testLocator = new InternalLocator();
-            testLocator.RegisterResolverCallbackChanged(notificationAction);
+            Locator.RegisterResolverCallbackChanged(notificationAction);
 
-            using (testLocator.Internal.WithResolver(false))
+            using (Locator.Internal.WithResolver(false))
             {
-                using (testLocator.Internal.WithResolver(false))
+                using (Locator.Internal.WithResolver(false))
                 {
                 }
             }

--- a/src/Splat/Logging/DefaultLogManager.cs
+++ b/src/Splat/Logging/DefaultLogManager.cs
@@ -21,7 +21,7 @@ namespace Splat
         /// Initializes a new instance of the <see cref="DefaultLogManager"/> class.
         /// </summary>
         /// <param name="dependencyResolver">A dependency resolver for testing purposes, will use the default Locator if null.</param>
-        public DefaultLogManager(IDependencyResolver dependencyResolver = null)
+        public DefaultLogManager(IReadonlyDependencyResolver dependencyResolver = null)
         {
             dependencyResolver = dependencyResolver ?? Locator.Current;
 

--- a/src/Splat/ServiceLocation/DependencyResolverMixins.cs
+++ b/src/Splat/ServiceLocation/DependencyResolverMixins.cs
@@ -23,7 +23,7 @@ namespace Splat
         /// <param name="resolver">The resolver we are getting the service from.</param>
         /// <param name="contract">A optional value which will retrieve only a object registered with the same contract.</param>
         /// <returns>The requested object, if found; <c>null</c> otherwise.</returns>
-        public static T GetService<T>(this IDependencyResolver resolver, string contract = null)
+        public static T GetService<T>(this IReadonlyDependencyResolver resolver, string contract = null)
         {
             return (T)resolver.GetService(typeof(T), contract);
         }
@@ -37,7 +37,7 @@ namespace Splat
         /// <param name="contract">A optional value which will retrieve only a object registered with the same contract.</param>
         /// <returns>A sequence of instances of the requested <typeparamref name="T"/>. The sequence
         /// should be empty (not <c>null</c>) if no objects of the given type are available.</returns>
-        public static IEnumerable<T> GetServices<T>(this IDependencyResolver resolver, string contract = null)
+        public static IEnumerable<T> GetServices<T>(this IReadonlyDependencyResolver resolver, string contract = null)
         {
             return resolver.GetServices(typeof(T), contract).Cast<T>();
         }
@@ -65,10 +65,10 @@ namespace Splat
         {
             var notificationDisposable = suppressResolverCallback ? Locator.SuppressResolverCallbackChangedNotifications() : new ActionDisposable(() => { });
 
-            var origResolver = Locator.Current;
-            Locator.Current = resolver;
+            var origResolver = Locator.Internal;
+            Locator.SetLocator(resolver);
 
-            return new CompositeDisposable(new ActionDisposable(() => Locator.Current = origResolver), notificationDisposable);
+            return new CompositeDisposable(new ActionDisposable(() => Locator.SetLocator(origResolver)), notificationDisposable);
         }
 
         /// <summary>

--- a/src/Splat/ServiceLocation/IDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/IDependencyResolver.cs
@@ -12,25 +12,7 @@ namespace Splat
     /// Represents a dependency resolver, a service to look up global class
     /// instances or types.
     /// </summary>
-    public interface IDependencyResolver : IDisposable
+    public interface IDependencyResolver : IReadonlyDependencyResolver, IMutableDependencyResolver, IDisposable
     {
-        /// <summary>
-        /// Gets an instance of the given <paramref name="serviceType"/>. Must return <c>null</c>
-        /// if the service is not available (must not throw).
-        /// </summary>
-        /// <param name="serviceType">The object type.</param>
-        /// <param name="contract">A optional value which will retrieve only a object registered with the same contract.</param>
-        /// <returns>The requested object, if found; <c>null</c> otherwise.</returns>
-        object GetService(Type serviceType, string contract = null);
-
-        /// <summary>
-        /// Gets all instances of the given <paramref name="serviceType"/>. Must return an empty
-        /// collection if the service is not available (must not return <c>null</c> or throw).
-        /// </summary>
-        /// <param name="serviceType">The object type.</param>
-        /// <param name="contract">A optional value which will retrieve only objects registered with the same contract.</param>
-        /// <returns>A sequence of instances of the requested <paramref name="serviceType"/>. The sequence
-        /// should be empty (not <c>null</c>) if no objects of the given type are available.</returns>
-        IEnumerable<object> GetServices(Type serviceType, string contract = null);
     }
 }

--- a/src/Splat/ServiceLocation/IMutableDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/IMutableDependencyResolver.cs
@@ -10,7 +10,7 @@ namespace Splat
     /// <summary>
     /// Represents a dependency resolver where types can be registered after setup.
     /// </summary>
-    public interface IMutableDependencyResolver : IDependencyResolver
+    public interface IMutableDependencyResolver
     {
         /// <summary>
         /// Register a function with the resolver which will generate a object

--- a/src/Splat/ServiceLocation/IReadonlyDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/IReadonlyDependencyResolver.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+using System;
+using System.Collections.Generic;
+
+namespace Splat
+{
+    /// <summary>
+    /// An interface for interacting with a dependency resolver in a read-only fashion.
+    /// </summary>
+    public interface IReadonlyDependencyResolver
+    {
+        /// <summary>
+        /// Gets an instance of the given <paramref name="serviceType"/>. Must return <c>null</c>
+        /// if the service is not available (must not throw).
+        /// </summary>
+        /// <param name="serviceType">The object type.</param>
+        /// <param name="contract">A optional value which will retrieve only a object registered with the same contract.</param>
+        /// <returns>The requested object, if found; <c>null</c> otherwise.</returns>
+        object GetService(Type serviceType, string contract = null);
+
+        /// <summary>
+        /// Gets all instances of the given <paramref name="serviceType"/>. Must return an empty
+        /// collection if the service is not available (must not return <c>null</c> or throw).
+        /// </summary>
+        /// <param name="serviceType">The object type.</param>
+        /// <param name="contract">A optional value which will retrieve only objects registered with the same contract.</param>
+        /// <returns>A sequence of instances of the requested <paramref name="serviceType"/>. The sequence
+        /// should be empty (not <c>null</c>) if no objects of the given type are available.</returns>
+        IEnumerable<object> GetServices(Type serviceType, string contract = null);
+    }
+}

--- a/src/Splat/ServiceLocation/InternalLocator.cs
+++ b/src/Splat/ServiceLocation/InternalLocator.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Splat
+{
+    internal class InternalLocator : IDisposable
+    {
+        // this has been done to have a default single instance. but allow isolation in unit tests.B
+        private readonly List<Action> _resolverChanged = new List<Action>();
+        private volatile int _resolverChangedNotificationSuspendCount;
+        private IDependencyResolver _dependencyResolver;
+
+        internal InternalLocator()
+        {
+            _dependencyResolver = new ModernDependencyResolver();
+
+            RegisterResolverCallbackChanged(() =>
+            {
+                if (CurrentMutable == null)
+                {
+                    return;
+                }
+
+                CurrentMutable.InitializeSplat();
+            });
+        }
+
+        /// <summary>
+        /// Gets the read only dependency resolver. This class is used throughout
+        /// libraries for many internal operations as well as for general use
+        /// by applications. If this isn't assigned on startup, a default, highly
+        /// capable implementation will be used, and it is advised for most people
+        /// to simply use the default implementation.
+        /// </summary>
+        /// <value>The dependency resolver.</value>
+        public IReadonlyDependencyResolver Current => _dependencyResolver;
+
+        /// <summary>
+        /// Gets the mutable dependency resolver.
+        /// The default resolver is also a mutable resolver, so this will be non-null.
+        /// Use this to register new types on startup if you are using the default resolver.
+        /// </summary>
+        public IMutableDependencyResolver CurrentMutable => _dependencyResolver;
+
+        internal IDependencyResolver Internal => _dependencyResolver;
+
+        public void Dispose()
+        {
+            _dependencyResolver?.Dispose();
+        }
+
+        /// <summary>
+        /// Allows setting the dependency resolver.
+        /// </summary>
+        /// <param name="dependencyResolver">The dependency resolver to set.</param>
+        public void SetLocator(IDependencyResolver dependencyResolver)
+        {
+            _dependencyResolver = dependencyResolver ?? throw new ArgumentNullException(nameof(dependencyResolver));
+
+            // DV: is this needed if we're changing the behaviour of setlocator?
+            /*
+            if (ModeDetector.InUnitTestRunner())
+            {
+                _unitTestDependencyResolver = value;
+                _dependencyResolver = _dependencyResolver ?? value;
+            }
+            else
+            {
+                _dependencyResolver = value;
+            }
+            */
+            if (AreResolverCallbackChangedNotificationsEnabled())
+            {
+                var currentCallbacks = default(Action[]);
+                lock (_resolverChanged)
+                {
+                    // NB: Prevent deadlocks should we reenter this setter from
+                    // the callbacks
+                    currentCallbacks = _resolverChanged.ToArray();
+                }
+
+                foreach (var block in currentCallbacks)
+                {
+                    block();
+                }
+            }
+        }
+
+        /// <summary>
+        /// This method allows libraries to register themselves to be set up
+        /// whenever the dependency resolver changes. Applications should avoid
+        /// this method, it is usually used for libraries that depend on service
+        /// location.
+        /// </summary>
+        /// <param name="callback">A callback that is invoked when the
+        /// resolver is changed. This callback is also invoked immediately,
+        /// to configure the current resolver.</param>
+        /// <returns>When disposed, removes the callback. You probably can
+        /// ignore this.</returns>
+        public IDisposable RegisterResolverCallbackChanged(Action callback)
+        {
+            lock (_resolverChanged)
+            {
+                _resolverChanged.Add(callback);
+            }
+
+            // NB: We always immediately invoke the callback to set up the
+            // current resolver with whatever we've got
+            if (AreResolverCallbackChangedNotificationsEnabled())
+            {
+                callback();
+            }
+
+            return new ActionDisposable(() =>
+            {
+                lock (_resolverChanged)
+                {
+                    _resolverChanged.Remove(callback);
+                }
+            });
+        }
+
+        /// <summary>
+        /// This method will prevent resolver changed notifications from happening until
+        /// the returned <see cref="IDisposable"/> is disposed.
+        /// </summary>
+        /// <returns>A disposable which when disposed will indicate the change
+        /// notification is no longer needed.</returns>
+        public IDisposable SuppressResolverCallbackChangedNotifications()
+        {
+            Interlocked.Increment(ref _resolverChangedNotificationSuspendCount);
+
+            return new ActionDisposable(() => Interlocked.Decrement(ref _resolverChangedNotificationSuspendCount));
+        }
+
+        /// <summary>
+        /// Indicates if the we are notifying external classes of updates to the resolver being changed.
+        /// </summary>
+        /// <returns>A value indicating whether the notifications are happening.</returns>
+        public bool AreResolverCallbackChangedNotificationsEnabled()
+        {
+            return _resolverChangedNotificationSuspendCount == 0;
+        }
+    }
+}

--- a/src/Splat/ServiceLocation/ModernDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/ModernDependencyResolver.cs
@@ -21,7 +21,7 @@ namespace Splat
     ///
     /// This container is not thread safe.
     /// </summary>
-    public class ModernDependencyResolver : IMutableDependencyResolver
+    public class ModernDependencyResolver : IDependencyResolver
     {
         private Dictionary<Tuple<Type, string>, List<Func<object>>> _registry;
         private Dictionary<Tuple<Type, string>, List<Action<IDisposable>>> _callbackRegistry;


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Reworks the locator to constrain usage around the readonly and mutable properties

**What is the current behavior? (You can also link to an open issue here)**

Some confusion as you can access the supposed readonly properties via Locator.CurrentMutable

**What is the new behavior (if this is a feature change)?**
 constrains interfaces as discussed in #276 and previously #265, #271


**What might this PR break?**

Breaks the locator for anyone wanting to change the locator, or anyone incorrectly using GetService on Locator.CurrentMutable

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
