### PR TITLE
feature: Added Allocation Free Error Logger

### DIFF
--- a/src/Splat.Serilog/SerilogFullLogger.cs
+++ b/src/Splat.Serilog/SerilogFullLogger.cs
@@ -190,6 +190,12 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Debug(Exception exception, [Localizable(false)] string message)
+        {
+            _logger.Debug(exception, message);
+        }
+
+        /// <inheritdoc />
         public void Error<T>(T value)
         {
             _logger.Error(value.ToString());
@@ -199,6 +205,12 @@ namespace Splat
         public void Error<T>(IFormatProvider formatProvider, T value)
         {
            _logger.Error(string.Format(formatProvider, "{0}", value));
+        }
+
+        /// <inheritdoc />
+        public void Error(Exception exception, string message)
+        {
+            _logger.Error(exception, message);
         }
 
         /// <inheritdoc />
@@ -328,6 +340,12 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Fatal(Exception exception, string message)
+        {
+            _logger.Fatal(exception, message);
+        }
+
+        /// <inheritdoc />
         public void Fatal(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
         {
            _logger.Fatal(string.Format(formatProvider, message, args));
@@ -454,6 +472,12 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Info(Exception exception, string message)
+        {
+            _logger.Information(exception, message);
+        }
+
+        /// <inheritdoc />
         public void Info(IFormatProvider formatProvider, [Localizable(false)] string message, params object[] args)
         {
            _logger.Information(string.Format(formatProvider, message, args));
@@ -577,6 +601,12 @@ namespace Splat
         public void Warn<T>(IFormatProvider formatProvider, T value)
         {
            _logger.Warning(string.Format(formatProvider, "{0}", value));
+        }
+
+        /// <inheritdoc />
+        public void Warn(Exception exception, string message)
+        {
+            _logger.Warning(exception, message);
         }
 
         /// <inheritdoc />

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
@@ -12,7 +12,7 @@ namespace Splat
         public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
         public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
-    public class AllocationFreeLoggerBase : Splat.IAllocationFreeLogger, Splat.ILogger
+    public class AllocationFreeLoggerBase : Splat.IAllocationFreeErrorLogger, Splat.IAllocationFreeLogger, Splat.ILogger
     {
         public AllocationFreeLoggerBase(Splat.ILogger inner) { }
         public bool IsDebugEnabled { get; }
@@ -21,60 +21,110 @@ namespace Splat
         public bool IsInfoEnabled { get; }
         public bool IsWarnEnabled { get; }
         public Splat.LogLevel Level { get; }
-        public virtual void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public virtual void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public virtual void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument) { }
+        public virtual void Debug<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Debug<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Debug<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
-        public virtual void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public virtual void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public virtual void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument) { }
+        public void Error<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Error<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Error<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
-        public virtual void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public virtual void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public virtual void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument) { }
+        public void Fatal<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Fatal<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
-        public virtual void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public virtual void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public virtual void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument) { }
+        public void Info<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Info<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Info<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
-        public virtual void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public virtual void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public virtual void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument) { }
+        public void Warn<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Warn<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Warn<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
-        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
-        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
-        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
-        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Write([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
     public class static BitmapLoader
     {
@@ -167,6 +217,59 @@ namespace Splat
         public FuncLogManager(System.Func<System.Type, Splat.IFullLogger> getLoggerFunc) { }
         public Splat.IFullLogger GetLogger(System.Type type) { }
     }
+    public interface IAllocationFreeErrorLogger : Splat.ILogger
+    {
+        void Debug<TArgument>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Debug<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Error<TArgument>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Error<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Fatal<TArgument>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Fatal<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Info<TArgument>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Info<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Warn<TArgument>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Warn<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+    }
     public interface IAllocationFreeLogger : Splat.ILogger
     {
         bool IsDebugEnabled { get; }
@@ -174,8 +277,8 @@ namespace Splat
         bool IsFatalEnabled { get; }
         bool IsInfoEnabled { get; }
         bool IsWarnEnabled { get; }
-        void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
         void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
         void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
@@ -184,8 +287,8 @@ namespace Splat
         void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
         void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
         void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
-        void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
         void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void Error<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
         void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
@@ -194,8 +297,8 @@ namespace Splat
         void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
         void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
         void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
-        void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
         void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
         void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
@@ -204,8 +307,8 @@ namespace Splat
         void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
         void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
         void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
-        void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
         void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void Info<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
         void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
@@ -214,8 +317,8 @@ namespace Splat
         void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
         void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
         void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
-        void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
         void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
         void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
@@ -244,6 +347,7 @@ namespace Splat
     {
         void Debug<T>(T value);
         void Debug<T>(System.IFormatProvider formatProvider, T value);
+        void Debug(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message);
         void Debug(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Debug([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Debug<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
@@ -252,9 +356,11 @@ namespace Splat
         void Debug<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Debug<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.ObsoleteAttribute("Use void Debug(Exception exception, [Localizable(false)] string message)")]
         void DebugException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Error<T>(T value);
         void Error<T>(System.IFormatProvider formatProvider, T value);
+        void Error(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message);
         void Error(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Error([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Error<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
@@ -263,9 +369,11 @@ namespace Splat
         void Error<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Error<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.ObsoleteAttribute("Use void Error(Exception exception, [Localizable(false)] string message)")]
         void ErrorException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Fatal<T>(T value);
         void Fatal<T>(System.IFormatProvider formatProvider, T value);
+        void Fatal(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message);
         void Fatal(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Fatal([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Fatal<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
@@ -274,9 +382,11 @@ namespace Splat
         void Fatal<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Fatal<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.ObsoleteAttribute("Use void Fatal(Exception exception, [Localizable(false)] string message)")]
         void FatalException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Info<T>(T value);
         void Info<T>(System.IFormatProvider formatProvider, T value);
+        void Info(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message);
         void Info(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Info([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Info<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
@@ -285,9 +395,11 @@ namespace Splat
         void Info<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Info<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.ObsoleteAttribute("Use void Info(Exception exception, [Localizable(false)] string message)")]
         void InfoException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Warn<T>(T value);
         void Warn<T>(System.IFormatProvider formatProvider, T value);
+        void Warn(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message);
         void Warn(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Warn([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Warn<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
@@ -296,6 +408,7 @@ namespace Splat
         void Warn<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.ObsoleteAttribute("Use void Warn(Exception exception, [Localizable(false)] string message)")]
         void WarnException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
     }
     public interface ILogger
@@ -687,6 +800,7 @@ namespace Splat
         public WrappingFullLogger(Splat.ILogger inner) { }
         public void Debug<T>(T value) { }
         public void Debug<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Debug(System.Exception exception, string message) { }
         public void Debug(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Debug(string message) { }
         public void Debug<T>(string message) { }
@@ -698,6 +812,7 @@ namespace Splat
         public void DebugException(string message, System.Exception exception) { }
         public void Error<T>(T value) { }
         public void Error<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Error(System.Exception exception, string message) { }
         public void Error(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Error(string message) { }
         public void Error<T>(string message) { }
@@ -709,6 +824,7 @@ namespace Splat
         public void ErrorException(string message, System.Exception exception) { }
         public void Fatal<T>(T value) { }
         public void Fatal<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Fatal(System.Exception exception, string message) { }
         public void Fatal(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Fatal(string message) { }
         public void Fatal<T>(string message) { }
@@ -720,6 +836,7 @@ namespace Splat
         public void FatalException(string message, System.Exception exception) { }
         public void Info<T>(T value) { }
         public void Info<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Info(System.Exception exception, string message) { }
         public void Info(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Info(string message) { }
         public void Info<T>(string message) { }
@@ -731,6 +848,7 @@ namespace Splat
         public void InfoException(string message, System.Exception exception) { }
         public void Warn<T>(T value) { }
         public void Warn<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Warn(System.Exception exception, string message) { }
         public void Warn(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Warn(string message) { }
         public void Warn<T>(string message) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
@@ -12,7 +12,7 @@ namespace Splat
         public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
         public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
-    public class AllocationFreeLoggerBase : Splat.IAllocationFreeLogger, Splat.ILogger
+    public class AllocationFreeLoggerBase : Splat.IAllocationFreeErrorLogger, Splat.IAllocationFreeLogger, Splat.ILogger
     {
         public AllocationFreeLoggerBase(Splat.ILogger inner) { }
         public bool IsDebugEnabled { get; }
@@ -21,60 +21,110 @@ namespace Splat
         public bool IsInfoEnabled { get; }
         public bool IsWarnEnabled { get; }
         public Splat.LogLevel Level { get; }
-        public virtual void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public virtual void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public virtual void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument) { }
+        public virtual void Debug<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Debug<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Debug<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
-        public virtual void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public virtual void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public virtual void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument) { }
+        public void Error<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Error<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Error<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
-        public virtual void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public virtual void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public virtual void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument) { }
+        public void Fatal<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Fatal<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
-        public virtual void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public virtual void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public virtual void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument) { }
+        public void Info<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Info<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Info<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
-        public virtual void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument) { }
-        public virtual void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2) { }
-        public virtual void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument) { }
+        public void Warn<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Warn<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Warn<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
-        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
-        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, Splat.LogLevel logLevel) { }
-        public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
-        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Write([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
     public class static BitmapLoader
     {
@@ -156,6 +206,59 @@ namespace Splat
         public FuncLogManager(System.Func<System.Type, Splat.IFullLogger> getLoggerFunc) { }
         public Splat.IFullLogger GetLogger(System.Type type) { }
     }
+    public interface IAllocationFreeErrorLogger : Splat.ILogger
+    {
+        void Debug<TArgument>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Debug<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Error<TArgument>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Error<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Fatal<TArgument>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Fatal<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Info<TArgument>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Info<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Warn<TArgument>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Warn<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+    }
     public interface IAllocationFreeLogger : Splat.ILogger
     {
         bool IsDebugEnabled { get; }
@@ -163,8 +266,8 @@ namespace Splat
         bool IsFatalEnabled { get; }
         bool IsInfoEnabled { get; }
         bool IsWarnEnabled { get; }
-        void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Debug<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
         void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
         void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
@@ -173,8 +276,8 @@ namespace Splat
         void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
         void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
         void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
-        void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Error<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
         void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void Error<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
         void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
@@ -183,8 +286,8 @@ namespace Splat
         void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
         void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
         void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
-        void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Fatal<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
         void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
         void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
@@ -193,8 +296,8 @@ namespace Splat
         void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
         void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
         void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
-        void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Info<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
         void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void Info<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
         void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
@@ -203,8 +306,8 @@ namespace Splat
         void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
         void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
         void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
-        void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
-        void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument argument);
+        void Warn<TArgument1, TArgument2>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
         void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
         void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
         void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.LocalizableAttribute(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
@@ -233,6 +336,7 @@ namespace Splat
     {
         void Debug<T>(T value);
         void Debug<T>(System.IFormatProvider formatProvider, T value);
+        void Debug(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message);
         void Debug(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Debug([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Debug<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
@@ -241,9 +345,11 @@ namespace Splat
         void Debug<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Debug<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.ObsoleteAttribute("Use void Debug(Exception exception, [Localizable(false)] string message)")]
         void DebugException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Error<T>(T value);
         void Error<T>(System.IFormatProvider formatProvider, T value);
+        void Error(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message);
         void Error(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Error([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Error<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
@@ -252,9 +358,11 @@ namespace Splat
         void Error<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Error<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.ObsoleteAttribute("Use void Error(Exception exception, [Localizable(false)] string message)")]
         void ErrorException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Fatal<T>(T value);
         void Fatal<T>(System.IFormatProvider formatProvider, T value);
+        void Fatal(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message);
         void Fatal(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Fatal([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Fatal<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
@@ -263,9 +371,11 @@ namespace Splat
         void Fatal<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Fatal<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.ObsoleteAttribute("Use void Fatal(Exception exception, [Localizable(false)] string message)")]
         void FatalException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Info<T>(T value);
         void Info<T>(System.IFormatProvider formatProvider, T value);
+        void Info(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message);
         void Info(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Info([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Info<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
@@ -274,9 +384,11 @@ namespace Splat
         void Info<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Info<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.ObsoleteAttribute("Use void Info(Exception exception, [Localizable(false)] string message)")]
         void InfoException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
         void Warn<T>(T value);
         void Warn<T>(System.IFormatProvider formatProvider, T value);
+        void Warn(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message);
         void Warn(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, params object[] args);
         void Warn([System.ComponentModel.LocalizableAttribute(false)] string message);
         void Warn<T>([System.ComponentModel.LocalizableAttribute(false)] string message);
@@ -285,6 +397,7 @@ namespace Splat
         void Warn<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument argument);
         void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2);
         void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.LocalizableAttribute(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.ObsoleteAttribute("Use void Warn(Exception exception, [Localizable(false)] string message)")]
         void WarnException([System.ComponentModel.LocalizableAttribute(false)] string message, System.Exception exception);
     }
     public interface ILogger
@@ -639,6 +752,7 @@ namespace Splat
         public WrappingFullLogger(Splat.ILogger inner) { }
         public void Debug<T>(T value) { }
         public void Debug<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Debug(System.Exception exception, string message) { }
         public void Debug(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Debug(string message) { }
         public void Debug<T>(string message) { }
@@ -650,6 +764,7 @@ namespace Splat
         public void DebugException(string message, System.Exception exception) { }
         public void Error<T>(T value) { }
         public void Error<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Error(System.Exception exception, string message) { }
         public void Error(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Error(string message) { }
         public void Error<T>(string message) { }
@@ -661,6 +776,7 @@ namespace Splat
         public void ErrorException(string message, System.Exception exception) { }
         public void Fatal<T>(T value) { }
         public void Fatal<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Fatal(System.Exception exception, string message) { }
         public void Fatal(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Fatal(string message) { }
         public void Fatal<T>(string message) { }
@@ -672,6 +788,7 @@ namespace Splat
         public void FatalException(string message, System.Exception exception) { }
         public void Info<T>(T value) { }
         public void Info<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Info(System.Exception exception, string message) { }
         public void Info(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Info(string message) { }
         public void Info<T>(string message) { }
@@ -683,6 +800,7 @@ namespace Splat
         public void InfoException(string message, System.Exception exception) { }
         public void Warn<T>(T value) { }
         public void Warn<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Warn(System.Exception exception, string message) { }
         public void Warn(System.IFormatProvider formatProvider, string message, params object[] args) { }
         public void Warn(string message) { }
         public void Warn<T>(string message) { }

--- a/src/Splat.Tests/Logging/AllocationFreeLoggerBaseTests.cs
+++ b/src/Splat.Tests/Logging/AllocationFreeLoggerBaseTests.cs
@@ -15,8 +15,10 @@ namespace Splat.Tests.Logging
     {
         private static char[] NewLine => Environment.NewLine.ToCharArray();
 
+        private static Exception Exception => new Exception();
+
         /// <summary>
-        /// Tests that check the functionality of the debug method with four arguments.
+        /// Tests that check the functionality of the debug method with one argument.
         /// </summary>
         public class DebugOneArgumentMethod
         {
@@ -46,6 +48,42 @@ namespace Splat.Tests.Logging
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Debug("{0}", 1);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class DebugExceptionOneArgumentMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}", 1);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}", 1);
 
                 Assert.Null(inner.Value);
             }
@@ -88,6 +126,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class DebugExceptionTwoArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}", 1, 2);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}", 1, 2);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the debug method with six arguments.
         /// </summary>
         public class DebugThreeArgumentsMethod
@@ -118,6 +192,42 @@ namespace Splat.Tests.Logging
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Debug("{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class DebugExceptionThreeArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}", 1, 2, 3);
 
                 Assert.Null(inner.Value);
             }
@@ -160,6 +270,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class DebugExceptionFourArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the debug method with five arguments.
         /// </summary>
         public class DebugFiveArgumentsMethod
@@ -190,6 +336,42 @@ namespace Splat.Tests.Logging
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Debug("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class DebugExceptionFiveArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
 
                 Assert.Null(inner.Value);
             }
@@ -232,6 +414,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class DebugExceptionSixArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the debug method with seven arguments.
         /// </summary>
         public class DebugSevenArgumentsMethod
@@ -261,7 +479,43 @@ namespace Splat.Tests.Logging
                 inner.Level = LogLevel.Fatal;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+                logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class DebugExceptionSevenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
 
                 Assert.Null(inner.Value);
             }
@@ -270,7 +524,7 @@ namespace Splat.Tests.Logging
         /// <summary>
         /// Tests that check the functionality of the debug method with eight arguments.
         /// </summary>
-        public class DebugEighthArgumentsMethod
+        public class DebugEightArgumentsMethod
         {
             /// <summary>
             /// Tests the inner logger writes eight arguments.
@@ -297,7 +551,43 @@ namespace Splat.Tests.Logging
                 inner.Level = LogLevel.Fatal;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+                logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class DebugExceptionEightArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
 
                 Assert.Null(inner.Value);
             }
@@ -333,7 +623,43 @@ namespace Splat.Tests.Logging
                 inner.Level = LogLevel.Fatal;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class DebugExceptionNineArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8, 9", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
                 Assert.Null(inner.Value);
             }
@@ -369,7 +695,43 @@ namespace Splat.Tests.Logging
                 inner.Level = LogLevel.Fatal;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                logger.Debug("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class DebugExceptionTenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
                 Assert.Null(inner.Value);
             }
@@ -412,6 +774,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class InfoExceptionOneArgumentMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}", 1);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}", 1);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the info method with two arguments.
         /// </summary>
         public class InfoTwoArgumentsMethod
@@ -442,6 +840,42 @@ namespace Splat.Tests.Logging
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Info("{0}, {1}", 1, 2);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class InfoExceptionTwoArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}", 1, 2);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}", 1, 2);
 
                 Assert.Null(inner.Value);
             }
@@ -484,6 +918,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class InfoExceptionThreeArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the debug method with four arguments.
         /// </summary>
         public class InfoFourArgumentsMethod
@@ -514,6 +984,42 @@ namespace Splat.Tests.Logging
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Info("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class InfoExceptionFourArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}", 1, 2, 3, 4);
 
                 Assert.Null(inner.Value);
             }
@@ -556,6 +1062,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class InfoExceptionFiveArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the debug method with six arguments.
         /// </summary>
         public class InfoSixArgumentsMethod
@@ -586,6 +1128,42 @@ namespace Splat.Tests.Logging
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Info("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class InfoExceptionSixArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
 
                 Assert.Null(inner.Value);
             }
@@ -628,9 +1206,45 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class InfoExceptionSevenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Info;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Debug(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the info method with eight arguments.
         /// </summary>
-        public class InfoEighthArgumentsMethod
+        public class InfoEightArgumentsMethod
         {
             /// <summary>
             /// Tests the inner logger writes eight arguments.
@@ -658,6 +1272,42 @@ namespace Splat.Tests.Logging
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Info("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class InfoExceptionEightArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
 
                 Assert.Null(inner.Value);
             }
@@ -700,6 +1350,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class InfoExceptionNineArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8, 9", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the info method with ten arguments.
         /// </summary>
         public class InfoTenArgumentsMethod
@@ -730,6 +1416,42 @@ namespace Splat.Tests.Logging
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Info("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class InfoExceptionTenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
                 Assert.Null(inner.Value);
             }
@@ -772,6 +1494,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class WarnExceptionOneArgumentMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}", 1);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}", 1);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the warn method with two arguments.
         /// </summary>
         public class WarnTwoArgumentsMethod
@@ -802,6 +1560,42 @@ namespace Splat.Tests.Logging
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Warn("{0}, {1}", 1, 2);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class WarnExceptionTwoArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}, {1}", 1, 2);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}, {1}", 1, 2);
 
                 Assert.Null(inner.Value);
             }
@@ -844,6 +1638,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class WarnExceptionThreeArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the debug method with four arguments.
         /// </summary>
         public class WarnFourArgumentsMethod
@@ -874,6 +1704,42 @@ namespace Splat.Tests.Logging
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Info("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class WarnExceptionFourArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}", 1, 2, 3, 4);
 
                 Assert.Null(inner.Value);
             }
@@ -916,6 +1782,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class WarnExceptionFiveArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the debug method with six arguments.
         /// </summary>
         public class WarnSixArgumentsMethod
@@ -946,6 +1848,42 @@ namespace Splat.Tests.Logging
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Info("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class WarnExceptionSixArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info(Exception, "{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
 
                 Assert.Null(inner.Value);
             }
@@ -988,9 +1926,45 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class WarnExceptionSevenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the warn method with eighth arguments.
         /// </summary>
-        public class WarnEighthArgumentsMethod
+        public class WarnEightArgumentsMethod
         {
             /// <summary>
             /// Tests the inner logger writes eighth arguments.
@@ -1018,6 +1992,42 @@ namespace Splat.Tests.Logging
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Warn("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class WarnExceptionEightArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8);
 
                 Assert.Null(inner.Value);
             }
@@ -1060,6 +2070,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class WarnExceptionNineArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8, 9", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the warn method with ten arguments.
         /// </summary>
         public class WarnTenArgumentsMethod
@@ -1096,6 +2142,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class WarnExceptionTenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Warn(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the error method with one argument.
         /// </summary>
         public class ErrorOneArgumentMethod
@@ -1107,7 +2189,7 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Error;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Error("{0}", 1);
@@ -1132,6 +2214,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the error method with one argument.
+        /// </summary>
+        public class ErrorExceptionOneArgumentMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}", 1);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}", 1);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the error method with two arguments.
         /// </summary>
         public class ErrorTwoArgumentsMethod
@@ -1143,7 +2261,7 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Error;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Error("{0}, {1}", 1, 2);
@@ -1168,6 +2286,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the error method with one argument.
+        /// </summary>
+        public class ErrorExceptionTwoArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}", 1, 2);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}", 1, 2);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the error method with three arguments.
         /// </summary>
         public class ErrorThreeArgumentsMethod
@@ -1179,7 +2333,7 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Error;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Error("{0}, {1}, {2}", 1, 2, 3);
@@ -1204,7 +2358,43 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
-        /// Tests that check the functionality of the debug method with four arguments.
+        /// Tests that check the functionality of the error method with one argument.
+        /// </summary>
+        public class ErrorExceptionThreeArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}", 1, 2, 3);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the error method with four arguments.
         /// </summary>
         public class ErrorFourArgumentsMethod
         {
@@ -1215,7 +2405,7 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Error;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Error("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
@@ -1230,17 +2420,53 @@ namespace Splat.Tests.Logging
             public void Should_Not_Write_If_Higher_Level()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
+                inner.Level = LogLevel.Error;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Error("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+                logger.Info("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
 
                 Assert.Null(inner.Value);
             }
         }
 
         /// <summary>
-        /// Tests that check the functionality of the debug method with five arguments.
+        /// Tests that check the functionality of the error method with one argument.
+        /// </summary>
+        public class ErrorExceptionFourArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the error method with five arguments.
         /// </summary>
         public class ErrorFiveArgumentsMethod
         {
@@ -1251,7 +2477,7 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Error;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Error("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
@@ -1266,17 +2492,53 @@ namespace Splat.Tests.Logging
             public void Should_Not_Write_If_Higher_Level()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
+                inner.Level = LogLevel.Error;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Error("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+                logger.Info("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
 
                 Assert.Null(inner.Value);
             }
         }
 
         /// <summary>
-        /// Tests that check the functionality of the debug method with six arguments.
+        /// Tests that check the functionality of the error method with one argument.
+        /// </summary>
+        public class ErrorExceptionFiveArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the error method with six arguments.
         /// </summary>
         public class ErrorSixArgumentsMethod
         {
@@ -1287,7 +2549,7 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Error;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Error("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
@@ -1302,10 +2564,46 @@ namespace Splat.Tests.Logging
             public void Should_Not_Write_If_Higher_Level()
             {
                 var inner = new TextLogger();
+                inner.Level = LogLevel.Error;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Info("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the error method with one argument.
+        /// </summary>
+        public class ErrorExceptionSixArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
                 inner.Level = LogLevel.Fatal;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+                logger.Error(Exception, "{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
 
                 Assert.Null(inner.Value);
             }
@@ -1323,7 +2621,7 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Error;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
@@ -1348,9 +2646,45 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the error method with one argument.
+        /// </summary>
+        public class ErrorExceptionSevenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the error method with eighth arguments.
         /// </summary>
-        public class ErrorEighthArgumentsMethod
+        public class ErrorEightArgumentsMethod
         {
             /// <summary>
             /// Tests the inner logger writes eighth arguments.
@@ -1359,7 +2693,7 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Error;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
@@ -1384,6 +2718,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the error method with one argument.
+        /// </summary>
+        public class ErrorExceptionEightArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the error method with nine arguments.
         /// </summary>
         public class ErrorNineArgumentsMethod
@@ -1395,7 +2765,7 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Error;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
@@ -1413,7 +2783,43 @@ namespace Splat.Tests.Logging
                 inner.Level = LogLevel.Fatal;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the error method with one argument.
+        /// </summary>
+        public class ErrorExceptionNineArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8, 9", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
                 Assert.Null(inner.Value);
             }
@@ -1431,7 +2837,7 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Error;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Error("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
@@ -1456,6 +2862,42 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Tests that check the functionality of the error method with one argument.
+        /// </summary>
+        public class ErrorExceptionTenArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10", inner.Value.TrimEnd(NewLine));
+            }
+
+            /// <summary>
+            /// Tests the inner logger writes three arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Not_Write_If_Higher_Level()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Fatal;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Error(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+
+                Assert.Null(inner.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that check the functionality of the fatal method with one argument.
         /// </summary>
         public class FatalOneArgumentMethod
@@ -1467,27 +2909,33 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Fatal("{0}", 1);
 
                 Assert.Equal("1", inner.Value.TrimEnd(NewLine));
             }
+        }
 
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class FatalExceptionOneArgumentMethod
+        {
             /// <summary>
             /// Tests the inner logger writes three arguments.
             /// </summary>
             [Fact]
-            public void Should_Write_If_Lower_Level()
+            public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
+                inner.Level = LogLevel.Debug;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Fatal("{0}", 1);
+                logger.Fatal(Exception, "{0}", 1);
 
-                Assert.Equal("1", inner.Value.TrimEnd(NewLine));
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1503,27 +2951,33 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Fatal("{0}, {1}", 1, 2);
 
                 Assert.Equal("1, 2", inner.Value.TrimEnd(NewLine));
             }
+        }
 
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class FatalExceptionTwoArgumentsMethod
+        {
             /// <summary>
             /// Tests the inner logger writes three arguments.
             /// </summary>
             [Fact]
-            public void Should_Write_If_Lower_Level()
+            public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
+                inner.Level = LogLevel.Debug;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Fatal("{0}, {1}", 1, 2);
+                logger.Fatal(Exception, "{0}, {1}", 1, 2);
 
-                Assert.Equal("1, 2", inner.Value.TrimEnd(NewLine));
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1539,27 +2993,33 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Fatal("{0}, {1}, {2}", 1, 2, 3);
 
                 Assert.Equal("1, 2, 3", inner.Value.TrimEnd(NewLine));
             }
+        }
 
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class FatalExceptionThreeArgumentsMethod
+        {
             /// <summary>
             /// Tests the inner logger writes three arguments.
             /// </summary>
             [Fact]
-            public void Should_Write_If_Lower_Level()
+            public void Should_Write_Message()
             {
                 var inner = new TextLogger();
                 inner.Level = LogLevel.Debug;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Fatal("{0}, {1}, {2}", 1, 2, 3);
+                logger.Fatal(Exception, "{0}, {1}, {2}", 1, 2, 3);
 
-                Assert.Equal("1, 2, 3", inner.Value.TrimEnd(NewLine));
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1575,27 +3035,33 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Fatal("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
 
                 Assert.Equal("1, 2, 3, 4", inner.Value.TrimEnd(NewLine));
             }
+        }
 
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class FatalExceptionFourArgumentsMethod
+        {
             /// <summary>
             /// Tests the inner logger writes three arguments.
             /// </summary>
             [Fact]
-            public void Should_Write_If_Lower_Level()
+            public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
+                inner.Level = LogLevel.Debug;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Fatal("{0}, {1}, {2}, {3}", 1, 2, 3, 4);
+                logger.Info(Exception, "{0}, {1}, {2}, {3}", 1, 2, 3, 4);
 
-                Assert.Equal("1, 2, 3, 4", inner.Value.TrimEnd(NewLine));
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1611,27 +3077,33 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
 
                 Assert.Equal("1, 2, 3, 4, 5", inner.Value.TrimEnd(NewLine));
             }
+        }
 
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class FatalExceptionFiveArgumentsMethod
+        {
             /// <summary>
             /// Tests the inner logger writes three arguments.
             /// </summary>
             [Fact]
-            public void Should_Write_If_Lower_Level()
+            public void Should_Write_Message()
             {
                 var inner = new TextLogger();
                 inner.Level = LogLevel.Debug;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Fatal("{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
+                logger.Fatal(Exception, "{0}, {1}, {2}, {3}, {4}", 1, 2, 3, 4, 5);
 
-                Assert.Equal("1, 2, 3, 4, 5", inner.Value.TrimEnd(NewLine));
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1654,20 +3126,26 @@ namespace Splat.Tests.Logging
 
                 Assert.Equal("1, 2, 3, 4, 5, 6", inner.Value.TrimEnd(NewLine));
             }
+        }
 
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class FatalExceptionSixArgumentsMethod
+        {
             /// <summary>
             /// Tests the inner logger writes three arguments.
             /// </summary>
             [Fact]
-            public void Should_Write_If_Lower_Level()
+            public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
+                inner.Level = LogLevel.Debug;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
+                logger.Info(Exception, "{0}, {1}, {2}, {3}, {4}, {5}", 1, 2, 3, 4, 5, 6);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6", inner.Value.TrimEnd(NewLine));
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1683,22 +3161,7 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
-                var logger = new AllocationFreeLoggerBase(inner);
-
-                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
-
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7", inner.Value.TrimEnd(NewLine));
-            }
-
-            /// <summary>
-            /// Tests the inner logger writes seven arguments.
-            /// </summary>
-            [Fact]
-            public void Should_Write_If_Lower_Level()
-            {
-                var inner = new TextLogger();
-                inner.Level = LogLevel.Debug;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
@@ -1708,38 +3171,65 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
-        /// Tests that check the functionality of the fatal method with eighth arguments.
+        /// Tests that check the functionality of the debug method with one argument.
         /// </summary>
-        public class FatalEighthArgumentsMethod
+        public class FatalExceptionSevenArgumentsMethod
         {
             /// <summary>
-            /// Tests the inner logger writes eight arguments.
+            /// Tests the inner logger writes three arguments.
             /// </summary>
             [Fact]
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
+                inner.Level = LogLevel.Debug;
+                var logger = new AllocationFreeLoggerBase(inner);
+
+                logger.Fatal(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}", 1, 2, 3, 4, 5, 6, 7);
+
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7", inner.Value.TrimEnd(NewLine));
+            }
+        }
+
+        /// <summary>
+        /// Tests that check the functionality of the fatal method with eighth arguments.
+        /// </summary>
+        public class FatalEightArgumentsMethod
+        {
+            /// <summary>
+            /// Tests the inner logger writes eighth arguments.
+            /// </summary>
+            [Fact]
+            public void Should_Write_Message()
+            {
+                var inner = new TextLogger();
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
 
                 Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8", inner.Value.TrimEnd(NewLine));
             }
+        }
 
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class FatalExceptionEightArgumentsMethod
+        {
             /// <summary>
-            /// Tests the inner logger writes eight arguments.
+            /// Tests the inner logger writes three arguments.
             /// </summary>
             [Fact]
-            public void Should_Write_If_Lower_Level()
+            public void Should_Write_Message()
             {
                 var inner = new TextLogger();
                 inner.Level = LogLevel.Debug;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
+                logger.Fatal(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}", 1, 2, 3, 4, 5, 6, 7, 8);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8", inner.Value.TrimEnd(NewLine));
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1755,27 +3245,33 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
                 Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9", inner.Value.TrimEnd(NewLine));
             }
+        }
 
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class FatalExceptionNineArgumentsMethod
+        {
             /// <summary>
-            /// Tests the inner logger writes nine arguments.
+            /// Tests the inner logger writes three arguments.
             /// </summary>
             [Fact]
-            public void Should_Write_If_Lower_Level()
+            public void Should_Write_Message()
             {
                 var inner = new TextLogger();
                 inner.Level = LogLevel.Debug;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
+                logger.Fatal(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}", 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9", inner.Value.TrimEnd(NewLine));
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8, 9", inner.Value.TrimEnd(NewLine));
             }
         }
 
@@ -1791,27 +3287,33 @@ namespace Splat.Tests.Logging
             public void Should_Write_Message()
             {
                 var inner = new TextLogger();
-                inner.Level = LogLevel.Fatal;
+                inner.Level = LogLevel.Warn;
                 var logger = new AllocationFreeLoggerBase(inner);
 
                 logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
                 Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10", inner.Value.TrimEnd(NewLine));
             }
+        }
 
+        /// <summary>
+        /// Tests that check the functionality of the debug method with one argument.
+        /// </summary>
+        public class FatalExceptionTenArgumentsMethod
+        {
             /// <summary>
-            /// Tests the inner logger writes ten arguments.
+            /// Tests the inner logger writes three arguments.
             /// </summary>
             [Fact]
-            public void Should_Write_If_Lower_Level()
+            public void Should_Write_Message()
             {
                 var inner = new TextLogger();
                 inner.Level = LogLevel.Debug;
                 var logger = new AllocationFreeLoggerBase(inner);
 
-                logger.Fatal("{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+                logger.Fatal(Exception, "{0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8}, {9}", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 
-                Assert.Equal("1, 2, 3, 4, 5, 6, 7, 8, 9, 10", inner.Value.TrimEnd(NewLine));
+                Assert.Equal("System.Exception: Exception of type 'System.Exception' was thrown.: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10", inner.Value.TrimEnd(NewLine));
             }
         }
     }

--- a/src/Splat.Tests/Logging/NLogLoggerTests.cs
+++ b/src/Splat.Tests/Logging/NLogLoggerTests.cs
@@ -98,6 +98,25 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Test to make sure the error is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Debug_With_Exception_Should_Write_Exception_Message_And_Provided()
+        {
+            var nlogLoggerAndTarget = GetSplatNLogLoggerAndErrorTarget();
+            var logger = new WrappingFullLogger(nlogLoggerAndTarget.Logger);
+            var target = nlogLoggerAndTarget.MemoryTarget;
+
+            Assert.Equal(0, target.Logs.Count);
+
+            logger.Debug(new Exception(), "This is a test.");
+
+            Assert.Equal(1, target.Logs.Count);
+
+            Assert.Equal("This is a test. System.Exception: Exception of type 'System.Exception' was thrown.", target.Logs.First());
+        }
+
+        /// <summary>
         /// Test to make sure the generic type parameter is passed to the logger.
         /// </summary>
         [Fact]
@@ -133,6 +152,25 @@ namespace Splat.Tests.Logging
             Assert.Equal(1, memoryTarget.Logs.Count);
 
             Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test.", memoryTarget.Logs.First());
+        }
+
+        /// <summary>
+        /// Test to make sure the error is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Info_With_Exception_Should_Write_Exception_Message_And_Provided()
+        {
+            var nlogLoggerAndTarget = GetSplatNLogLoggerAndErrorTarget();
+            var logger = new WrappingFullLogger(nlogLoggerAndTarget.Logger);
+            var target = nlogLoggerAndTarget.MemoryTarget;
+
+            Assert.Equal(0, target.Logs.Count);
+
+            logger.Info(new Exception(), "This is a test.");
+
+            Assert.Equal(1, target.Logs.Count);
+
+            Assert.Equal("This is a test. System.Exception: Exception of type 'System.Exception' was thrown.", target.Logs.First());
         }
 
         /// <summary>
@@ -173,6 +211,25 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Test to make sure the error is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Warn_With_Exception_Should_Write_Exception_Message_And_Provided()
+        {
+            var nlogLoggerAndTarget = GetSplatNLogLoggerAndErrorTarget();
+            var logger = new WrappingFullLogger(nlogLoggerAndTarget.Logger);
+            var target = nlogLoggerAndTarget.MemoryTarget;
+
+            Assert.Equal(0, target.Logs.Count);
+
+            logger.Warn(new Exception(), "This is a test.");
+
+            Assert.Equal(1, target.Logs.Count);
+
+            Assert.Equal("This is a test. System.Exception: Exception of type 'System.Exception' was thrown.", target.Logs.First());
+        }
+
+        /// <summary>
         /// Test to make sure the generic type parameter is passed to the logger.
         /// </summary>
         [Fact]
@@ -206,6 +263,25 @@ namespace Splat.Tests.Logging
 
             Assert.Equal(1, memoryTarget.Logs.Count);
             Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test.", memoryTarget.Logs.First());
+        }
+
+        /// <summary>
+        /// Test to make sure the error is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Error_With_Exception_Should_Write_Exception_Message_And_Provided()
+        {
+            var nlogLoggerAndTarget = GetSplatNLogLoggerAndErrorTarget();
+            var logger = new WrappingFullLogger(nlogLoggerAndTarget.Logger);
+            var target = nlogLoggerAndTarget.MemoryTarget;
+
+            Assert.Equal(0, target.Logs.Count);
+
+            logger.Error(new Exception(), "This is a test.");
+
+            Assert.Equal(1, target.Logs.Count);
+
+            Assert.Equal("This is a test. System.Exception: Exception of type 'System.Exception' was thrown.", target.Logs.First());
         }
 
         /// <summary>
@@ -244,6 +320,25 @@ namespace Splat.Tests.Logging
             Assert.Equal($"{nameof(DummyObjectClass2)}: This is a test.", memoryTarget.Logs.First());
         }
 
+        /// <summary>
+        /// Test to make sure the error is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Fatal_With_Exception_Should_Write_Exception_Message_And_Provided()
+        {
+            var nlogLoggerAndTarget = GetSplatNLogLoggerAndErrorTarget();
+            var logger = new WrappingFullLogger(nlogLoggerAndTarget.Logger);
+            var target = nlogLoggerAndTarget.MemoryTarget;
+
+            Assert.Equal(0, target.Logs.Count);
+
+            logger.Fatal(new Exception(), "This is a test.");
+
+            Assert.Equal(1, target.Logs.Count);
+
+            Assert.Equal("This is a test. System.Exception: Exception of type 'System.Exception' was thrown.", target.Logs.First());
+        }
+
         private static (global::NLog.ILogger Logger, MemoryTarget MemoryTarget) GetActualNLogLoggerAndMemoryTarget()
         {
             var configuration = new LoggingConfiguration();
@@ -261,9 +356,32 @@ namespace Splat.Tests.Logging
             return (LogManager.GetCurrentClassLogger(), memoryTarget);
         }
 
+        private static (global::NLog.ILogger Logger, MemoryTarget MemoryTarget) GetActualNLogLoggerAndErrorTarget()
+        {
+            var configuration = new LoggingConfiguration();
+
+            var errorTarget = new MemoryTarget("ErrorTarget")
+            {
+                Layout = "${message} ${exception:format=tostring}"
+            };
+            configuration.AddTarget(errorTarget);
+            var errorLoggingRule = new LoggingRule("*", global::NLog.LogLevel.Trace, errorTarget);
+            configuration.LoggingRules.Add(errorLoggingRule);
+
+            LogManager.Configuration = configuration;
+
+            return (LogManager.GetCurrentClassLogger(), errorTarget);
+        }
+
         private static (ILogger Logger, MemoryTarget MemoryTarget) GetSplatNLogLoggerAndMemoryTarget()
         {
             var actualNLogLogger = GetActualNLogLoggerAndMemoryTarget();
+            return (new NLogLogger(actualNLogLogger.Logger), actualNLogLogger.MemoryTarget);
+        }
+
+        private static (ILogger Logger, MemoryTarget MemoryTarget) GetSplatNLogLoggerAndErrorTarget()
+        {
+            var actualNLogLogger = GetActualNLogLoggerAndErrorTarget();
             return (new NLogLogger(actualNLogLogger.Logger), actualNLogLogger.MemoryTarget);
         }
     }

--- a/src/Splat.Tests/Logging/SerilogLoggerTests.cs
+++ b/src/Splat.Tests/Logging/SerilogLoggerTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
+using Serilog.Exceptions;
 using Serilog.Formatting;
 using Splat.Serilog;
 using Splat.Tests.Mocks;
@@ -98,6 +99,25 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Test to make sure the error is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Debug_With_Exception_Should_Write_Exception_Message_And_Provided()
+        {
+            var serilogLoggerAndTarget = GetSplatSerilogLoggerAndTarget();
+            var logger = new WrappingFullLogger(serilogLoggerAndTarget.Logger);
+            var target = serilogLoggerAndTarget.Target;
+
+            Assert.Equal(0, target.Logs.Count);
+
+            logger.Debug(new Exception(), "This is a test.");
+
+            Assert.Equal(1, target.Logs.Count);
+
+            Assert.Equal("[(\"Type\": \"System.Exception\"), (\"HResult\": -2146233088), (\"Message\": \"Exception of type 'System.Exception' was thrown.\"), (\"Source\": null)]: This is a test.", target.Logs.First());
+        }
+
+        /// <summary>
         /// Test to make sure the generic type parameter is passed to the logger.
         /// </summary>
         [Fact]
@@ -133,6 +153,25 @@ namespace Splat.Tests.Logging
             Assert.Equal(1, target.Logs.Count);
 
             Assert.Equal($"{typeof(DummyObjectClass2).FullName}: This is a test.", target.Logs.First());
+        }
+
+        /// <summary>
+        /// Test to make sure the error is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Info_With_Exception_Should_Write_Exception_Message_And_Provided()
+        {
+            var serilogLoggerAndTarget = GetSplatSerilogLoggerAndTarget();
+            var logger = new WrappingFullLogger(serilogLoggerAndTarget.Logger);
+            var target = serilogLoggerAndTarget.Target;
+
+            Assert.Equal(0, target.Logs.Count);
+
+            logger.Info(new Exception(), "This is a test.");
+
+            Assert.Equal(1, target.Logs.Count);
+
+            Assert.Equal("[(\"Type\": \"System.Exception\"), (\"HResult\": -2146233088), (\"Message\": \"Exception of type 'System.Exception' was thrown.\"), (\"Source\": null)]: This is a test.", target.Logs.First());
         }
 
         /// <summary>
@@ -173,6 +212,25 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Test to make sure the error is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Warn_With_Exception_Should_Write_Exception_Message_And_Provided()
+        {
+            var serilogLoggerAndTarget = GetSplatSerilogLoggerAndTarget();
+            var logger = new WrappingFullLogger(serilogLoggerAndTarget.Logger);
+            var target = serilogLoggerAndTarget.Target;
+
+            Assert.Equal(0, target.Logs.Count);
+
+            logger.Warn(new Exception(), "This is a test.");
+
+            Assert.Equal(1, target.Logs.Count);
+
+            Assert.Equal("[(\"Type\": \"System.Exception\"), (\"HResult\": -2146233088), (\"Message\": \"Exception of type 'System.Exception' was thrown.\"), (\"Source\": null)]: This is a test.", target.Logs.First());
+        }
+
+        /// <summary>
         /// Test to make sure the generic type parameter is passed to the logger.
         /// </summary>
         [Fact]
@@ -209,6 +267,25 @@ namespace Splat.Tests.Logging
         }
 
         /// <summary>
+        /// Test to make sure the error is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Error_With_Exception_Should_Write_Exception_Message_And_Provided()
+        {
+            var serilogLoggerAndTarget = GetSplatSerilogLoggerAndTarget();
+            var logger = new WrappingFullLogger(serilogLoggerAndTarget.Logger);
+            var target = serilogLoggerAndTarget.Target;
+
+            Assert.Equal(0, target.Logs.Count);
+
+            logger.Error(new Exception(), "This is a test.");
+
+            Assert.Equal(1, target.Logs.Count);
+
+            Assert.Equal("[(\"Type\": \"System.Exception\"), (\"HResult\": -2146233088), (\"Message\": \"Exception of type 'System.Exception' was thrown.\"), (\"Source\": null)]: This is a test.", target.Logs.First());
+        }
+
+        /// <summary>
         /// Test to make sure the generic type parameter is passed to the logger.
         /// </summary>
         [Fact]
@@ -242,6 +319,25 @@ namespace Splat.Tests.Logging
 
             Assert.Equal(1, target.Logs.Count);
             Assert.Equal($"{typeof(DummyObjectClass2).FullName}: This is a test.", target.Logs.First());
+        }
+
+        /// <summary>
+        /// Test to make sure the error is passed to the logger.
+        /// </summary>
+        [Fact]
+        public void Fatal_With_Exception_Should_Write_Exception_Message_And_Provided()
+        {
+            var serilogLoggerAndTarget = GetSplatSerilogLoggerAndTarget();
+            var logger = new WrappingFullLogger(serilogLoggerAndTarget.Logger);
+            var target = serilogLoggerAndTarget.Target;
+
+            Assert.Equal(0, target.Logs.Count);
+
+            logger.Fatal(new Exception(), "This is a test.");
+
+            Assert.Equal(1, target.Logs.Count);
+
+            Assert.Equal("[(\"Type\": \"System.Exception\"), (\"HResult\": -2146233088), (\"Message\": \"Exception of type 'System.Exception' was thrown.\"), (\"Source\": null)]: This is a test.", target.Logs.First());
         }
 
         /// <summary>
