### PR TITLE
bug: log4net adaptor level setter is public

### DIFF
--- a/src/Splat.Log4Net/Log4NetLogger.cs
+++ b/src/Splat.Log4Net/Log4NetLogger.cs
@@ -30,7 +30,7 @@ namespace Splat.Log4Net
         }
 
         /// <inheritdoc />
-        public LogLevel Level { get; set; }
+        public LogLevel Level { get; private set; }
 
         /// <inheritdoc />
         public void Dispose()


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Tiny tweak. Missed a change in #246 log4net level property

**What is the current behavior? (You can also link to an open issue here)**

level property setter was still visible.

**What is the new behavior (if this is a feature change)?**

level property setter now private

**What might this PR break?**

nothing

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

