### PR TITLE
housekeeping: use platform aware newlines

### DIFF
--- a/c1e5ac01-8696-48cf-8c29-bd556f49c8a8.cake
+++ b/c1e5ac01-8696-48cf-8c29-bd556f49c8a8.cake
@@ -1,0 +1,2 @@
+#module nuget:?package=Cake.DotNetTool.Module&version=0.1.0
+#tool dotnet:?package=SignClient&version=1.1.7

--- a/c1e5ac01-8696-48cf-8c29-bd556f49c8a8.cake
+++ b/c1e5ac01-8696-48cf-8c29-bd556f49c8a8.cake
@@ -1,2 +1,0 @@
-#module nuget:?package=Cake.DotNetTool.Module&version=0.1.0
-#tool dotnet:?package=SignClient&version=1.1.7

--- a/src/Splat.Tests/Logging/FullLoggerExtensionsTests.cs
+++ b/src/Splat.Tests/Logging/FullLoggerExtensionsTests.cs
@@ -59,7 +59,7 @@ namespace Splat.Tests.Logging
                     return "This is a test.";
                 });
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
             Assert.True(invoked);
         }
@@ -105,7 +105,7 @@ namespace Splat.Tests.Logging
                     return "This is a test.";
                 });
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
             Assert.True(invoked);
         }
@@ -151,7 +151,7 @@ namespace Splat.Tests.Logging
                     return "This is a test.";
                 });
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
             Assert.True(invoked);
         }
@@ -197,7 +197,7 @@ namespace Splat.Tests.Logging
                     return "This is a test.";
                 });
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
             Assert.True(invoked);
         }
@@ -220,7 +220,7 @@ namespace Splat.Tests.Logging
                     return "This is a test.";
                 });
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
             Assert.True(invoked);
         }

--- a/src/Splat.Tests/Logging/WrappingFullLoggerTests.cs
+++ b/src/Splat.Tests/Logging/WrappingFullLoggerTests.cs
@@ -29,7 +29,7 @@ namespace Splat.Tests.Logging
 
             logger.Write("This is a test.", LogLevel.Debug);
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Splat.Tests.Logging
 
             logger.Write("This is a test.", LogLevel.Debug);
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace Splat.Tests.Logging
 
             logger.Debug<DummyObjectClass1>("This is a test.");
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
         }
 
@@ -72,7 +72,7 @@ namespace Splat.Tests.Logging
 
             logger.Debug<DummyObjectClass2>("This is a test.");
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass2), textLogger.PassedTypes.FirstOrDefault());
         }
 
@@ -87,7 +87,7 @@ namespace Splat.Tests.Logging
 
             logger.Info<DummyObjectClass1>("This is a test.");
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
         }
 
@@ -102,7 +102,7 @@ namespace Splat.Tests.Logging
 
             logger.Info<DummyObjectClass2>("This is a test.");
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass2), textLogger.PassedTypes.FirstOrDefault());
         }
 
@@ -117,7 +117,7 @@ namespace Splat.Tests.Logging
 
             logger.Warn<DummyObjectClass1>("This is a test.");
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
         }
 
@@ -132,7 +132,7 @@ namespace Splat.Tests.Logging
 
             logger.Warn<DummyObjectClass2>("This is a test.");
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass2), textLogger.PassedTypes.FirstOrDefault());
         }
 
@@ -147,7 +147,7 @@ namespace Splat.Tests.Logging
 
             logger.Error<DummyObjectClass1>("This is a test.");
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
         }
 
@@ -162,7 +162,7 @@ namespace Splat.Tests.Logging
 
             logger.Error<DummyObjectClass2>("This is a test.");
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass2), textLogger.PassedTypes.FirstOrDefault());
         }
 
@@ -177,7 +177,7 @@ namespace Splat.Tests.Logging
 
             logger.Fatal<DummyObjectClass1>("This is a test.");
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass1), textLogger.PassedTypes.FirstOrDefault());
         }
 
@@ -192,7 +192,7 @@ namespace Splat.Tests.Logging
 
             logger.Fatal<DummyObjectClass2>("This is a test.");
 
-            Assert.Equal("This is a test.\r\n", textLogger.Value);
+            Assert.Equal("This is a test." + Environment.NewLine, textLogger.Value);
             Assert.Equal(typeof(DummyObjectClass2), textLogger.PassedTypes.FirstOrDefault());
         }
     }

--- a/src/Splat.Tests/Logging/WrappingPrefixLoggerTests.cs
+++ b/src/Splat.Tests/Logging/WrappingPrefixLoggerTests.cs
@@ -27,7 +27,7 @@ namespace Splat.Tests.Logging
 
             logger.Write("This is a test.", LogLevel.Debug);
 
-            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test.\r\n", textLogger.Value);
+            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test." + Environment.NewLine, textLogger.Value);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace Splat.Tests.Logging
 
             logger.Write("This is a test.", typeof(DummyObjectClass1), LogLevel.Debug);
 
-            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test.\r\n", textLogger.Value);
+            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test." + Environment.NewLine, textLogger.Value);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Splat.Tests.Logging
 
             logger.Debug<DummyObjectClass1>("This is a test.");
 
-            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test.\r\n", textLogger.Value);
+            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test." + Environment.NewLine, textLogger.Value);
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Splat.Tests.Logging
 
             logger.Debug<DummyObjectClass2>("This is a test.");
 
-            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test.\r\n", textLogger.Value);
+            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test." + Environment.NewLine, textLogger.Value);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace Splat.Tests.Logging
 
             logger.Info<DummyObjectClass1>("This is a test.");
 
-            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test.\r\n", textLogger.Value);
+            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test." + Environment.NewLine, textLogger.Value);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Splat.Tests.Logging
 
             logger.Info<DummyObjectClass2>("This is a test.");
 
-            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test.\r\n", textLogger.Value);
+            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test." + Environment.NewLine, textLogger.Value);
         }
 
         /// <summary>
@@ -111,7 +111,7 @@ namespace Splat.Tests.Logging
 
             logger.Warn<DummyObjectClass1>("This is a test.");
 
-            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test.\r\n", textLogger.Value);
+            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test." + Environment.NewLine, textLogger.Value);
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace Splat.Tests.Logging
 
             logger.Warn<DummyObjectClass2>("This is a test.");
 
-            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test.\r\n", textLogger.Value);
+            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test." + Environment.NewLine, textLogger.Value);
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace Splat.Tests.Logging
 
             logger.Error<DummyObjectClass1>("This is a test.");
 
-            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test.\r\n", textLogger.Value);
+            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test." + Environment.NewLine, textLogger.Value);
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace Splat.Tests.Logging
 
             logger.Error<DummyObjectClass2>("This is a test.");
 
-            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test.\r\n", textLogger.Value);
+            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test." + Environment.NewLine, textLogger.Value);
         }
 
         /// <summary>
@@ -167,7 +167,7 @@ namespace Splat.Tests.Logging
 
             logger.Fatal<DummyObjectClass1>("This is a test.");
 
-            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test.\r\n", textLogger.Value);
+            Assert.Equal($"{nameof(DummyObjectClass1)}: This is a test." + Environment.NewLine, textLogger.Value);
         }
 
         /// <summary>
@@ -181,7 +181,7 @@ namespace Splat.Tests.Logging
 
             logger.Fatal<DummyObjectClass2>("This is a test.");
 
-            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test.\r\n", textLogger.Value);
+            Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test." + Environment.NewLine, textLogger.Value);
         }
     }
 }


### PR DESCRIPTION
The mac unit tests fail due to the new line being different. They are now consistent.