@@ -308,8 +404,12 @@ namespace Splat.Tests.Logging
             var messages = new LogTarget();
 
             var log = new LoggerConfiguration()
-                .MinimumLevel.Debug()
-                .WriteTo.Sink(messages)
+                .Enrich
+                .WithExceptionDetails()
+                .MinimumLevel
+                .Debug()
+                .WriteTo
+                .Sink(messages)
                 .CreateLogger();
 
             return (log, messages);
@@ -327,9 +427,13 @@ namespace Splat.Tests.Logging
 
             public void Emit(LogEvent logEvent)
             {
-                if (logEvent.Properties.TryGetValue("SourceContext", out var value))
+                if (logEvent.Properties.TryGetValue("SourceContext", out var context))
                 {
-                    Logs.Add(value.ToString().Trim('"').Trim() + ": " + logEvent.RenderMessage());
+                    Logs.Add(context.ToString().Trim('"').Trim() + ": " + logEvent.RenderMessage());
+                }
+                else if (logEvent.Properties.TryGetValue("ExceptionDetail", out var error))
+                {
+                    Logs.Add(error.ToString().Trim('"').Trim() + ": " + logEvent.RenderMessage());
                 }
                 else
                 {

--- a/src/Splat.Tests/Mocks/TextLogger.cs
+++ b/src/Splat.Tests/Mocks/TextLogger.cs
@@ -50,7 +50,7 @@ namespace Splat.Tests.Mocks
         /// <inheritdoc />
         public void Write(Exception exception, string message, LogLevel logLevel)
         {
-            Write($"{message} - {exception}", logLevel);
+            Write($"{exception}: {message}", logLevel);
         }
 
         /// <inheritdoc />

--- a/src/Splat.Tests/Splat.Tests.csproj
+++ b/src/Splat.Tests/Splat.Tests.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Serilog.Exceptions" Version="5.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Splat.Log4Net\Splat.Log4Net.csproj" />
     <ProjectReference Include="..\Splat.Microsoft.Extensions.Logging\Splat.Microsoft.Extensions.Logging.csproj" />
     <ProjectReference Include="..\Splat.NLog\Splat.NLog.csproj" />

--- a/src/Splat/Logging/AllocationFreeLoggerBase.cs
+++ b/src/Splat/Logging/AllocationFreeLoggerBase.cs
@@ -19,7 +19,7 @@ namespace Splat
     /// </summary>
     /// <seealso cref="IAllocationFreeLogger" />
     [SuppressMessage("Naming", "CA1716: Do not use built in identifiers", Justification = "Deliberate usage")]
-    public class AllocationFreeLoggerBase : IAllocationFreeLogger
+    public class AllocationFreeLoggerBase : IAllocationFreeLogger, IAllocationFreeErrorLogger
     {
         private readonly ILogger _inner;
 
@@ -51,26 +51,48 @@ namespace Splat
         public bool IsFatalEnabled => Level <= LogLevel.Fatal;
 
         /// <inheritdoc />
-        public virtual void Debug<TArgument>([Localizable(false)] string message, TArgument argument)
+        public virtual void Debug<TArgument>([Localizable(false)] string messageFormat, TArgument argument)
         {
             if (IsDebugEnabled)
             {
-                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Debug);
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, messageFormat, argument), LogLevel.Debug);
             }
         }
 
         /// <inheritdoc />
