### PR TITLE
feature: Added Allocation Free Logging

### DIFF
--- a/src/Splat.Serilog/SerilogFullLogger.cs
+++ b/src/Splat.Serilog/SerilogFullLogger.cs
@@ -142,6 +142,48 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4)
+        {
+           _logger.Debug(messageFormat, argument1, argument2, argument3, argument4);
+        }
+
+        /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5)
+        {
+           _logger.Debug(messageFormat, argument1, argument2, argument3, argument4, argument5);
+        }
+
+        /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6)
+        {
+           _logger.Debug(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6);
+        }
+
+        /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7)
+        {
+           _logger.Debug(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7);
+        }
+
+        /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8)
+        {
+           _logger.Debug(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8);
+        }
+
+        /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9)
+        {
+           _logger.Debug(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8, argument9);
+        }
+
+        /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10)
+        {
+           _logger.Debug(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8, argument9, argument10);
+        }
+
+        /// <inheritdoc />
         public void DebugException([Localizable(false)] string message, Exception exception)
         {
             _logger.Debug(exception, message);
@@ -223,6 +265,48 @@ namespace Splat
         public void Error<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
             _logger.Error(message, argument1, argument2, argument3);
+        }
+
+        /// <inheritdoc />
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4)
+        {
+            _logger.Error(messageFormat, argument1, argument2, argument3, argument4);
+        }
+
+        /// <inheritdoc />
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5)
+        {
+            _logger.Error(messageFormat, argument1, argument2, argument3, argument4, argument5);
+        }
+
+        /// <inheritdoc />
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6)
+        {
+            _logger.Error(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6);
+        }
+
+        /// <inheritdoc />
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7)
+        {
+            _logger.Error(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7);
+        }
+
+        /// <inheritdoc />
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8)
+        {
+            _logger.Error(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8);
+        }
+
+        /// <inheritdoc />
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9)
+        {
+            _logger.Error(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8, argument9);
+        }
+
+        /// <inheritdoc />
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10)
+        {
+            _logger.Error(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8, argument9, argument10);
         }
 
         /// <inheritdoc />
@@ -310,6 +394,48 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4)
+        {
+            _logger.Fatal(messageFormat, argument1, argument2, argument3, argument4);
+        }
+
+        /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5)
+        {
+            _logger.Fatal(messageFormat, argument1, argument2, argument3, argument4, argument5);
+        }
+
+        /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6)
+        {
+            _logger.Fatal(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6);
+        }
+
+        /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7)
+        {
+            _logger.Fatal(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7);
+        }
+
+        /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8)
+        {
+            _logger.Fatal(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8);
+        }
+
+        /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9)
+        {
+            _logger.Fatal(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8, argument9);
+        }
+
+        /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10)
+        {
+            _logger.Fatal(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8, argument9, argument10);
+        }
+
+        /// <inheritdoc />
         public void FatalException([Localizable(false)] string message, Exception exception)
         {
             _logger.Fatal(exception, message);
@@ -394,6 +520,48 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4)
+        {
+            _logger.Information(messageFormat, argument1, argument2, argument3, argument4);
+        }
+
+        /// <inheritdoc />
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5)
+        {
+            _logger.Information(messageFormat, argument1, argument2, argument3, argument4, argument5);
+        }
+
+        /// <inheritdoc />
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6)
+        {
+            _logger.Information(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6);
+        }
+
+        /// <inheritdoc />
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7)
+        {
+            _logger.Information(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7);
+        }
+
+        /// <inheritdoc />
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8)
+        {
+            _logger.Information(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8);
+        }
+
+        /// <inheritdoc />
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9)
+        {
+            _logger.Information(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8, argument9);
+        }
+
+        /// <inheritdoc />
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10)
+        {
+            _logger.Information(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8, argument9, argument10);
+        }
+
+        /// <inheritdoc />
         public void InfoException([Localizable(false)] string message, Exception exception)
         {
             _logger.Information(exception, message);
@@ -475,6 +643,48 @@ namespace Splat
         public void Warn<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
             _logger.Warning(message, argument1, argument2, argument3);
+        }
+
+        /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4)
+        {
+            _logger.Warning(messageFormat, argument1, argument2, argument3, argument4);
+        }
+
+        /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5)
+        {
+            _logger.Warning(messageFormat, argument1, argument2, argument3, argument4, argument5);
+        }
+
+        /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6)
+        {
+            _logger.Warning(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6);
+        }
+
+        /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7)
+        {
+            _logger.Warning(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7);
+        }
+
+        /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8)
+        {
+            _logger.Warning(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8);
+        }
+
+        /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9)
+        {
+            _logger.Warning(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8, argument9);
+        }
+
+        /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10)
+        {
+            _logger.Warning(messageFormat, argument1, argument2, argument3, argument4, argument5, argument6, argument7, argument8, argument9, argument10);
         }
 
         /// <inheritdoc />

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
@@ -240,13 +240,8 @@ namespace Splat
     public interface IDependencyResolver : Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable { }
     [System.Runtime.InteropServices.ComVisibleAttribute(false)]
     public interface IEnableLogger { }
