### PR TITLE
housekeeping: Add ability to change InternalLocator and run serial tests

### DIFF
--- a/src/Splat.Tests/Logging/SerilogLoggerTests.cs
+++ b/src/Splat.Tests/Logging/SerilogLoggerTests.cs
@@ -250,18 +250,28 @@ namespace Splat.Tests.Logging
         [Fact]
         public void Configuring_With_Static_Log_Should_Write_Message()
         {
-            var serilogLoggerAndTarget = GetActualSerilogLoggerAndTarget();
-            Log.Logger = serilogLoggerAndTarget.Logger;
-            var target = serilogLoggerAndTarget.Target;
-            Locator.CurrentMutable.UseSerilogFullLogger();
+            var originalLocator = Locator.InternalLocator;
+            try
+            {
+                Locator.InternalLocator = new InternalLocator();
+                var serilogLoggerAndTarget = GetActualSerilogLoggerAndTarget();
+                Log.Logger = serilogLoggerAndTarget.Logger;
+                var target = serilogLoggerAndTarget.Target;
 
-            Assert.Equal(0, target.Logs.Count);
+                Locator.CurrentMutable.UseSerilogFullLogger();
 
-            IEnableLogger logger = null;
-            logger.Log().Debug<DummyObjectClass2>("This is a test.");
+                Assert.Equal(0, target.Logs.Count);
 
-            Assert.Equal(1, target.Logs.Count);
-            Assert.Equal($"{typeof(DummyObjectClass2).FullName}: This is a test.", target.Logs.First());
+                IEnableLogger logger = null;
+                logger.Log().Debug<DummyObjectClass2>("This is a test.");
+
+                Assert.Equal(1, target.Logs.Count);
+                Assert.Equal($"{typeof(DummyObjectClass2).FullName}: This is a test.", target.Logs.First());
+            }
+            finally
+            {
+                Locator.InternalLocator = originalLocator;
+            }
         }
 
         /// <summary>
@@ -270,19 +280,27 @@ namespace Splat.Tests.Logging
         [Fact]
         public void Configuring_With_PreConfigured_Log_Should_Write_Message()
         {
-            var serilogLoggerAndTarget = GetActualSerilogLoggerAndTarget();
-            var target = serilogLoggerAndTarget.Target;
-            Locator.CurrentMutable.UseSerilogFullLogger(serilogLoggerAndTarget.Logger);
+            var originalLocator = Locator.InternalLocator;
+            try
+            {
+                Locator.InternalLocator = new InternalLocator();
+                var serilogLoggerAndTarget = GetActualSerilogLoggerAndTarget();
+                var target = serilogLoggerAndTarget.Target;
+                Locator.CurrentMutable.UseSerilogFullLogger(serilogLoggerAndTarget.Logger);
 
-            Assert.Equal(0, target.Logs.Count);
+                Assert.Equal(0, target.Logs.Count);
 
-            IEnableLogger logger = null;
+                IEnableLogger logger = null;
 
-            // Will Fail
-            logger.Log().Debug<DummyObjectClass2>("This is a test.");
+                logger.Log().Debug<DummyObjectClass2>("This is a test.");
 
-            Assert.Equal(1, target.Logs.Count);
-            Assert.Equal($"{typeof(DummyObjectClass2).FullName}: This is a test.", target.Logs.First());
+                Assert.Equal(1, target.Logs.Count);
+                Assert.Equal($"{typeof(DummyObjectClass2).FullName}: This is a test.", target.Logs.First());
+            }
+            finally
+            {
+                Locator.InternalLocator = originalLocator;
+            }
         }
 
         private static (global::Serilog.ILogger Logger, LogTarget Target) GetActualSerilogLoggerAndTarget()

--- a/src/Splat.Tests/xunit.runner.json
+++ b/src/Splat.Tests/xunit.runner.json
@@ -1,3 +1,5 @@
 ﻿{
-  "shadowCopy": false
+    "$schema": "https://xunit.github.io/schema/current/xunit.runner.schema.json",
+    "shadowCopy": false,
+    "parallelizeTestCollections":  false 
 }

--- a/src/Splat/ServiceLocation/Locator.cs
+++ b/src/Splat/ServiceLocation/Locator.cs
@@ -14,11 +14,9 @@ namespace Splat
     /// </summary>
     public static class Locator
     {
-        private static readonly InternalLocator _locator;
-
         static Locator()
         {
-            _locator = new InternalLocator();
+            InternalLocator = new InternalLocator();
         }
 
         /// <summary>
@@ -29,16 +27,22 @@ namespace Splat
         /// to simply use the default implementation.
         /// </summary>
         /// <value>The dependency resolver.</value>
-        public static IReadonlyDependencyResolver Current => _locator.Current;
+        public static IReadonlyDependencyResolver Current => InternalLocator.Current;
 
         /// <summary>
         /// Gets the mutable dependency resolver.
         /// The default resolver is also a mutable resolver, so this will be non-null.
         /// Use this to register new types on startup if you are using the default resolver.
         /// </summary>
-        public static IMutableDependencyResolver CurrentMutable => _locator.CurrentMutable;
+        public static IMutableDependencyResolver CurrentMutable => InternalLocator.CurrentMutable;
 
-        internal static IDependencyResolver Internal => _locator.Internal;
+        internal static IDependencyResolver Internal => InternalLocator.Internal;
+
+        /// <summary>
+        /// Gets or sets the current locator instance.
+        /// Used mostly for testing purposes.
+        /// </summary>
+        internal static InternalLocator InternalLocator { get; set; }
 
         /// <summary>
         /// Allows setting the dependency resolver.
@@ -46,7 +50,7 @@ namespace Splat
         /// <param name="dependencyResolver">The dependency resolver to set.</param>
         public static void SetLocator(IDependencyResolver dependencyResolver)
         {
-            _locator.SetLocator(dependencyResolver);
+            InternalLocator.SetLocator(dependencyResolver);
         }
 
         /// <summary>
@@ -62,7 +66,7 @@ namespace Splat
         /// ignore this.</returns>
         public static IDisposable RegisterResolverCallbackChanged(Action callback)
         {
-            return _locator.RegisterResolverCallbackChanged(callback);
+            return InternalLocator.RegisterResolverCallbackChanged(callback);
         }
 
         /// <summary>
@@ -73,7 +77,7 @@ namespace Splat
         /// notification is no longer needed.</returns>
         public static IDisposable SuppressResolverCallbackChangedNotifications()
         {
-            return _locator.SuppressResolverCallbackChangedNotifications();
+            return InternalLocator.SuppressResolverCallbackChangedNotifications();
         }
 
         /// <summary>
@@ -82,7 +86,7 @@ namespace Splat
         /// <returns>A value indicating whether the notifications are happening.</returns>
         public static bool AreResolverCallbackChangedNotificationsEnabled()
         {
-            return _locator.AreResolverCallbackChangedNotificationsEnabled();
+            return InternalLocator.AreResolverCallbackChangedNotificationsEnabled();
         }
     }
 }


### PR DESCRIPTION
We kept getting some locator tests failing still with Serilog.

Now allow for overriding so we can test the extension methods when needed against the Locator. Also now just run the tests serial in the main test project. This means you don't have contention issues on the Locator.