-        public virtual void Debug<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
+        public virtual void Debug<TArgument>(Exception exception, string messageFormat, TArgument argument)
         {
             if (IsDebugEnabled)
             {
-                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Debug);
+                _inner.Write(exception, string.Format(CultureInfo.InvariantCulture, messageFormat, argument), LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Debug<TArgument1, TArgument2>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2), LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(exception, string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2), LogLevel.Debug);
             }
         }
 
         /// <inheritdoc />
         public virtual void Debug<TArgument1, TArgument2, TArgument3>(
-            [Localizable(false)] string message,
+            [Localizable(false)] string messageFormat,
             TArgument1 argument1,
             TArgument2 argument2,
             TArgument3 argument3)
@@ -78,7 +100,24 @@ namespace Splat
             if (IsDebugEnabled)
             {
                 _inner.Write(
-                    string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3),
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2, argument3),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2, TArgument3>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2, argument3),
                     LogLevel.Debug);
             }
         }
@@ -106,6 +145,30 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
             [Localizable(false)] string messageFormat,
             TArgument1 argument1,
@@ -117,6 +180,32 @@ namespace Splat
             if (IsDebugEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -156,6 +245,34 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
             string messageFormat,
             TArgument1 argument1,
@@ -169,6 +286,36 @@ namespace Splat
             if (IsDebugEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -214,6 +361,38 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
             string messageFormat,
             TArgument1 argument1,
@@ -229,6 +408,40 @@ namespace Splat
             if (IsDebugEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9),
+                    LogLevel.Debug);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9)
+        {
+            if (IsDebugEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -280,26 +493,90 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public virtual void Info<TArgument>([Localizable(false)] string message, TArgument argument)
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9,
+            TArgument10 argument10)
         {
-            if (IsInfoEnabled)
+            if (IsDebugEnabled)
             {
-                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Info);
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9,
+                        argument10),
+                    LogLevel.Debug);
             }
         }
 
         /// <inheritdoc />