-    public interface IFullLogger : Splat.ILogger
+    public interface IFullLogger : Splat.IAllocationFreeLogger, Splat.ILogger
     {
-        bool IsDebugEnabled { get; }
-        bool IsErrorEnabled { get; }
-        bool IsFatalEnabled { get; }
-        bool IsInfoEnabled { get; }
-        bool IsWarnEnabled { get; }
         void Debug<T>(T value);
         void Debug<T>(System.IFormatProvider formatProvider, T value);
         void Debug(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
@@ -687,7 +682,7 @@ namespace Splat
     {
         public static string GetTargetFrameworkName(this System.Reflection.Assembly assembly) { }
     }
-    public class WrappingFullLogger : Splat.AllocationFreeLoggerBase, Splat.IFullLogger, Splat.ILogger
+    public class WrappingFullLogger : Splat.AllocationFreeLoggerBase, Splat.IAllocationFreeLogger, Splat.IFullLogger, Splat.ILogger
     {
         public WrappingFullLogger(Splat.ILogger inner) { }
         public void Debug<T>(T value) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
@@ -1,12 +1,76 @@
 [assembly: System.Resources.NeutralResourcesLanguageAttribute("en-US")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Splat.Tests")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
 namespace Splat
 {
     public class ActionLogger : Splat.ILogger
     {
         public ActionLogger(System.Action<string, Splat.LogLevel> writeNoType, System.Action<string, System.Type, Splat.LogLevel> writeWithType, System.Action<System.Exception, string, Splat.LogLevel> writeNoTypeWithException, System.Action<System.Exception, string, System.Type, Splat.LogLevel> writeWithTypeAndException) { }
         public Splat.LogLevel Level { get; set; }
+        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public class AllocationFreeLoggerBase : Splat.IAllocationFreeLogger, Splat.ILogger
+    {
+        public AllocationFreeLoggerBase(Splat.ILogger inner) { }
+        public bool IsDebugEnabled { get; }
+        public bool IsErrorEnabled { get; }
+        public bool IsFatalEnabled { get; }
+        public bool IsInfoEnabled { get; }
+        public bool IsWarnEnabled { get; }
+        public Splat.LogLevel Level { get; }
+        public virtual void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public virtual void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public virtual void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public virtual void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public virtual void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public virtual void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
         public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
         public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
         public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
@@ -22,17 +86,6 @@ namespace Splat
         public BitmapLoaderException(string message) { }
         public BitmapLoaderException(string message, System.Exception innerException) { }
         protected BitmapLoaderException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
-    }
-    public class static BitmapMixins
-    {
-        public static Splat.IBitmap FromNative(this System.Windows.Media.Imaging.BitmapSource value) { }
-        public static System.Windows.Media.Imaging.BitmapSource ToNative(this Splat.IBitmap value) { }
-    }
-    public class static ColorExtensions
-    {
-        public static System.Drawing.Color FromNative(this System.Windows.Media.Color value) { }
-        public static System.Windows.Media.Color ToNative(this System.Drawing.Color value) { }
-        public static System.Windows.Media.SolidColorBrush ToNativeBrush(this System.Drawing.Color value) { }
     }
     public enum CompressedBitmapFormat
     {
@@ -103,6 +156,64 @@ namespace Splat
         public FuncLogManager(System.Func<System.Type, Splat.IFullLogger> getLoggerFunc) { }
         public Splat.IFullLogger GetLogger(System.Type type) { }
     }
+    public interface IAllocationFreeLogger : Splat.ILogger
+    {
+        bool IsDebugEnabled { get; }
+        bool IsErrorEnabled { get; }
+        bool IsFatalEnabled { get; }
+        bool IsInfoEnabled { get; }
+        bool IsWarnEnabled { get; }
+        void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
+        void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
+        void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
+        void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
+        void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
+        void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+    }
     public interface IBitmap : System.IDisposable
     {
         float Height { get; }
@@ -133,11 +244,8 @@ namespace Splat
         void Debug([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Debug<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Debug<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
-        void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Debug<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-        void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void DebugException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Error<T>(T value);
         void Error<T>(System.IFormatProvider formatProvider, T value);
@@ -147,11 +255,8 @@ namespace Splat
         void Error([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Error<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Error<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
-        void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Error<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-        void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void ErrorException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Fatal<T>(T value);
         void Fatal<T>(System.IFormatProvider formatProvider, T value);
@@ -161,11 +266,8 @@ namespace Splat
         void Fatal([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Fatal<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Fatal<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
-        void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Fatal<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-        void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void FatalException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Info<T>(T value);
         void Info<T>(System.IFormatProvider formatProvider, T value);
@@ -175,11 +277,8 @@ namespace Splat
         void Info([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Info<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Info<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
-        void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Info<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-        void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void InfoException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Warn<T>(T value);
         void Warn<T>(System.IFormatProvider formatProvider, T value);
@@ -189,11 +288,8 @@ namespace Splat
         void Warn([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Warn<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Warn<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
-        void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-        void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void WarnException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
     }
     public interface ILogger
@@ -475,25 +571,6 @@ namespace Splat
         public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
         public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
-    public class PlatformBitmapLoader : Splat.IBitmapLoader
-    {
-        public PlatformBitmapLoader() { }
-        public Splat.IBitmap Create(float width, float height) { }
-        public System.Threading.Tasks.Task<Splat.IBitmap> Load(System.IO.Stream sourceStream, System.Nullable<float> desiredWidth, System.Nullable<float> desiredHeight) { }
-        public System.Threading.Tasks.Task<Splat.IBitmap> LoadFromResource(string resource, System.Nullable<float> desiredWidth, System.Nullable<float> desiredHeight) { }
-    }
-    public class PlatformModeDetector : Splat.IModeDetector
-    {
-        public PlatformModeDetector() { }
-        public System.Nullable<bool> InDesignMode() { }
-        public System.Nullable<bool> InUnitTestRunner() { }
-    }
-    public class static PointExtensions
-    {
-        public static System.Drawing.PointF FromNative(this System.Windows.Point value) { }
-        public static System.Windows.Point ToNative(this System.Drawing.Point value) { }
-        public static System.Windows.Point ToNative(this System.Drawing.PointF value) { }
-    }
     public class static PointMathExtensions
     {
         public static float AngleInDegrees(this System.Drawing.PointF value) { }
@@ -521,18 +598,6 @@ namespace Splat
         Top = 1,
         Right = 2,
         Bottom = 3,
-    }
-    public class static RectExtensions
-    {
-        public static System.Drawing.RectangleF FromNative(this System.Windows.Rect value) { }
-        public static System.Windows.Rect ToNative(this System.Drawing.Rectangle value) { }
-        public static System.Windows.Rect ToNative(this System.Drawing.RectangleF value) { }
-    }
-    public class static SizeExtensions
-    {
-        public static System.Drawing.SizeF FromNative(this System.Windows.Size value) { }
-        public static System.Windows.Size ToNative(this System.Drawing.Size value) { }
-        public static System.Windows.Size ToNative(this System.Drawing.SizeF value) { }
     }
     public class static SizeMathExtensions
     {
@@ -570,25 +635,13 @@ namespace Splat
         public Splat.KnownColor ToKnownColor() { }
         public override string ToString() { }
     }
-    public class static SplatColorExtensions
-    {
-        public static Splat.SplatColor FromNative(this System.Windows.Media.Color value) { }
-        public static System.Windows.Media.Color ToNative(this Splat.SplatColor value) { }
-        public static System.Windows.Media.SolidColorBrush ToNativeBrush(this Splat.SplatColor value) { }
-    }
     public class static TargetFrameworkExtensions
     {
         public static string GetTargetFrameworkName(this System.Reflection.Assembly assembly) { }
     }
-    public class WrappingFullLogger : Splat.IFullLogger, Splat.ILogger
+    public class WrappingFullLogger : Splat.AllocationFreeLoggerBase, Splat.IFullLogger, Splat.ILogger
     {
         public WrappingFullLogger(Splat.ILogger inner) { }
-        public bool IsDebugEnabled { get; }
-        public bool IsErrorEnabled { get; }
-        public bool IsFatalEnabled { get; }
-        public bool IsInfoEnabled { get; }
-        public bool IsWarnEnabled { get; }
-        public Splat.LogLevel Level { get; }
         public void Debug<T>(T value) { }
         public void Debug<T>(System.IFormatProvider formatProvider, T value) { }
         public void Debug(System.IFormatProvider formatProvider, string message, params object[] args) { }
@@ -597,11 +650,8 @@ namespace Splat
         public void Debug(string message, params object[] args) { }
         public void Debug<T>(string message, params object[] args) { }
         public void Debug<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
-        public void Debug<TArgument>(string message, TArgument argument) { }
         public void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Debug<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
         public void Debug<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
-        public void Debug<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public void DebugException(string message, System.Exception exception) { }
         public void Error<T>(T value) { }
         public void Error<T>(System.IFormatProvider formatProvider, T value) { }
@@ -611,11 +661,8 @@ namespace Splat
         public void Error(string message, params object[] args) { }
         public void Error<T>(string message, params object[] args) { }
         public void Error<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
-        public void Error<TArgument>(string message, TArgument argument) { }
         public void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Error<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
         public void Error<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
-        public void Error<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public void ErrorException(string message, System.Exception exception) { }
         public void Fatal<T>(T value) { }
         public void Fatal<T>(System.IFormatProvider formatProvider, T value) { }
@@ -625,11 +672,8 @@ namespace Splat
         public void Fatal(string message, params object[] args) { }
         public void Fatal<T>(string message, params object[] args) { }
         public void Fatal<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
-        public void Fatal<TArgument>(string message, TArgument argument) { }
         public void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Fatal<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
         public void Fatal<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
-        public void Fatal<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public void FatalException(string message, System.Exception exception) { }
         public void Info<T>(T value) { }
         public void Info<T>(System.IFormatProvider formatProvider, T value) { }
@@ -639,11 +683,8 @@ namespace Splat
         public void Info(string message, params object[] args) { }
         public void Info<T>(string message, params object[] args) { }
         public void Info<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
-        public void Info<TArgument>(string message, TArgument argument) { }
         public void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Info<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
         public void Info<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
-        public void Info<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public void InfoException(string message, System.Exception exception) { }
         public void Warn<T>(T value) { }
         public void Warn<T>(System.IFormatProvider formatProvider, T value) { }
@@ -653,16 +694,9 @@ namespace Splat
         public void Warn(string message, params object[] args) { }
         public void Warn<T>(string message, params object[] args) { }
         public void Warn<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
-        public void Warn<TArgument>(string message, TArgument argument) { }
         public void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Warn<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
         public void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
-        public void Warn<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public void WarnException(string message, System.Exception exception) { }
-        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
-        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
-        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
-        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
     public class WrappingPrefixLogger : Splat.ILogger
     {

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
@@ -1,6 +1,6 @@
 [assembly: System.Resources.NeutralResourcesLanguageAttribute("en-US")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleToAttribute("Splat.Tests")]
-[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
+[assembly: System.Runtime.Versioning.TargetFrameworkAttribute(".NETFramework,Version=v4.6.1", FrameworkDisplayName=".NET Framework 4.6.1")]
 namespace Splat
 {
     public class ActionLogger : Splat.ILogger
@@ -86,6 +86,17 @@ namespace Splat
         public BitmapLoaderException(string message) { }
         public BitmapLoaderException(string message, System.Exception innerException) { }
         protected BitmapLoaderException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+    }
+    public class static BitmapMixins
+    {
+        public static Splat.IBitmap FromNative(this System.Windows.Media.Imaging.BitmapSource value) { }
+        public static System.Windows.Media.Imaging.BitmapSource ToNative(this Splat.IBitmap value) { }
+    }
+    public class static ColorExtensions
+    {
+        public static System.Drawing.Color FromNative(this System.Windows.Media.Color value) { }
+        public static System.Windows.Media.Color ToNative(this System.Drawing.Color value) { }
+        public static System.Windows.Media.SolidColorBrush ToNativeBrush(this System.Drawing.Color value) { }
     }
     public enum CompressedBitmapFormat
     {
@@ -571,6 +582,25 @@ namespace Splat
         public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
         public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
+    public class PlatformBitmapLoader : Splat.IBitmapLoader
+    {
+        public PlatformBitmapLoader() { }
+        public Splat.IBitmap Create(float width, float height) { }
+        public System.Threading.Tasks.Task<Splat.IBitmap> Load(System.IO.Stream sourceStream, System.Nullable<float> desiredWidth, System.Nullable<float> desiredHeight) { }
+        public System.Threading.Tasks.Task<Splat.IBitmap> LoadFromResource(string resource, System.Nullable<float> desiredWidth, System.Nullable<float> desiredHeight) { }
+    }
+    public class PlatformModeDetector : Splat.IModeDetector
+    {
+        public PlatformModeDetector() { }
+        public System.Nullable<bool> InDesignMode() { }
+        public System.Nullable<bool> InUnitTestRunner() { }
+    }
+    public class static PointExtensions
+    {
+        public static System.Drawing.PointF FromNative(this System.Windows.Point value) { }
+        public static System.Windows.Point ToNative(this System.Drawing.Point value) { }
+        public static System.Windows.Point ToNative(this System.Drawing.PointF value) { }
+    }
     public class static PointMathExtensions
     {
         public static float AngleInDegrees(this System.Drawing.PointF value) { }
@@ -598,6 +628,18 @@ namespace Splat
         Top = 1,
         Right = 2,
         Bottom = 3,
+    }
+    public class static RectExtensions
+    {
+        public static System.Drawing.RectangleF FromNative(this System.Windows.Rect value) { }
+        public static System.Windows.Rect ToNative(this System.Drawing.Rectangle value) { }
+        public static System.Windows.Rect ToNative(this System.Drawing.RectangleF value) { }
+    }
+    public class static SizeExtensions
+    {
+        public static System.Drawing.SizeF FromNative(this System.Windows.Size value) { }
+        public static System.Windows.Size ToNative(this System.Drawing.Size value) { }
+        public static System.Windows.Size ToNative(this System.Drawing.SizeF value) { }
     }
     public class static SizeMathExtensions
     {
@@ -634,6 +676,12 @@ namespace Splat
         public int ToArgb() { }
         public Splat.KnownColor ToKnownColor() { }
         public override string ToString() { }
+    }
+    public class static SplatColorExtensions
+    {
+        public static Splat.SplatColor FromNative(this System.Windows.Media.Color value) { }
+        public static System.Windows.Media.Color ToNative(this Splat.SplatColor value) { }
+        public static System.Windows.Media.SolidColorBrush ToNativeBrush(this Splat.SplatColor value) { }
     }
     public class static TargetFrameworkExtensions
     {

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
@@ -12,59 +12,69 @@ namespace Splat
         public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
         public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
-    public class AllocationFreeLoggerBase : Splat.WrappingFullLogger, Splat.IAllocationFreeLogger, Splat.IFullLogger, Splat.ILogger
+    public class AllocationFreeLoggerBase : Splat.IAllocationFreeLogger, Splat.ILogger
     {
         public AllocationFreeLoggerBase(Splat.ILogger inner) { }
-        public void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public bool IsDebugEnabled { get; }
+        public bool IsErrorEnabled { get; }
+        public bool IsFatalEnabled { get; }
+        public bool IsInfoEnabled { get; }
+        public bool IsWarnEnabled { get; }
+        public Splat.LogLevel Level { get; }
+        public virtual void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public virtual void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
-        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
-        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
-        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
-        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
-        public void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public virtual void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
-        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
-        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
-        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
-        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
-        public void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public virtual void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
-        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
-        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
-        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
-        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
-        public void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public virtual void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
-        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
-        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
-        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
-        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
-        public void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public virtual void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
-        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
-        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
-        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
-        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
     public class static BitmapLoader
     {
@@ -146,8 +156,13 @@ namespace Splat
         public FuncLogManager(System.Func<System.Type, Splat.IFullLogger> getLoggerFunc) { }
         public Splat.IFullLogger GetLogger(System.Type type) { }
     }
-    public interface IAllocationFreeLogger : Splat.IFullLogger, Splat.ILogger
+    public interface IAllocationFreeLogger : Splat.ILogger
     {
+        bool IsDebugEnabled { get; }
+        bool IsErrorEnabled { get; }
+        bool IsFatalEnabled { get; }
+        bool IsInfoEnabled { get; }
+        bool IsWarnEnabled { get; }
         void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
@@ -624,15 +639,9 @@ namespace Splat
     {
         public static string GetTargetFrameworkName(this System.Reflection.Assembly assembly) { }
     }
-    public class WrappingFullLogger : Splat.IFullLogger, Splat.ILogger
+    public class WrappingFullLogger : Splat.AllocationFreeLoggerBase, Splat.IFullLogger, Splat.ILogger
     {
         public WrappingFullLogger(Splat.ILogger inner) { }
-        public bool IsDebugEnabled { get; }
-        public bool IsErrorEnabled { get; }
-        public bool IsFatalEnabled { get; }
-        public bool IsInfoEnabled { get; }
-        public bool IsWarnEnabled { get; }
-        public Splat.LogLevel Level { get; }
         public void Debug<T>(T value) { }
         public void Debug<T>(System.IFormatProvider formatProvider, T value) { }
         public void Debug(System.IFormatProvider formatProvider, string message, params object[] args) { }
@@ -688,10 +697,6 @@ namespace Splat
         public void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
         public void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public void WarnException(string message, System.Exception exception) { }
-        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
-        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
-        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
-        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
     public class WrappingPrefixLogger : Splat.ILogger
     {

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
@@ -229,13 +229,8 @@ namespace Splat
     public interface IDependencyResolver : Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable { }
     [System.Runtime.InteropServices.ComVisibleAttribute(false)]
     public interface IEnableLogger { }
-    public interface IFullLogger : Splat.ILogger
+    public interface IFullLogger : Splat.IAllocationFreeLogger, Splat.ILogger
     {
-        bool IsDebugEnabled { get; }
-        bool IsErrorEnabled { get; }
-        bool IsFatalEnabled { get; }
-        bool IsInfoEnabled { get; }
-        bool IsWarnEnabled { get; }
         void Debug<T>(T value);
         void Debug<T>(System.IFormatProvider formatProvider, T value);
         void Debug(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
@@ -639,7 +634,7 @@ namespace Splat
     {
         public static string GetTargetFrameworkName(this System.Reflection.Assembly assembly) { }
     }
-    public class WrappingFullLogger : Splat.AllocationFreeLoggerBase, Splat.IFullLogger, Splat.ILogger
+    public class WrappingFullLogger : Splat.AllocationFreeLoggerBase, Splat.IAllocationFreeLogger, Splat.IFullLogger, Splat.ILogger
     {
         public WrappingFullLogger(Splat.ILogger inner) { }
         public void Debug<T>(T value) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
@@ -12,6 +12,60 @@ namespace Splat
         public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
         public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
+    public class AllocationFreeLoggerBase : Splat.WrappingFullLogger, Splat.IAllocationFreeLogger, Splat.IFullLogger, Splat.ILogger
+    {
+        public AllocationFreeLoggerBase(Splat.ILogger inner) { }
+        public void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
+        public void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+    }
     public class static BitmapLoader
     {
         public static Splat.IBitmapLoader Current { get; set; }
@@ -92,6 +146,59 @@ namespace Splat
         public FuncLogManager(System.Func<System.Type, Splat.IFullLogger> getLoggerFunc) { }
         public Splat.IFullLogger GetLogger(System.Type type) { }
     }
+    public interface IAllocationFreeLogger : Splat.IFullLogger, Splat.ILogger
+    {
+        void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
+        void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
+        void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
+        void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
+        void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
+        void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+    }
     public interface IBitmap : System.IDisposable
     {
         float Height { get; }
@@ -122,11 +229,8 @@ namespace Splat
         void Debug([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Debug<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Debug<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
-        void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Debug<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-        void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void DebugException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Error<T>(T value);
         void Error<T>(System.IFormatProvider formatProvider, T value);
@@ -136,11 +240,8 @@ namespace Splat
         void Error([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Error<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Error<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
-        void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Error<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-        void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void ErrorException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Fatal<T>(T value);
         void Fatal<T>(System.IFormatProvider formatProvider, T value);
@@ -150,11 +251,8 @@ namespace Splat
         void Fatal([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Fatal<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Fatal<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
-        void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Fatal<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-        void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void FatalException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Info<T>(T value);
         void Info<T>(System.IFormatProvider formatProvider, T value);
@@ -164,11 +262,8 @@ namespace Splat
         void Info([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Info<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Info<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
-        void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Info<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-        void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void InfoException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Warn<T>(T value);
         void Warn<T>(System.IFormatProvider formatProvider, T value);
@@ -178,11 +273,8 @@ namespace Splat
         void Warn([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Warn<T>([System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Warn<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
-        void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-        void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void WarnException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
     }
     public interface ILogger
@@ -549,11 +641,8 @@ namespace Splat
         public void Debug(string message, params object[] args) { }
         public void Debug<T>(string message, params object[] args) { }
         public void Debug<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
-        public void Debug<TArgument>(string message, TArgument argument) { }
         public void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Debug<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
         public void Debug<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
-        public void Debug<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public void DebugException(string message, System.Exception exception) { }
         public void Error<T>(T value) { }
         public void Error<T>(System.IFormatProvider formatProvider, T value) { }
@@ -563,11 +652,8 @@ namespace Splat
         public void Error(string message, params object[] args) { }
         public void Error<T>(string message, params object[] args) { }
         public void Error<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
-        public void Error<TArgument>(string message, TArgument argument) { }
         public void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Error<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
         public void Error<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
-        public void Error<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public void ErrorException(string message, System.Exception exception) { }
         public void Fatal<T>(T value) { }
         public void Fatal<T>(System.IFormatProvider formatProvider, T value) { }
@@ -577,11 +663,8 @@ namespace Splat
         public void Fatal(string message, params object[] args) { }
         public void Fatal<T>(string message, params object[] args) { }
         public void Fatal<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
-        public void Fatal<TArgument>(string message, TArgument argument) { }
         public void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Fatal<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
         public void Fatal<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
-        public void Fatal<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public void FatalException(string message, System.Exception exception) { }
         public void Info<T>(T value) { }
         public void Info<T>(System.IFormatProvider formatProvider, T value) { }
@@ -591,11 +674,8 @@ namespace Splat
         public void Info(string message, params object[] args) { }
         public void Info<T>(string message, params object[] args) { }
         public void Info<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
-        public void Info<TArgument>(string message, TArgument argument) { }
         public void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Info<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
         public void Info<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
-        public void Info<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public void InfoException(string message, System.Exception exception) { }
         public void Warn<T>(T value) { }
         public void Warn<T>(System.IFormatProvider formatProvider, T value) { }
@@ -605,11 +685,8 @@ namespace Splat
         public void Warn(string message, params object[] args) { }
         public void Warn<T>(string message, params object[] args) { }
         public void Warn<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
-        public void Warn<TArgument>(string message, TArgument argument) { }
         public void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
-        public void Warn<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2) { }
         public void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
-        public void Warn<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public void WarnException(string message, System.Exception exception) { }
         public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
         public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }

--- a/src/Splat.Tests/Logging/AllocationFreeLoggerBaseTests.cs
+++ b/src/Splat.Tests/Logging/AllocationFreeLoggerBaseTests.cs
@@ -1,0 +1,1814 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Splat.Tests.Mocks;
+using Xunit;
+
+namespace Splat.Tests.Logging
+{
+    /// <summary>
+    /// Tests that check the functionality of the <see cref="AllocationFreeLoggerBase"/> class.
+    /// </summary>
+    public class AllocationFreeLoggerBaseTests
+    {
+        /// <summary>
+        /// Tests that check the functionality of the debug method with four arguments.
+        /// </summary>
+        public class DebugOneArgumentMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}", 1);
+
+                Assert.Equal("1\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}", 1);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with five arguments.
+        /// </summary>
+        public class DebugTwoArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}, {1}", 1, 2);
+
+                Assert.Equal("1, 2\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}, {1}", 1, 2);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with six arguments.
+        /// </summary>
+        public class DebugThreeArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Equal("1, 2, 3\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with four arguments.
+        /// </summary>
+        public class DebugFourArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Equal("1, 2, 3, 4\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with five arguments.
+        /// </summary>
+        public class DebugFiveArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Equal("1, 2, 3, 4, 5\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with six arguments.
+        /// </summary>
+        public class DebugSixArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with seven arguments.
+        /// </summary>
+        public class DebugSevenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes seven arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes seven arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with eight arguments.
+        /// </summary>
+        public class DebugEighthArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes eight arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes eighth arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with nine arguments.
+        /// </summary>
+        public class DebugNineArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes nine arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes nine arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with ten arguments.
+        /// </summary>
+        public class DebugTenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes ten arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes ten arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the info method with one argument.
+        /// </summary>
+        public class InfoOneArgumentMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}", 1);
+
+                Assert.Equal("1\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}", 1);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the info method with two arguments.
+        /// </summary>
+        public class InfoTwoArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}", 1, 2);
+
+                Assert.Equal("1, 2\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}", 1, 2);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the info method with three arguments.
+        /// </summary>
+        public class InfoThreeArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Equal("1, 2, 3\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with four arguments.
+        /// </summary>
+        public class InfoFourArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Equal("1, 2, 3, 4\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with five arguments.
+        /// </summary>
+        public class InfoFiveArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Equal("1, 2, 3, 4, 5\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with six arguments.
+        /// </summary>
+        public class InfoSixArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the info method with seven arguments.
+        /// </summary>
+        public class InfoSevenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes seven arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes seven arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the info method with eight arguments.
+        /// </summary>
+        public class InfoEighthArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes eight arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes eight arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the info method with nine arguments.
+        /// </summary>
+        public class InfoNineArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes nine arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes nine arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the info method with ten arguments.
+        /// </summary>
+        public class InfoTenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes ten arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes ten arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the warn method with one argument.
+        /// </summary>
+        public class WarnOneArgumentMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}", 1);
+
+                Assert.Equal("1\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}", 1);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the warn method with two arguments.
+        /// </summary>
+        public class WarnTwoArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}", 1, 2);
+
+                Assert.Equal("1, 2\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}", 1, 2);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the warn method with three arguments.
+        /// </summary>
+        public class WarnThreeArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Equal("1, 2, 3\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with four arguments.
+        /// </summary>
+        public class WarnFourArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Equal("1, 2, 3, 4\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with five arguments.
+        /// </summary>
+        public class WarnFiveArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Equal("1, 2, 3, 4, 5\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with six arguments.
+        /// </summary>
+        public class WarnSixArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the warn method with seven arguments.
+        /// </summary>
+        public class WarnSevenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes seven arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes seven arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the warn method with eighth arguments.
+        /// </summary>
+        public class WarnEighthArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes eighth arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes eighth arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the warn method with nine arguments.
+        /// </summary>
+        public class WarnNineArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes nine arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes nine arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the warn method with ten arguments.
+        /// </summary>
+        public class WarnTenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes ten arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes ten arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the error method with one argument.
+        /// </summary>
+        public class ErrorOneArgumentMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}", 1);
+
+                Assert.Equal("1\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}", 1);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the error method with two arguments.
+        /// </summary>
+        public class ErrorTwoArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}", 1, 2);
+
+                Assert.Equal("1, 2\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}", 1, 2);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the error method with three arguments.
+        /// </summary>
+        public class ErrorThreeArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Equal("1, 2, 3\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with four arguments.
+        /// </summary>
+        public class ErrorFourArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Equal("1, 2, 3, 4\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with five arguments.
+        /// </summary>
+        public class ErrorFiveArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Equal("1, 2, 3, 4, 5\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with six arguments.
+        /// </summary>
+        public class ErrorSixArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the error method with seven arguments.
+        /// </summary>
+        public class ErrorSevenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes seven arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes seven arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the error method with eighth arguments.
+        /// </summary>
+        public class ErrorEighthArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes eighth arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes eighth arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the error method with nine arguments.
+        /// </summary>
+        public class ErrorNineArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes nine arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes nine arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the error method with ten arguments.
+        /// </summary>
+        public class ErrorTenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes ten arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes ten arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the fatal method with one argument.
+        /// </summary>
+        public class FatalOneArgumentMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}", 1);
+
+                Assert.Equal("1\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_If_Lower_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}", 1);
+
+                Assert.Equal("1\r\n", inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the fatal method with two arguments.
+        /// </summary>
+        public class FatalTwoArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}", 1, 2);
+
+                Assert.Equal("1, 2\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_If_Lower_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}", 1, 2);
+
+                Assert.Equal("1, 2\r\n", inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the fatal method with three arguments.
+        /// </summary>
+        public class FatalThreeArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Equal("1, 2, 3\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_If_Lower_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Equal("1, 2, 3\r\n", inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with four arguments.
+        /// </summary>
+        public class FatalFourArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Equal("1, 2, 3, 4\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_If_Lower_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Equal("1, 2, 3, 4\r\n", inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with five arguments.
+        /// </summary>
+        public class FatalFiveArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Equal("1, 2, 3, 4, 5\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_If_Lower_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Equal("1, 2, 3, 4, 5\r\n", inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with six arguments.
+        /// </summary>
+        public class FatalSixArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_If_Lower_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6\r\n", inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the fatal method with seven arguments.
+        /// </summary>
+        public class FatalSevenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes seven arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes seven arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_If_Lower_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7\r\n", inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the fatal method with eighth arguments.
+        /// </summary>
+        public class FatalEighthArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes eight arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes eight arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_If_Lower_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8\r\n", inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the fatal method with nine arguments.
+        /// </summary>
+        public class FatalNineArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes nine arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes nine arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_If_Lower_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9\r\n", inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the fatal method with ten arguments.
+        /// </summary>
+        public class FatalTenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes ten arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10\r\n", inner.Value);
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes ten arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_If_Lower_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10\r\n", inner.Value);
+            }
+        }
+    }
+}

--- a/src/Splat.Tests/Logging/AllocationFreeLoggerBaseTests.cs
+++ b/src/Splat.Tests/Logging/AllocationFreeLoggerBaseTests.cs
@@ -11,6 +11,8 @@ namespace Splat.Tests.Logging
     /// </summary>
     public class AllocationFreeLoggerBaseTests
     {
+        private static char[] NewLine => Environment.NewLine.ToCharArray();
+
         /// <summary>
         /// Tests that check the functionality of the debug method with four arguments.
         /// </summary>
@@ -28,7 +30,7 @@ namespace Splat.Tests.Logging
 
                 logger.Debug("{0}", 1);
 
-                Assert.Equal("1\r\n", inner.Value);
+                Assert.Equal("1", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -64,7 +66,7 @@ namespace Splat.Tests.Logging
 
                 logger.Debug("{0}, {1}", 1, 2);
 
-                Assert.Equal("1, 2\r\n", inner.Value);
+                Assert.Equal("1, 2", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -100,7 +102,7 @@ namespace Splat.Tests.Logging
 
                 logger.Debug("{0}, {1}, {2}", 1, 2, 3);
 
-                Assert.Equal("1, 2, 3\r\n", inner.Value);
+                Assert.Equal("1, 2, 3", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -136,7 +138,7 @@ namespace Splat.Tests.Logging
 
                 logger.Debug("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
 
-                Assert.Equal("1, 2, 3, 4\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -172,7 +174,7 @@ namespace Splat.Tests.Logging
 
                 logger.Debug("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
 
-                Assert.Equal("1, 2, 3, 4, 5\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -208,7 +210,7 @@ namespace Splat.Tests.Logging
 
                 logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -244,7 +246,7 @@ namespace Splat.Tests.Logging
 
                 logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -280,7 +282,7 @@ namespace Splat.Tests.Logging
 
                 logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -316,7 +318,7 @@ namespace Splat.Tests.Logging
 
                 logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -352,7 +354,7 @@ namespace Splat.Tests.Logging
 
                 logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -388,7 +390,7 @@ namespace Splat.Tests.Logging
 
                 logger.Info("{0}", 1);
 
-                Assert.Equal("1\r\n", inner.Value);
+                Assert.Equal("1", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -424,7 +426,7 @@ namespace Splat.Tests.Logging
 
                 logger.Info("{0}, {1}", 1, 2);
 
-                Assert.Equal("1, 2\r\n", inner.Value);
+                Assert.Equal("1, 2", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -460,7 +462,7 @@ namespace Splat.Tests.Logging
 
                 logger.Info("{0}, {1}, {2}", 1, 2, 3);
 
-                Assert.Equal("1, 2, 3\r\n", inner.Value);
+                Assert.Equal("1, 2, 3", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -496,7 +498,7 @@ namespace Splat.Tests.Logging
 
                 logger.Info("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
 
-                Assert.Equal("1, 2, 3, 4\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -532,7 +534,7 @@ namespace Splat.Tests.Logging
 
                 logger.Info("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
 
-                Assert.Equal("1, 2, 3, 4, 5\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -568,7 +570,7 @@ namespace Splat.Tests.Logging
 
                 logger.Info("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -604,7 +606,7 @@ namespace Splat.Tests.Logging
 
                 logger.Info("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -640,7 +642,7 @@ namespace Splat.Tests.Logging
 
                 logger.Info("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -676,7 +678,7 @@ namespace Splat.Tests.Logging
 
                 logger.Info("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -712,7 +714,7 @@ namespace Splat.Tests.Logging
 
                 logger.Info("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -748,7 +750,7 @@ namespace Splat.Tests.Logging
 
                 logger.Warn("{0}", 1);
 
-                Assert.Equal("1\r\n", inner.Value);
+                Assert.Equal("1", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -784,7 +786,7 @@ namespace Splat.Tests.Logging
 
                 logger.Warn("{0}, {1}", 1, 2);
 
-                Assert.Equal("1, 2\r\n", inner.Value);
+                Assert.Equal("1, 2", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -820,7 +822,7 @@ namespace Splat.Tests.Logging
 
                 logger.Warn("{0}, {1}, {2}", 1, 2, 3);
 
-                Assert.Equal("1, 2, 3\r\n", inner.Value);
+                Assert.Equal("1, 2, 3", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -856,7 +858,7 @@ namespace Splat.Tests.Logging
 
                 logger.Warn("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
 
-                Assert.Equal("1, 2, 3, 4\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -892,7 +894,7 @@ namespace Splat.Tests.Logging
 
                 logger.Warn("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
 
-                Assert.Equal("1, 2, 3, 4, 5\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -928,7 +930,7 @@ namespace Splat.Tests.Logging
 
                 logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -964,7 +966,7 @@ namespace Splat.Tests.Logging
 
                 logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1000,7 +1002,7 @@ namespace Splat.Tests.Logging
 
                 logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1036,7 +1038,7 @@ namespace Splat.Tests.Logging
 
                 logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1072,7 +1074,7 @@ namespace Splat.Tests.Logging
 
                 logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1108,7 +1110,7 @@ namespace Splat.Tests.Logging
 
                 logger.Error("{0}", 1);
 
-                Assert.Equal("1\r\n", inner.Value);
+                Assert.Equal("1", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1144,7 +1146,7 @@ namespace Splat.Tests.Logging
 
                 logger.Error("{0}, {1}", 1, 2);
 
-                Assert.Equal("1, 2\r\n", inner.Value);
+                Assert.Equal("1, 2", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1180,7 +1182,7 @@ namespace Splat.Tests.Logging
 
                 logger.Error("{0}, {1}, {2}", 1, 2, 3);
 
-                Assert.Equal("1, 2, 3\r\n", inner.Value);
+                Assert.Equal("1, 2, 3", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1216,7 +1218,7 @@ namespace Splat.Tests.Logging
 
                 logger.Error("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
 
-                Assert.Equal("1, 2, 3, 4\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1252,7 +1254,7 @@ namespace Splat.Tests.Logging
 
                 logger.Error("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
 
-                Assert.Equal("1, 2, 3, 4, 5\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1288,7 +1290,7 @@ namespace Splat.Tests.Logging
 
                 logger.Error("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1324,7 +1326,7 @@ namespace Splat.Tests.Logging
 
                 logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1360,7 +1362,7 @@ namespace Splat.Tests.Logging
 
                 logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1396,7 +1398,7 @@ namespace Splat.Tests.Logging
 
                 logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1432,7 +1434,7 @@ namespace Splat.Tests.Logging
 
                 logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1468,7 +1470,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}", 1);
 
-                Assert.Equal("1\r\n", inner.Value);
+                Assert.Equal("1", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1483,7 +1485,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}", 1);
 
-                Assert.Equal("1\r\n", inner.Value);
+                Assert.Equal("1", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1504,7 +1506,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}", 1, 2);
 
-                Assert.Equal("1, 2\r\n", inner.Value);
+                Assert.Equal("1, 2", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1519,7 +1521,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}", 1, 2);
 
-                Assert.Equal("1, 2\r\n", inner.Value);
+                Assert.Equal("1, 2", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1540,7 +1542,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}", 1, 2, 3);
 
-                Assert.Equal("1, 2, 3\r\n", inner.Value);
+                Assert.Equal("1, 2, 3", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1555,7 +1557,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}", 1, 2, 3);
 
-                Assert.Equal("1, 2, 3\r\n", inner.Value);
+                Assert.Equal("1, 2, 3", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1576,7 +1578,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
 
-                Assert.Equal("1, 2, 3, 4\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1591,7 +1593,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
 
-                Assert.Equal("1, 2, 3, 4\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1612,7 +1614,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
 
-                Assert.Equal("1, 2, 3, 4, 5\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1627,7 +1629,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
 
-                Assert.Equal("1, 2, 3, 4, 5\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1648,7 +1650,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1663,7 +1665,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1684,7 +1686,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1699,7 +1701,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1720,7 +1722,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1735,7 +1737,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1756,7 +1758,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1771,7 +1773,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1792,7 +1794,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10", inner.Value.TrimEnd(NewLine));
             }
 
             /// <summary>
@@ -1807,7 +1809,7 @@ namespace Splat.Tests.Logging
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10\r\n", inner.Value);
+                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10", inner.Value.TrimEnd(NewLine));
             }
         }
     }

--- a/src/Splat.Tests/Logging/AllocationFreeLoggerBaseTests.cs
+++ b/src/Splat.Tests/Logging/AllocationFreeLoggerBaseTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 using Splat.Tests.Mocks;
 using Xunit;
@@ -9,7 +10,8 @@ namespace Splat.Tests.Logging
     /// <summary>
     /// Tests that check the functionality of the <see cref="AllocationFreeLoggerBase"/> class.
     /// </summary>
-    public class AllocationFreeLoggerBaseTests
+    [SuppressMessage("Naming", "CA1034: Do not nest type", Justification = "Deliberate usage")]
+    public static class AllocationFreeLoggerBaseTests
     {
         private static char[] NewLine => Environment.NewLine.ToCharArray();
 

--- a/src/Splat/Logging/AllocationFreeLoggerBase.cs
+++ b/src/Splat/Logging/AllocationFreeLoggerBase.cs
@@ -16,9 +16,8 @@ namespace Splat
     /// <summary>
     /// Base class for a logger the provides allocation free logging.
     /// </summary>
-    /// <seealso cref="Splat.WrappingFullLogger" />
-    /// <seealso cref="Splat.IAllocationFreeLogger" />
-    public class AllocationFreeLoggerBase : WrappingFullLogger, IAllocationFreeLogger
+    /// <seealso cref="IAllocationFreeLogger" />
+    public class AllocationFreeLoggerBase : IAllocationFreeLogger
     {
         private readonly ILogger _inner;
 
@@ -27,10 +26,27 @@ namespace Splat
         /// </summary>
         /// <param name="inner">The <see cref="T:Splat.ILogger" /> to wrap in this class.</param>
         public AllocationFreeLoggerBase(ILogger inner)
-            : base(inner)
         {
             _inner = inner;
         }
+
+        /// <inheritdoc />
+        public LogLevel Level => _inner.Level;
+
+        /// <inheritdoc />
+        public bool IsDebugEnabled => Level <= LogLevel.Debug;
+
+        /// <inheritdoc />
+        public bool IsInfoEnabled => Level <= LogLevel.Info;
+
+        /// <inheritdoc />
+        public bool IsWarnEnabled => Level <= LogLevel.Warn;
+
+        /// <inheritdoc />
+        public bool IsErrorEnabled => Level <= LogLevel.Error;
+
+        /// <inheritdoc />
+        public bool IsFatalEnabled => Level <= LogLevel.Fatal;
 
         /// <inheritdoc />
         public virtual void Debug<TArgument>([Localizable(false)] string message, TArgument argument)
@@ -1153,6 +1169,30 @@ namespace Splat
                         argument10),
                     LogLevel.Fatal);
             }
+        }
+
+        /// <inheritdoc />
+        public void Write([Localizable(false)] string message, LogLevel logLevel)
+        {
+            _inner.Write(message, logLevel);
+        }
+
+        /// <inheritdoc />
+        public void Write(Exception exception, [Localizable(false)] string message, LogLevel logLevel)
+        {
+            _inner.Write(exception, message, logLevel);
+        }
+
+        /// <inheritdoc />
+        public void Write([Localizable(false)] string message, [Localizable(false)] Type type, LogLevel logLevel)
+        {
+            _inner.Write(message, type, logLevel);
+        }
+
+        /// <inheritdoc />
+        public void Write(Exception exception, [Localizable(false)] string message, [Localizable(false)] Type type, LogLevel logLevel)
+        {
+            _inner.Write(exception, message, type, logLevel);
         }
     }
 }

--- a/src/Splat/Logging/AllocationFreeLoggerBase.cs
+++ b/src/Splat/Logging/AllocationFreeLoggerBase.cs
@@ -6,6 +6,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Text;
@@ -17,6 +18,7 @@ namespace Splat
     /// Base class for a logger the provides allocation free logging.
     /// </summary>
     /// <seealso cref="IAllocationFreeLogger" />
+    [SuppressMessage("Naming", "CA1716: Do not use built in identifiers", Justification = "Deliberate usage")]
     public class AllocationFreeLoggerBase : IAllocationFreeLogger
     {
         private readonly ILogger _inner;
@@ -24,7 +26,7 @@ namespace Splat
         /// <summary>
         /// Initializes a new instance of the <see cref="AllocationFreeLoggerBase"/> class.
         /// </summary>
-        /// <param name="inner">The <see cref="T:Splat.ILogger" /> to wrap in this class.</param>
+        /// <param name="inner">The <see cref="Splat.ILogger" /> to wrap in this class.</param>
         public AllocationFreeLoggerBase(ILogger inner)
         {
             _inner = inner;

--- a/src/Splat/Logging/AllocationFreeLoggerBase.cs
+++ b/src/Splat/Logging/AllocationFreeLoggerBase.cs
@@ -1,0 +1,1158 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Splat
+{
+    /// <summary>
+    /// Base class for a logger the provides allocation free logging.
+    /// </summary>
+    /// <seealso cref="Splat.WrappingFullLogger" />
+    /// <seealso cref="Splat.IAllocationFreeLogger" />
+    public class AllocationFreeLoggerBase : WrappingFullLogger, IAllocationFreeLogger
+    {
+        private readonly ILogger _inner;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AllocationFreeLoggerBase"/> class.
+        /// </summary>
+        /// <param name="inner">The <see cref="T:Splat.ILogger" /> to wrap in this class.</param>
+        public AllocationFreeLoggerBase(ILogger inner)
+            : base(inner)
+        {
+            _inner = inner;
+        }
+
+        /// <inheritdoc />
+        public virtual void Debug<TArgument>([Localizable(false)] string message, TArgument argument)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Debug<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Debug<TArgument1, TArgument2, TArgument3>(
+            [Localizable(false)] string message,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9,
+            TArgument10 argument10)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9,
+                        argument10),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Info<TArgument>([Localizable(false)] string message, TArgument argument)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Info<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Info<TArgument1, TArgument2, TArgument3>(
+            [Localizable(false)] string message,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2, argument3, argument4),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9,
+            TArgument10>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9,
+            TArgument10 argument10)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9,
+                        argument10),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Warn<TArgument>([Localizable(false)] string message, TArgument argument)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Warn<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Warn<TArgument1, TArgument2, TArgument3>(
+            [Localizable(false)] string message,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2, argument3, argument4),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9,
+            TArgument10>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9,
+            TArgument10 argument10)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9,
+                        argument10),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Error<TArgument>([Localizable(false)] string message, TArgument argument)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Error<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Error<TArgument1, TArgument2, TArgument3>(
+            [Localizable(false)] string message,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2, argument3, argument4),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9,
+            TArgument10 argument10)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9,
+                        argument10),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Fatal<TArgument>([Localizable(false)] string message, TArgument argument)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Fatal<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3>(
+            [Localizable(false)] string message,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2, argument3, argument4),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(
+            [Localizable(false)] string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9,
+            TArgument10 argument10)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9,
+                        argument10),
+                    LogLevel.Fatal);
+            }
+        }
+    }
+}

--- a/src/Splat/Logging/FullLoggerExtensions.cs
+++ b/src/Splat/Logging/FullLoggerExtensions.cs
@@ -49,7 +49,7 @@ namespace Splat
         {
             if (logger.IsDebugEnabled)
             {
-                logger.Debug(function.Invoke(), exception);
+                logger.DebugException(function.Invoke(), exception);
             }
         }
 
@@ -90,7 +90,7 @@ namespace Splat
         {
             if (logger.IsInfoEnabled)
             {
-                logger.Info(function.Invoke(), exception);
+                logger.InfoException(function.Invoke(), exception);
             }
         }
 
@@ -131,7 +131,7 @@ namespace Splat
         {
             if (logger.IsWarnEnabled)
             {
-                logger.Warn(function.Invoke(), exception);
+                logger.WarnException(function.Invoke(), exception);
             }
         }
 

--- a/src/Splat/Logging/IAllocationFreeLogger.cs
+++ b/src/Splat/Logging/IAllocationFreeLogger.cs
@@ -15,8 +15,33 @@ namespace Splat
     /// A <see cref="WrappingFullLogger"/> will wrap simple loggers into a full logger.
     /// </summary>
     [SuppressMessage("Naming", "CA1716: Do not use built in identifiers", Justification = "Deliberate usage")]
-    public interface IAllocationFreeLogger : IFullLogger
+    public interface IAllocationFreeLogger : ILogger
     {
+        /// <summary>
+        /// Gets a value indicating whether the logger currently emits debug logs.
+        /// </summary>
+        bool IsDebugEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the logger currently emits information logs.
+        /// </summary>
+        bool IsInfoEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the logger currently emits warning logs.
+        /// </summary>
+        bool IsWarnEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the logger currently emits error logs.
+        /// </summary>
+        bool IsErrorEnabled { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the logger currently emits fatal logs.
+        /// </summary>
+        bool IsFatalEnabled { get; }
+
         /// <summary>
         /// Emits a message using formatting to the debug log.
         /// </summary>

--- a/src/Splat/Logging/IAllocationFreeLogger.cs
+++ b/src/Splat/Logging/IAllocationFreeLogger.cs
@@ -1,0 +1,870 @@
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Splat
+{
+    /// <summary>
+    /// An allocation free logger which wraps all the possible logging methods available.
+    /// Often not needed for your own loggers.
+    /// A <see cref="WrappingFullLogger"/> will wrap simple loggers into a full logger.
+    /// </summary>
+    [SuppressMessage("Naming", "CA1716: Do not use built in identifiers", Justification = "Deliberate usage")]
+    public interface IAllocationFreeLogger : IFullLogger
+    {
+        /// <summary>
+        /// Emits a message using formatting to the debug log.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
+        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="argument">The argument for formatting purposes.</param>
+        void Debug<TArgument>([Localizable(false)] string message, TArgument argument);
+
+        /// <summary>
+        /// Emits a message using formatting to the debug log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        void Debug<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+
+        /// <summary>
+        /// Emits a message using formatting to the debug log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        void Debug<TArgument1, TArgument2, TArgument3>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+
+        /// <summary>
+        /// Emits a message using formatting to the debug log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+
+        /// <summary>
+        /// Emits a message using formatting to the debug log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+
+        /// <summary>
+        /// Emits a message using formatting to the debug log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+
+        /// <summary>
+        /// Emits a message using formatting to the debug log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+
+        /// <summary>
+        /// Emits a message using formatting to the debug log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+
+        /// <summary>
+        /// Emits a message using formatting to the debug log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        /// <param name="argument9">The ninth argument for formatting purposes.</param>
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+
+        /// <summary>
+        /// Emits a message using formatting to the debug log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument10">The type of the tenth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        /// <param name="argument9">The ninth argument for formatting purposes.</param>
+        /// <param name="argument10">The tenth argument for formatting purposes.</param>
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+
+        /// <summary>
+        /// Emits a message using formatting to the info log.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
+        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="argument">The argument for formatting purposes.</param>
+        void Info<TArgument>([Localizable(false)] string message, TArgument argument);
+
+        /// <summary>
+        /// Emits a message using formatting to the info log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        void Info<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+
+        /// <summary>
+        /// Emits a message using formatting to the info log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        void Info<TArgument1, TArgument2, TArgument3>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+
+        /// <summary>
+        /// Emits a message using formatting to the info log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+
+        /// <summary>
+        /// Logs a info message with the provided message format and values.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+
+        /// <summary>
+        /// Logs a info message with the provided message format and values.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+
+        /// <summary>
+        /// Emits a message using formatting to the info log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+
+        /// <summary>
+        /// Emits a message using formatting to the info log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+
+        /// <summary>
+        /// Emits a message using formatting to the info log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        /// <param name="argument9">The ninth argument for formatting purposes.</param>
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+
+        /// <summary>
+        /// Emits a message using formatting to the info log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument10">The type of the tenth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        /// <param name="argument9">The ninth argument for formatting purposes.</param>
+        /// <param name="argument10">The tenth argument for formatting purposes.</param>
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+
+        /// <summary>
+        /// Emits a message using formatting to the warning log.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
+        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="argument">The argument for formatting purposes.</param>
+        void Warn<TArgument>([Localizable(false)] string message, TArgument argument);
+
+        /// <summary>
+        /// Emits a message using formatting to the warning log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        void Warn<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+
+        /// <summary>
+        /// Emits a message using formatting to the warning log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        void Warn<TArgument1, TArgument2, TArgument3>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+
+        /// <summary>
+        /// Emits a message using formatting to the warning log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+
+        /// <summary>
+        /// Emits a message using formatting to the warning log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+
+        /// <summary>
+        /// Emits a message using formatting to the warning log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+
+        /// <summary>
+        /// Emits a message using formatting to the warn log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+
+        /// <summary>
+        /// Emits a message using formatting to the warn log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+
+        /// <summary>
+        /// Emits a message using formatting to the warn log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        /// <param name="argument9">The ninth argument for formatting purposes.</param>
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+
+        /// <summary>
+        /// Emits a message using formatting to the warn log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument10">The type of the tenth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        /// <param name="argument9">The ninth argument for formatting purposes.</param>
+        /// <param name="argument10">The tenth argument for formatting purposes.</param>
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+
+        /// <summary>
+        /// Emits a message using formatting to the error log.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
+        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="argument">The argument for formatting purposes.</param>
+        void Error<TArgument>([Localizable(false)] string message, TArgument argument);
+
+        /// <summary>
+        /// Emits a message using formatting to the error log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        void Error<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+
+        /// <summary>
+        /// Emits a message using formatting to the error log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        void Error<TArgument1, TArgument2, TArgument3>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+
+        /// <summary>
+        /// Emits a message using formatting to the error log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+
+        /// <summary>
+        /// Emits a message using formatting to the error log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+
+        /// <summary>
+        /// Emits a message using formatting to the error log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+
+        /// <summary>
+        /// Emits a message using formatting to the error log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+
+        /// <summary>
+        /// Emits a message using formatting to the error log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+
+        /// <summary>
+        /// Emits a message using formatting to the error log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        /// <param name="argument9">The ninth argument for formatting purposes.</param>
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+
+        /// <summary>
+        /// Emits a message using formatting to the error log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument10">The type of the tenth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        /// <param name="argument9">The ninth argument for formatting purposes.</param>
+        /// <param name="argument10">The tenth argument for formatting purposes.</param>
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+
+        /// <summary>
+        /// Emits a message using formatting to the fatal log.
+        /// </summary>
+        /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
+        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="argument">The argument for formatting purposes.</param>
+        void Fatal<TArgument>([Localizable(false)] string message, TArgument argument);
+
+        /// <summary>
+        /// Emits a message using formatting to the fatal log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        void Fatal<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+
+        /// <summary>
+        /// Emits a message using formatting to the fatal log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        void Fatal<TArgument1, TArgument2, TArgument3>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+
+        /// <summary>
+        /// Emits a message using formatting to the fatal log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+
+        /// <summary>
+        /// Emits a message using formatting to the fatal log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+
+        /// <summary>
+        /// Emits a message using formatting to the fatal log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+
+        /// <summary>
+        /// Emits a message using formatting to the fatal log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+
+        /// <summary>
+        /// Emits a message using formatting to the fatal log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+
+        /// <summary>
+        /// Emits a message using formatting to the fatal log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        /// <param name="argument9">The ninth argument for formatting purposes.</param>
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+
+        /// <summary>
+        /// Emits a message using formatting to the fatal log.
+        /// </summary>
+        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <typeparam name="TArgument10">The type of the tenth argument which is used in the formatting.</typeparam>
+        /// <param name="messageFormat">The message format.</param>
+        /// <param name="argument1">The first argument for formatting purposes.</param>
+        /// <param name="argument2">The second argument for formatting purposes.</param>
+        /// <param name="argument3">The third argument for formatting purposes.</param>
+        /// <param name="argument4">The fourth argument for formatting purposes.</param>
+        /// <param name="argument5">The fifth argument for formatting purposes.</param>
+        /// <param name="argument6">The sixth argument for formatting purposes.</param>
+        /// <param name="argument7">The seventh argument for formatting purposes.</param>
+        /// <param name="argument8">The eighth argument for formatting purposes.</param>
+        /// <param name="argument9">The ninth argument for formatting purposes.</param>
+        /// <param name="argument10">The tenth argument for formatting purposes.</param>
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+    }
+}

--- a/src/Splat/Logging/IFullLogger.cs
+++ b/src/Splat/Logging/IFullLogger.cs
@@ -116,14 +116,6 @@ namespace Splat
         /// <summary>
         /// Emits a message using formatting to the debug log.
         /// </summary>
-        /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument">The argument for formatting purposes.</param>
-        void Debug<TArgument>([Localizable(false)] string message, TArgument argument);
-
-        /// <summary>
-        /// Emits a message using formatting to the debug log.
-        /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <param name="formatProvider">The format provider to use.</param>
@@ -137,16 +129,6 @@ namespace Splat
         /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument1">The first argument for formatting purposes.</param>
-        /// <param name="argument2">The second argument for formatting purposes.</param>
-        void Debug<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
-
-        /// <summary>
-        /// Emits a message using formatting to the debug log.
-        /// </summary>
-        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <param name="formatProvider">The format provider to use.</param>
         /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
@@ -154,18 +136,6 @@ namespace Splat
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         void Debug<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-
-        /// <summary>
-        /// Emits a message using formatting to the debug log.
-        /// </summary>
-        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument1">The first argument for formatting purposes.</param>
-        /// <param name="argument2">The second argument for formatting purposes.</param>
-        /// <param name="argument3">The third argument for formatting purposes.</param>
-        void Debug<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
         /// <summary>
         /// Emits a info log message.
@@ -241,14 +211,6 @@ namespace Splat
         /// <summary>
         /// Emits a message using formatting to the info log.
         /// </summary>
-        /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument">The argument for formatting purposes.</param>
-        void Info<TArgument>([Localizable(false)] string message, TArgument argument);
-
-        /// <summary>
-        /// Emits a message using formatting to the info log.
-        /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <param name="formatProvider">The format provider to use.</param>
@@ -262,16 +224,6 @@ namespace Splat
         /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument1">The first argument for formatting purposes.</param>
-        /// <param name="argument2">The second argument for formatting purposes.</param>
-        void Info<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
-
-        /// <summary>
-        /// Emits a message using formatting to the info log.
-        /// </summary>
-        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <param name="formatProvider">The format provider to use.</param>
         /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
@@ -279,18 +231,6 @@ namespace Splat
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         void Info<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-
-        /// <summary>
-        /// Emits a message using formatting to the debug log.
-        /// </summary>
-        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument1">The first argument for formatting purposes.</param>
-        /// <param name="argument2">The second argument for formatting purposes.</param>
-        /// <param name="argument3">The third argument for formatting purposes.</param>
-        void Info<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
         /// <summary>
         /// Emits a warning log message.
@@ -366,14 +306,6 @@ namespace Splat
         /// <summary>
         /// Emits a message using formatting to the warning log.
         /// </summary>
-        /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument">The argument for formatting purposes.</param>
-        void Warn<TArgument>([Localizable(false)] string message, TArgument argument);
-
-        /// <summary>
-        /// Emits a message using formatting to the warning log.
-        /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <param name="formatProvider">The format provider to use.</param>
@@ -387,16 +319,6 @@ namespace Splat
         /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument1">The first argument for formatting purposes.</param>
-        /// <param name="argument2">The second argument for formatting purposes.</param>
-        void Warn<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
-
-        /// <summary>
-        /// Emits a message using formatting to the warning log.
-        /// </summary>
-        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <param name="formatProvider">The format provider to use.</param>
         /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
@@ -404,18 +326,6 @@ namespace Splat
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         void Warn<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-
-        /// <summary>
-        /// Emits a message using formatting to the warning log.
-        /// </summary>
-        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument1">The first argument for formatting purposes.</param>
-        /// <param name="argument2">The second argument for formatting purposes.</param>
-        /// <param name="argument3">The third argument for formatting purposes.</param>
-        void Warn<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
         /// <summary>
         /// Emits a error log message.
@@ -491,14 +401,6 @@ namespace Splat
         /// <summary>
         /// Emits a message using formatting to the error log.
         /// </summary>
-        /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument">The argument for formatting purposes.</param>
-        void Error<TArgument>([Localizable(false)] string message, TArgument argument);
-
-        /// <summary>
-        /// Emits a message using formatting to the error log.
-        /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <param name="formatProvider">The format provider to use.</param>
@@ -512,16 +414,6 @@ namespace Splat
         /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument1">The first argument for formatting purposes.</param>
-        /// <param name="argument2">The second argument for formatting purposes.</param>
-        void Error<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
-
-        /// <summary>
-        /// Emits a message using formatting to the error log.
-        /// </summary>
-        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <param name="formatProvider">The format provider to use.</param>
         /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
@@ -529,18 +421,6 @@ namespace Splat
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         void Error<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-
-        /// <summary>
-        /// Emits a message using formatting to the error log.
-        /// </summary>
-        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument1">The first argument for formatting purposes.</param>
-        /// <param name="argument2">The second argument for formatting purposes.</param>
-        /// <param name="argument3">The third argument for formatting purposes.</param>
-        void Error<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
         /// <summary>
         /// Emits a fatal log message.
@@ -616,14 +496,6 @@ namespace Splat
         /// <summary>
         /// Emits a message using formatting to the fatal log.
         /// </summary>
-        /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument">The argument for formatting purposes.</param>
-        void Fatal<TArgument>([Localizable(false)] string message, TArgument argument);
-
-        /// <summary>
-        /// Emits a message using formatting to the fatal log.
-        /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <param name="formatProvider">The format provider to use.</param>
@@ -637,16 +509,6 @@ namespace Splat
         /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument1">The first argument for formatting purposes.</param>
-        /// <param name="argument2">The second argument for formatting purposes.</param>
-        void Fatal<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
-
-        /// <summary>
-        /// Emits a message using formatting to the fatal log.
-        /// </summary>
-        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <param name="formatProvider">The format provider to use.</param>
         /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
@@ -654,17 +516,5 @@ namespace Splat
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         void Fatal<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, [Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
-
-        /// <summary>
-        /// Emits a message using formatting to the fatal log.
-        /// </summary>
-        /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
-        /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
-        /// <param name="message">A message to emit to the log which includes the standard formatting tags.</param>
-        /// <param name="argument1">The first argument for formatting purposes.</param>
-        /// <param name="argument2">The second argument for formatting purposes.</param>
-        /// <param name="argument3">The third argument for formatting purposes.</param>
-        void Fatal<TArgument1, TArgument2, TArgument3>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
     }
 }

--- a/src/Splat/Logging/IFullLogger.cs
+++ b/src/Splat/Logging/IFullLogger.cs
@@ -15,33 +15,8 @@ namespace Splat
     /// A <see cref="WrappingFullLogger"/> will wrap simple loggers into a full logger.
     /// </summary>
     [SuppressMessage("Naming", "CA1716: Do not use built in identifiers", Justification = "Deliberate usage")]
-    public interface IFullLogger : ILogger
+    public interface IFullLogger : ILogger, IAllocationFreeLogger
     {
-        /// <summary>
-        /// Gets a value indicating whether the logger currently emits debug logs.
-        /// </summary>
-        bool IsDebugEnabled { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the logger currently emits information logs.
-        /// </summary>
-        bool IsInfoEnabled { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the logger currently emits warning logs.
-        /// </summary>
-        bool IsWarnEnabled { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the logger currently emits error logs.
-        /// </summary>
-        bool IsErrorEnabled { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the logger currently emits fatal logs.
-        /// </summary>
-        bool IsFatalEnabled { get; }
-
         /// <summary>
         /// Emits a debug log message.
         /// This will emit the public contents of the object provided to the log.

--- a/src/Splat/Logging/WrappingFullLogger.cs
+++ b/src/Splat/Logging/WrappingFullLogger.cs
@@ -114,33 +114,15 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public void Debug<TArgument>(string message, TArgument argument)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Debug);
-        }
-
-        /// <inheritdoc />
         public void Debug<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
         {
             _inner.Write(string.Format(formatProvider, message, argument1, argument2), LogLevel.Debug);
         }
 
         /// <inheritdoc />
-        public void Debug<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Debug);
-        }
-
-        /// <inheritdoc />
         public void Debug<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
             _inner.Write(string.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Debug);
-        }
-
-        /// <inheritdoc />
-        public void Debug<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Debug);
         }
 
         /// <inheritdoc />
@@ -206,33 +188,15 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public void Info<TArgument>(string message, TArgument argument)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Info);
-        }
-
-        /// <inheritdoc />
         public void Info<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
         {
             _inner.Write(string.Format(formatProvider, message, argument1, argument2), LogLevel.Info);
         }
 
         /// <inheritdoc />
-        public void Info<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Info);
-        }
-
-        /// <inheritdoc />
         public void Info<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
             _inner.Write(string.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Info);
-        }
-
-        /// <inheritdoc />
-        public void Info<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Info);
         }
 
         /// <inheritdoc />
@@ -298,33 +262,15 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public void Warn<TArgument>(string message, TArgument argument)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Warn);
-        }
-
-        /// <inheritdoc />
         public void Warn<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
         {
             _inner.Write(string.Format(formatProvider, message, argument1, argument2), LogLevel.Warn);
         }
 
         /// <inheritdoc />
-        public void Warn<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Warn);
-        }
-
-        /// <inheritdoc />
         public void Warn<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
             _inner.Write(string.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Warn);
-        }
-
-        /// <inheritdoc />
-        public void Warn<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Warn);
         }
 
         /// <inheritdoc />
@@ -390,33 +336,15 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public void Error<TArgument>(string message, TArgument argument)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Error);
-        }
-
-        /// <inheritdoc />
         public void Error<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
         {
             _inner.Write(string.Format(formatProvider, message, argument1, argument2), LogLevel.Error);
         }
 
         /// <inheritdoc />
-        public void Error<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Error);
-        }
-
-        /// <inheritdoc />
         public void Error<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
             _inner.Write(string.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Error);
-        }
-
-        /// <inheritdoc />
-        public void Error<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Error);
         }
 
         /// <inheritdoc />
@@ -482,33 +410,15 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public void Fatal<TArgument>(string message, TArgument argument)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Fatal);
-        }
-
-        /// <inheritdoc />
         public void Fatal<TArgument1, TArgument2>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2)
         {
             _inner.Write(string.Format(formatProvider, message, argument1, argument2), LogLevel.Fatal);
         }
 
         /// <inheritdoc />
-        public void Fatal<TArgument1, TArgument2>(string message, TArgument1 argument1, TArgument2 argument2)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Fatal);
-        }
-
-        /// <inheritdoc />
         public void Fatal<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
             _inner.Write(string.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Fatal);
-        }
-
-        /// <inheritdoc />
-        public void Fatal<TArgument1, TArgument2, TArgument3>(string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
-        {
-            _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3), LogLevel.Fatal);
         }
 
         /// <inheritdoc />

--- a/src/Splat/Logging/WrappingFullLogger.cs
+++ b/src/Splat/Logging/WrappingFullLogger.cs
@@ -14,7 +14,7 @@ namespace Splat
     /// <summary>
     /// A full logger which wraps a <see cref="ILogger"/>.
     /// </summary>
-    public class WrappingFullLogger : IFullLogger
+    public class WrappingFullLogger : AllocationFreeLoggerBase, IFullLogger
     {
         private readonly ILogger _inner;
         private readonly MethodInfo _stringFormat;
@@ -24,6 +24,7 @@ namespace Splat
         /// </summary>
         /// <param name="inner">The <see cref="ILogger"/> to wrap in this class.</param>
         public WrappingFullLogger(ILogger inner)
+            : base(inner)
         {
             _inner = inner;
 
@@ -31,24 +32,6 @@ namespace Splat
             Contract.Requires(inner != null);
             Contract.Requires(_stringFormat != null);
         }
-
-        /// <inheritdoc />
-        public LogLevel Level => _inner.Level;
-
-        /// <inheritdoc />
-        public bool IsDebugEnabled => Level <= LogLevel.Debug;
-
-        /// <inheritdoc />
-        public bool IsInfoEnabled => Level <= LogLevel.Info;
-
-        /// <inheritdoc />
-        public bool IsWarnEnabled => Level <= LogLevel.Warn;
-
-        /// <inheritdoc />
-        public bool IsErrorEnabled => Level <= LogLevel.Error;
-
-        /// <inheritdoc />
-        public bool IsFatalEnabled => Level <= LogLevel.Fatal;
 
         /// <inheritdoc />
         public void Debug<T>(T value)
@@ -419,30 +402,6 @@ namespace Splat
         public void Fatal<TArgument1, TArgument2, TArgument3>(IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3)
         {
             _inner.Write(string.Format(formatProvider, message, argument1, argument2, argument3), LogLevel.Fatal);
-        }
-
-        /// <inheritdoc />
-        public void Write([Localizable(false)] string message, LogLevel logLevel)
-        {
-            _inner.Write(message, logLevel);
-        }
-
-        /// <inheritdoc />
-        public void Write(Exception exception, [Localizable(false)] string message, LogLevel logLevel)
-        {
-            _inner.Write(exception, message, logLevel);
-        }
-
-        /// <inheritdoc />
-        public void Write([Localizable(false)] string message, [Localizable(false)] Type type, LogLevel logLevel)
-        {
-            _inner.Write(message, type, logLevel);
-        }
-
-        /// <inheritdoc />
-        public void Write(Exception exception, [Localizable(false)] string message, [Localizable(false)] Type type, LogLevel logLevel)
-        {
-            _inner.Write(exception, message, type, logLevel);
         }
 
         private string InvokeStringFormat(IFormatProvider formatProvider, string message, object[] args)


### PR DESCRIPTION
- Added AllocationFreeLogger interface
- Added AllocationFreeLoggerBase class
- Added AllocationFreeLoggerBase tests
- Moved methods from IFullLogger to IAllocationFreeLogger
- Removed method from WrappingFullLogger

Resolves #228 

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Adds Allocation Free Logger to Splat

**What is the current behavior? (You can also link to an open issue here)**

There are a few allocation free logger methods on the `WrappingFullLoger` and `IFullLogger` interface

**What is the new behavior (if this is a feature change)?**

There are 10 allocation free logging methods per logging type

**What might this PR break?**

`IFullLogger` and `WrappingFullLogger`

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