-        public virtual void Info<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
+        public virtual void Info<TArgument>([Localizable(false)] string messageFormat, TArgument argument)
         {
             if (IsInfoEnabled)
             {
-                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Info);
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, messageFormat, argument), LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Info<TArgument>(Exception exception, string messageFormat, TArgument argument)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Info<TArgument1, TArgument2>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2), LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Info<TArgument1, TArgument2>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2),
+                    LogLevel.Info);
             }
         }
 
         /// <inheritdoc />
         public virtual void Info<TArgument1, TArgument2, TArgument3>(
-            [Localizable(false)] string message,
+            [Localizable(false)] string messageFormat,
             TArgument1 argument1,
             TArgument2 argument2,
             TArgument3 argument3)
@@ -307,7 +584,24 @@ namespace Splat
             if (IsInfoEnabled)
             {
                 _inner.Write(
-                    string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3),
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2, argument3),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Info<TArgument1, TArgument2, TArgument3>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2, argument3),
                     LogLevel.Info);
             }
         }
@@ -329,6 +623,30 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
             [Localizable(false)] string messageFormat,
             TArgument1 argument1,
@@ -340,6 +658,32 @@ namespace Splat
             if (IsInfoEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -379,6 +723,34 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
             [Localizable(false)] string messageFormat,
             TArgument1 argument1,
@@ -392,6 +764,36 @@ namespace Splat
             if (IsInfoEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -437,6 +839,38 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
             [Localizable(false)] string messageFormat,
             TArgument1 argument1,
@@ -452,6 +886,40 @@ namespace Splat
             if (IsInfoEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9),
+                    LogLevel.Info);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9)
+        {
+            if (IsInfoEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -504,26 +972,85 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public virtual void Warn<TArgument>([Localizable(false)] string message, TArgument argument)
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9,
+            TArgument10>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9,
+            TArgument10 argument10)
         {
-            if (IsWarnEnabled)
+            if (IsInfoEnabled)
             {
-                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Warn);
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9,
+                        argument10),
+                    LogLevel.Info);
             }
         }
 
         /// <inheritdoc />
-        public virtual void Warn<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
+        public virtual void Warn<TArgument>([Localizable(false)] string messageFormat, TArgument argument)
         {
             if (IsWarnEnabled)
             {
-                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Warn);
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, messageFormat, argument), LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Warn<TArgument>(Exception exception, string messageFormat, TArgument argument)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(exception, string.Format(CultureInfo.InvariantCulture, messageFormat, argument), LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Warn<TArgument1, TArgument2>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2), LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(exception, string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2), LogLevel.Warn);
             }
         }
 
         /// <inheritdoc />
         public virtual void Warn<TArgument1, TArgument2, TArgument3>(
-            [Localizable(false)] string message,
+            [Localizable(false)] string messageFormat,
             TArgument1 argument1,
             TArgument2 argument2,
             TArgument3 argument3)
@@ -531,7 +1058,24 @@ namespace Splat
             if (IsWarnEnabled)
             {
                 _inner.Write(
-                    string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3),
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2, argument3),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2, TArgument3>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2, argument3),
                     LogLevel.Warn);
             }
         }
@@ -553,6 +1097,30 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
             [Localizable(false)] string messageFormat,
             TArgument1 argument1,
@@ -564,6 +1132,32 @@ namespace Splat
             if (IsWarnEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -603,6 +1197,34 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
             [Localizable(false)] string messageFormat,
             TArgument1 argument1,
@@ -616,6 +1238,36 @@ namespace Splat
             if (IsWarnEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -661,6 +1313,38 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
             [Localizable(false)] string messageFormat,
             TArgument1 argument1,
@@ -676,6 +1360,40 @@ namespace Splat
             if (IsWarnEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9),
+                    LogLevel.Warn);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9)
+        {
+            if (IsWarnEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -728,26 +1446,95 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public virtual void Error<TArgument>([Localizable(false)] string message, TArgument argument)
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9,
+            TArgument10>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9,
+            TArgument10 argument10)
         {
-            if (IsErrorEnabled)
+            if (IsWarnEnabled)
             {
-                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Error);
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9,
+                        argument10),
+                    LogLevel.Warn);
             }
         }
 
         /// <inheritdoc />
-        public virtual void Error<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
+        public virtual void Error<TArgument>([Localizable(false)] string messageFormat, TArgument argument)
         {
             if (IsErrorEnabled)
             {
-                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Error);
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, messageFormat, argument), LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Error<TArgument>(Exception exception, string messageFormat, TArgument argument)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Error<TArgument1, TArgument2>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2), LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Error<TArgument1, TArgument2>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2),
+                    LogLevel.Error);
             }
         }
 
         /// <inheritdoc />
         public virtual void Error<TArgument1, TArgument2, TArgument3>(
-            [Localizable(false)] string message,
+            [Localizable(false)] string messageFormat,
             TArgument1 argument1,
             TArgument2 argument2,
             TArgument3 argument3)
@@ -755,7 +1542,29 @@ namespace Splat
             if (IsErrorEnabled)
             {
                 _inner.Write(
-                    string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3),
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2, argument3),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Error<TArgument1, TArgument2, TArgument3>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3),
                     LogLevel.Error);
             }
         }
@@ -777,6 +1586,30 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
             [Localizable(false)] string messageFormat,
             TArgument1 argument1,
@@ -788,6 +1621,32 @@ namespace Splat
             if (IsErrorEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -827,6 +1686,34 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
             [Localizable(false)] string messageFormat,
             TArgument1 argument1,
@@ -840,6 +1727,36 @@ namespace Splat
             if (IsErrorEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -885,6 +1802,38 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
             [Localizable(false)] string messageFormat,
             TArgument1 argument1,
@@ -900,6 +1849,40 @@ namespace Splat
             if (IsErrorEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9),
+                    LogLevel.Error);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9)
+        {
+            if (IsErrorEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -951,26 +1934,94 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public virtual void Fatal<TArgument>([Localizable(false)] string message, TArgument argument)
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9,
+            TArgument10 argument10)
         {
-            if (IsFatalEnabled)
+            if (IsErrorEnabled)
             {
-                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument), LogLevel.Fatal);
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9,
+                        argument10),
+                    LogLevel.Error);
             }
         }
 
         /// <inheritdoc />
-        public virtual void Fatal<TArgument1, TArgument2>([Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2)
+        public virtual void Fatal<TArgument>([Localizable(false)] string messageFormat, TArgument argument)
         {
             if (IsFatalEnabled)
             {
-                _inner.Write(string.Format(CultureInfo.InvariantCulture, message, argument1, argument2), LogLevel.Fatal);
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, messageFormat, argument), LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Fatal<TArgument>(Exception exception, string messageFormat, TArgument argument)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public virtual void Fatal<TArgument1, TArgument2>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2), LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2),
+                    LogLevel.Fatal);
             }
         }
 
         /// <inheritdoc />
         public virtual void Fatal<TArgument1, TArgument2, TArgument3>(
-            [Localizable(false)] string message,
+            [Localizable(false)] string messageFormat,
             TArgument1 argument1,
             TArgument2 argument2,
             TArgument3 argument3)
@@ -978,7 +2029,29 @@ namespace Splat
             if (IsFatalEnabled)
             {
                 _inner.Write(
-                    string.Format(CultureInfo.InvariantCulture, message, argument1, argument2, argument3),
+                    string.Format(CultureInfo.InvariantCulture, messageFormat, argument1, argument2, argument3),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2, TArgument3>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3),
                     LogLevel.Fatal);
             }
         }
@@ -1000,6 +2073,30 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
             [Localizable(false)] string messageFormat,
             TArgument1 argument1,
@@ -1011,6 +2108,32 @@ namespace Splat
             if (IsFatalEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -1050,6 +2173,34 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
             [Localizable(false)] string messageFormat,
             TArgument1 argument1,
@@ -1063,6 +2214,36 @@ namespace Splat
             if (IsFatalEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -1108,6 +2289,38 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
         public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
             [Localizable(false)] string messageFormat,
             TArgument1 argument1,
@@ -1123,6 +2336,40 @@ namespace Splat
             if (IsFatalEnabled)
             {
                 _inner.Write(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9),
+                    LogLevel.Fatal);
+            }
+        }
+
+        /// <inheritdoc />
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9)
+        {
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    exception,
                     string.Format(
                         CultureInfo.InvariantCulture,
                         messageFormat,
@@ -1174,27 +2421,64 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public void Write([Localizable(false)] string message, LogLevel logLevel)
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9,
+            TArgument10>(
+            Exception exception,
+            string messageFormat,
+            TArgument1 argument1,
+            TArgument2 argument2,
+            TArgument3 argument3,
+            TArgument4 argument4,
+            TArgument5 argument5,
+            TArgument6 argument6,
+            TArgument7 argument7,
+            TArgument8 argument8,
+            TArgument9 argument9,
+            TArgument10 argument10)
         {
-            _inner.Write(message, logLevel);
+            if (IsFatalEnabled)
+            {
+                _inner.Write(
+                    exception,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        messageFormat,
+                        argument1,
+                        argument2,
+                        argument3,
+                        argument4,
+                        argument5,
+                        argument6,
+                        argument7,
+                        argument8,
+                        argument9,
+                        argument10),
+                    LogLevel.Fatal);
+            }
         }
 
         /// <inheritdoc />
-        public void Write(Exception exception, [Localizable(false)] string message, LogLevel logLevel)
+        public void Write([Localizable(false)] string messageFormat, LogLevel logLevel)
         {
-            _inner.Write(exception, message, logLevel);
+            _inner.Write(messageFormat, logLevel);
         }
 
         /// <inheritdoc />
-        public void Write([Localizable(false)] string message, [Localizable(false)] Type type, LogLevel logLevel)
+        public void Write(Exception exception, [Localizable(false)] string messageFormat, LogLevel logLevel)
         {
-            _inner.Write(message, type, logLevel);
+            _inner.Write(exception, messageFormat, logLevel);
         }
 
         /// <inheritdoc />
-        public void Write(Exception exception, [Localizable(false)] string message, [Localizable(false)] Type type, LogLevel logLevel)
+        public void Write([Localizable(false)] string messageFormat, [Localizable(false)] Type type, LogLevel logLevel)
         {
-            _inner.Write(exception, message, type, logLevel);
+            _inner.Write(messageFormat, type, logLevel);
+        }
+
+        /// <inheritdoc />
+        public void Write(Exception exception, [Localizable(false)] string messageFormat, [Localizable(false)] Type type, LogLevel logLevel)
+        {
+            _inner.Write(exception, messageFormat, type, logLevel);
         }
     }
 }

--- a/src/Splat/Logging/IAllocationFreeErrorLogger.cs
+++ b/src/Splat/Logging/IAllocationFreeErrorLogger.cs
@@ -1,64 +1,43 @@
-// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Splat
 {
     /// <summary>
-    /// An allocation free logger which wraps all the possible logging methods available.
+    /// An allocation free exception logger which wraps all the possible logging methods available.
     /// Often not needed for your own loggers.
     /// A <see cref="WrappingFullLogger"/> will wrap simple loggers into a full logger.
     /// </summary>
-    [SuppressMessage("Naming", "CA1716: Do not use built in identifiers", Justification = "Deliberate usage")]
-    public interface IAllocationFreeLogger : ILogger
+    public interface IAllocationFreeErrorLogger : ILogger
     {
         /// <summary>
-        /// Gets a value indicating whether the logger currently emits debug logs.
-        /// </summary>
-        bool IsDebugEnabled { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the logger currently emits information logs.
-        /// </summary>
-        bool IsInfoEnabled { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the logger currently emits warning logs.
-        /// </summary>
-        bool IsWarnEnabled { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the logger currently emits error logs.
-        /// </summary>
-        bool IsErrorEnabled { get; }
-
-        /// <summary>
-        /// Gets a value indicating whether the logger currently emits fatal logs.
-        /// </summary>
-        bool IsFatalEnabled { get; }
-
-        /// <summary>
         /// Emits a message using formatting to the debug log.
         /// </summary>
         /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument">The argument for formatting purposes.</param>
-        void Debug<TArgument>([Localizable(false)] string messageFormat, TArgument argument);
+        void Debug<TArgument>(Exception exception, [Localizable(false)] string messageFormat, TArgument argument);
 
         /// <summary>
         /// Emits a message using formatting to the debug log.
         /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
-        void Debug<TArgument1, TArgument2>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument1, TArgument2>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
 
         /// <summary>
         /// Emits a message using formatting to the debug log.
@@ -66,11 +45,12 @@ namespace Splat
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
-        void Debug<TArgument1, TArgument2, TArgument3>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Debug<TArgument1, TArgument2, TArgument3>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
         /// <summary>
         /// Emits a message using formatting to the debug log.
@@ -79,12 +59,13 @@ namespace Splat
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
-        void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
 
         /// <summary>
         /// Emits a message using formatting to the debug log.
@@ -94,13 +75,14 @@ namespace Splat
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
-        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
 
         /// <summary>
         /// Emits a message using formatting to the debug log.
@@ -111,6 +93,7 @@ namespace Splat
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -118,7 +101,7 @@ namespace Splat
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
-        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
 
         /// <summary>
         /// Emits a message using formatting to the debug log.
@@ -130,6 +113,7 @@ namespace Splat
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -138,7 +122,7 @@ namespace Splat
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
-        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
 
         /// <summary>
         /// Emits a message using formatting to the debug log.
@@ -151,6 +135,7 @@ namespace Splat
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -160,7 +145,7 @@ namespace Splat
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
-        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
 
         /// <summary>
         /// Emits a message using formatting to the debug log.
@@ -174,6 +159,7 @@ namespace Splat
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -184,7 +170,7 @@ namespace Splat
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
         /// <param name="argument9">The ninth argument for formatting purposes.</param>
-        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
 
         /// <summary>
         /// Emits a message using formatting to the debug log.
@@ -199,6 +185,7 @@ namespace Splat
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument10">The type of the tenth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -210,25 +197,27 @@ namespace Splat
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
         /// <param name="argument9">The ninth argument for formatting purposes.</param>
         /// <param name="argument10">The tenth argument for formatting purposes.</param>
-        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
 
         /// <summary>
         /// Emits a message using formatting to the info log.
         /// </summary>
         /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument">The argument for formatting purposes.</param>
-        void Info<TArgument>([Localizable(false)] string messageFormat, TArgument argument);
+        void Info<TArgument>(Exception exception, [Localizable(false)] string messageFormat, TArgument argument);
 
         /// <summary>
         /// Emits a message using formatting to the info log.
         /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
-        void Info<TArgument1, TArgument2>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument1, TArgument2>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
 
         /// <summary>
         /// Emits a message using formatting to the info log.
@@ -236,11 +225,12 @@ namespace Splat
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
-        void Info<TArgument1, TArgument2, TArgument3>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Info<TArgument1, TArgument2, TArgument3>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
         /// <summary>
         /// Emits a message using formatting to the info log.
@@ -249,12 +239,13 @@ namespace Splat
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
-        void Info<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
 
         /// <summary>
         /// Logs a info message with the provided message format and values.
@@ -264,13 +255,14 @@ namespace Splat
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
-        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
 
         /// <summary>
         /// Logs a info message with the provided message format and values.
@@ -281,6 +273,7 @@ namespace Splat
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -288,7 +281,7 @@ namespace Splat
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
-        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
 
         /// <summary>
         /// Emits a message using formatting to the info log.
@@ -300,6 +293,7 @@ namespace Splat
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -308,7 +302,7 @@ namespace Splat
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
-        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
 
         /// <summary>
         /// Emits a message using formatting to the info log.
@@ -321,6 +315,7 @@ namespace Splat
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -330,7 +325,7 @@ namespace Splat
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
-        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
 
         /// <summary>
         /// Emits a message using formatting to the info log.
@@ -344,6 +339,7 @@ namespace Splat
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -354,7 +350,7 @@ namespace Splat
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
         /// <param name="argument9">The ninth argument for formatting purposes.</param>
-        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
 
         /// <summary>
         /// Emits a message using formatting to the info log.
@@ -369,6 +365,7 @@ namespace Splat
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument10">The type of the tenth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -380,25 +377,27 @@ namespace Splat
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
         /// <param name="argument9">The ninth argument for formatting purposes.</param>
         /// <param name="argument10">The tenth argument for formatting purposes.</param>
-        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
 
         /// <summary>
         /// Emits a message using formatting to the warning log.
         /// </summary>
         /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument">The argument for formatting purposes.</param>
-        void Warn<TArgument>([Localizable(false)] string messageFormat, TArgument argument);
+        void Warn<TArgument>(Exception exception, [Localizable(false)] string messageFormat, TArgument argument);
 
         /// <summary>
         /// Emits a message using formatting to the warning log.
         /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
-        void Warn<TArgument1, TArgument2>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument1, TArgument2>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
 
         /// <summary>
         /// Emits a message using formatting to the warning log.
@@ -406,11 +405,12 @@ namespace Splat
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
-        void Warn<TArgument1, TArgument2, TArgument3>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Warn<TArgument1, TArgument2, TArgument3>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
         /// <summary>
         /// Emits a message using formatting to the warning log.
@@ -419,12 +419,13 @@ namespace Splat
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
-        void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
 
         /// <summary>
         /// Emits a message using formatting to the warning log.
@@ -434,13 +435,14 @@ namespace Splat
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
-        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
 
         /// <summary>
         /// Emits a message using formatting to the warning log.
@@ -451,6 +453,7 @@ namespace Splat
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -458,7 +461,7 @@ namespace Splat
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
-        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
 
         /// <summary>
         /// Emits a message using formatting to the warn log.
@@ -470,6 +473,7 @@ namespace Splat
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -478,7 +482,7 @@ namespace Splat
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
-        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
 
         /// <summary>
         /// Emits a message using formatting to the warn log.
@@ -491,6 +495,7 @@ namespace Splat
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -500,7 +505,7 @@ namespace Splat
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
-        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
 
         /// <summary>
         /// Emits a message using formatting to the warn log.
@@ -514,6 +519,7 @@ namespace Splat
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -524,7 +530,7 @@ namespace Splat
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
         /// <param name="argument9">The ninth argument for formatting purposes.</param>
-        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
 
         /// <summary>
         /// Emits a message using formatting to the warn log.
@@ -539,6 +545,7 @@ namespace Splat
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument10">The type of the tenth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -550,25 +557,27 @@ namespace Splat
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
         /// <param name="argument9">The ninth argument for formatting purposes.</param>
         /// <param name="argument10">The tenth argument for formatting purposes.</param>
-        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
 
         /// <summary>
         /// Emits a message using formatting to the error log.
         /// </summary>
         /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument">The argument for formatting purposes.</param>
-        void Error<TArgument>([Localizable(false)] string messageFormat, TArgument argument);
+        void Error<TArgument>(Exception exception, [Localizable(false)] string messageFormat, TArgument argument);
 
         /// <summary>
         /// Emits a message using formatting to the error log.
         /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
-        void Error<TArgument1, TArgument2>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument1, TArgument2>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
 
         /// <summary>
         /// Emits a message using formatting to the error log.
@@ -576,11 +585,12 @@ namespace Splat
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
-        void Error<TArgument1, TArgument2, TArgument3>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Error<TArgument1, TArgument2, TArgument3>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
         /// <summary>
         /// Emits a message using formatting to the error log.
@@ -589,12 +599,13 @@ namespace Splat
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
-        void Error<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
 
         /// <summary>
         /// Emits a message using formatting to the error log.
@@ -604,13 +615,14 @@ namespace Splat
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
-        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
 
         /// <summary>
         /// Emits a message using formatting to the error log.
@@ -621,6 +633,7 @@ namespace Splat
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -628,7 +641,7 @@ namespace Splat
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
-        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
 
         /// <summary>
         /// Emits a message using formatting to the error log.
@@ -640,6 +653,7 @@ namespace Splat
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -648,7 +662,7 @@ namespace Splat
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
-        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
 
         /// <summary>
         /// Emits a message using formatting to the error log.
@@ -661,6 +675,7 @@ namespace Splat
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -670,7 +685,7 @@ namespace Splat
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
-        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
 
         /// <summary>
         /// Emits a message using formatting to the error log.
@@ -684,6 +699,7 @@ namespace Splat
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -694,7 +710,7 @@ namespace Splat
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
         /// <param name="argument9">The ninth argument for formatting purposes.</param>
-        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
 
         /// <summary>
         /// Emits a message using formatting to the error log.
@@ -709,6 +725,7 @@ namespace Splat
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument10">The type of the tenth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -720,25 +737,27 @@ namespace Splat
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
         /// <param name="argument9">The ninth argument for formatting purposes.</param>
         /// <param name="argument10">The tenth argument for formatting purposes.</param>
-        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
 
         /// <summary>
         /// Emits a message using formatting to the fatal log.
         /// </summary>
         /// <typeparam name="TArgument">The type of the argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument">The argument for formatting purposes.</param>
-        void Fatal<TArgument>([Localizable(false)] string messageFormat, TArgument argument);
+        void Fatal<TArgument>(Exception exception, [Localizable(false)] string messageFormat, TArgument argument);
 
         /// <summary>
         /// Emits a message using formatting to the fatal log.
         /// </summary>
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
-        void Fatal<TArgument1, TArgument2>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument1, TArgument2>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
 
         /// <summary>
         /// Emits a message using formatting to the fatal log.
@@ -746,11 +765,12 @@ namespace Splat
         /// <typeparam name="TArgument1">The type of the first argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
-        void Fatal<TArgument1, TArgument2, TArgument3>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Fatal<TArgument1, TArgument2, TArgument3>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
 
         /// <summary>
         /// Emits a message using formatting to the fatal log.
@@ -759,12 +779,13 @@ namespace Splat
         /// <typeparam name="TArgument2">The type of the second argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
-        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
 
         /// <summary>
         /// Emits a message using formatting to the fatal log.
@@ -774,13 +795,14 @@ namespace Splat
         /// <typeparam name="TArgument3">The type of the third argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
         /// <param name="argument3">The third argument for formatting purposes.</param>
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
-        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
 
         /// <summary>
         /// Emits a message using formatting to the fatal log.
@@ -791,6 +813,7 @@ namespace Splat
         /// <typeparam name="TArgument4">The type of the fourth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -798,7 +821,7 @@ namespace Splat
         /// <param name="argument4">The fourth argument for formatting purposes.</param>
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
-        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
 
         /// <summary>
         /// Emits a message using formatting to the fatal log.
@@ -810,6 +833,7 @@ namespace Splat
         /// <typeparam name="TArgument5">The type of the fifth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -818,7 +842,7 @@ namespace Splat
         /// <param name="argument5">The fifth argument for formatting purposes.</param>
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
-        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
 
         /// <summary>
         /// Emits a message using formatting to the fatal log.
@@ -831,6 +855,7 @@ namespace Splat
         /// <typeparam name="TArgument6">The type of the sixth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -840,7 +865,7 @@ namespace Splat
         /// <param name="argument6">The sixth argument for formatting purposes.</param>
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
-        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
 
         /// <summary>
         /// Emits a message using formatting to the fatal log.
@@ -854,6 +879,7 @@ namespace Splat
         /// <typeparam name="TArgument7">The type of the seventh argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -864,7 +890,7 @@ namespace Splat
         /// <param name="argument7">The seventh argument for formatting purposes.</param>
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
         /// <param name="argument9">The ninth argument for formatting purposes.</param>
-        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
 
         /// <summary>
         /// Emits a message using formatting to the fatal log.
@@ -879,6 +905,7 @@ namespace Splat
         /// <typeparam name="TArgument8">The type of the eighth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument9">The type of the ninth argument which is used in the formatting.</typeparam>
         /// <typeparam name="TArgument10">The type of the tenth argument which is used in the formatting.</typeparam>
+        /// <param name="exception">The exception.</param>
         /// <param name="messageFormat">The message format used to emit a message with the type arguments.</param>
         /// <param name="argument1">The first argument for formatting purposes.</param>
         /// <param name="argument2">The second argument for formatting purposes.</param>
@@ -890,6 +917,6 @@ namespace Splat
         /// <param name="argument8">The eighth argument for formatting purposes.</param>
         /// <param name="argument9">The ninth argument for formatting purposes.</param>
         /// <param name="argument10">The tenth argument for formatting purposes.</param>
-        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(Exception exception, [Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
     }
 }

--- a/src/Splat/Logging/IFullLogger.cs
+++ b/src/Splat/Logging/IFullLogger.cs
@@ -15,7 +15,7 @@ namespace Splat
     /// A <see cref="WrappingFullLogger"/> will wrap simple loggers into a full logger.
     /// </summary>
     [SuppressMessage("Naming", "CA1716: Do not use built in identifiers", Justification = "Deliberate usage")]
-    public interface IFullLogger : ILogger, IAllocationFreeLogger
+    public interface IFullLogger : IAllocationFreeLogger
     {
         /// <summary>
         /// Emits a debug log message.
@@ -41,7 +41,15 @@ namespace Splat
         /// </summary>
         /// <param name="message">A message to emit.</param>
         /// <param name="exception">The exception which to emit in the log.</param>
+        [Obsolete("Use void Debug(Exception exception, [Localizable(false)] string message)")]
         void DebugException([Localizable(false)] string message, Exception exception);
+
+        /// <summary>
+        /// Emits a debug log message with an exception.
+        /// </summary>
+        /// <param name="exception">The exception.</param>
+        /// <param name="message">The message.</param>
+        void Debug(Exception exception, [Localizable(false)] string message);
 
         /// <summary>
         /// Emits a message using formatting to the debug log.
@@ -136,7 +144,17 @@ namespace Splat
         /// </summary>
         /// <param name="message">A message to emit.</param>
         /// <param name="exception">The exception which to emit in the log.</param>
+        [Obsolete("Use void Info(Exception exception, [Localizable(false)] string message)")]
         void InfoException([Localizable(false)] string message, Exception exception);
+
+        /// <summary>
+        /// Emits a info log message with exception.
+        /// This will emit details about a exception.
+        /// This type of logging is not able to be localized.
+        /// </summary>
+        /// <param name="exception">The exception which to emit in the log.</param>
+        /// <param name="message">A message to emit.</param>
+        void Info(Exception exception, [Localizable(false)] string message);
 
         /// <summary>
         /// Emits a message using formatting to the info log.
@@ -231,7 +249,17 @@ namespace Splat
         /// </summary>
         /// <param name="message">A message to emit.</param>
         /// <param name="exception">The exception which to emit in the log.</param>
+        [Obsolete("Use void Warn(Exception exception, [Localizable(false)] string message)")]
         void WarnException([Localizable(false)] string message, Exception exception);
+
+        /// <summary>
+        /// Emits a warning log message with exception.
+        /// This will emit details about a exception.
+        /// This type of logging is not able to be localized.
+        /// </summary>
+        /// <param name="exception">The exception which to emit in the log.</param>
+        /// <param name="message">A message to emit.</param>
+        void Warn(Exception exception, [Localizable(false)] string message);
 
         /// <summary>
         /// Emits a message using formatting to the warning log.
@@ -326,7 +354,17 @@ namespace Splat
         /// </summary>
         /// <param name="message">A message to emit.</param>
         /// <param name="exception">The exception which to emit in the log.</param>
+        [Obsolete("Use void Error(Exception exception, [Localizable(false)] string message)")]
         void ErrorException([Localizable(false)] string message, Exception exception);
+
+        /// <summary>
+        /// Emits a error log message with exception.
+        /// This will emit details about a exception.
+        /// This type of logging is not able to be localized.
+        /// </summary>
+        /// <param name="exception">The exception which to emit in the log.</param>
+        /// <param name="message">A message to emit.</param>
+        void Error(Exception exception, [Localizable(false)] string message);
 
         /// <summary>
         /// Emits a message using formatting to the error log.
@@ -421,7 +459,17 @@ namespace Splat
         /// </summary>
         /// <param name="message">A message to emit.</param>
         /// <param name="exception">The exception which to emit in the log.</param>
+        [Obsolete("Use void Fatal(Exception exception, [Localizable(false)] string message)")]
         void FatalException([Localizable(false)] string message, Exception exception);
+
+        /// <summary>
+        /// Emits a fatal log message with exception.
+        /// This will emit details about a exception.
+        /// This type of logging is not able to be localized.
+        /// </summary>
+        /// <param name="exception">The exception which to emit in the log.</param>
+        /// <param name="message">A message to emit.</param>
+        void Fatal(Exception exception, [Localizable(false)] string message);
 
         /// <summary>
         /// Emits a message using formatting to the fatal log.

--- a/src/Splat/Logging/WrappingFullLogger.cs
+++ b/src/Splat/Logging/WrappingFullLogger.cs
@@ -57,6 +57,12 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Debug(Exception exception, string message)
+        {
+            _inner.Write(exception, $"{message}", LogLevel.Debug);
+        }
+
+        /// <inheritdoc />
         public void Debug(IFormatProvider formatProvider, string message, params object[] args)
         {
             var result = InvokeStringFormat(formatProvider, message, args);
@@ -129,6 +135,12 @@ namespace Splat
         public void InfoException(string message, Exception exception)
         {
             _inner.Write(exception, $"{message}: {exception}", LogLevel.Info);
+        }
+
+        /// <inheritdoc />
+        public void Info(Exception exception, string message)
+        {
+            _inner.Write(exception, $"{message}", LogLevel.Info);
         }
 
         /// <inheritdoc />
@@ -206,6 +218,12 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Warn(Exception exception, string message)
+        {
+            _inner.Write(exception, $"{message}", LogLevel.Warn);
+        }
+
+        /// <inheritdoc />
         public void Warn(IFormatProvider formatProvider, string message, params object[] args)
         {
             var result = InvokeStringFormat(formatProvider, message, args);
@@ -280,6 +298,12 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public void Error(Exception exception, string message)
+        {
+            _inner.Write(exception, $"{message}", LogLevel.Error);
+        }
+
+        /// <inheritdoc />
         public void Error(IFormatProvider formatProvider, string message, params object[] args)
         {
             var result = InvokeStringFormat(formatProvider, message, args);
@@ -351,6 +375,12 @@ namespace Splat
         public void FatalException(string message, Exception exception)
         {
             _inner.Write(exception, $"{message}: {exception}", LogLevel.Fatal);
+        }
+
+        /// <inheritdoc />
+        public void Fatal(Exception exception, string message)
+        {
+            _inner.Write(exception, $"{message}", LogLevel.Fatal);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Resolves #120 

**What is the current behavior? (You can also link to an open issue here)**

There are level specific messages marked exception and the wrapping logger dictates format.

**What is the new behavior (if this is a feature change)?**

The `AllocationFreeLoggerBase` will have the ability to format the log message.

**What might this PR break?**

Logging?

**Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

