### PR TITLE
Fix: Thread Safety of MemoizingMRUCache 

### DIFF
--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
@@ -162,7 +162,7 @@ namespace Splat
         public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
         public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
-    public class DefaultLogManager : Splat.ILogManager
+    public sealed class DefaultLogManager : Splat.ILogManager
     {
         public DefaultLogManager(Splat.IReadonlyDependencyResolver dependencyResolver = null) { }
         public Splat.IFullLogger GetLogger(System.Type type) { }
@@ -651,14 +651,14 @@ namespace Splat
     {
         public static Splat.IFullLogger GetLogger<T>(this Splat.ILogManager logManager) { }
     }
-    public class MemoizingMRUCache<TParam, TVal>
+    public sealed class MemoizingMRUCache<TParam, TVal>
     {
         public MemoizingMRUCache(System.Func<TParam, object, TVal> calculationFunc, int maxSize, System.Action<TVal> onRelease = null) { }
         public System.Collections.Generic.IEnumerable<TVal> CachedValues() { }
         public TVal Get(TParam key) { }
         public TVal Get(TParam key, object context = null) { }
         public void Invalidate(TParam key) { }
-        public void InvalidateAll() { }
+        public void InvalidateAll(bool aggregateReleaseExceptions = False) { }
         public bool TryGet(TParam key, out TVal result) { }
     }
     public class static ModeDetector

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
@@ -151,7 +151,7 @@ namespace Splat
         public void Write([System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
         public void Write(System.Exception exception, [System.ComponentModel.LocalizableAttribute(false)] string message, [System.ComponentModel.LocalizableAttribute(false)] System.Type type, Splat.LogLevel logLevel) { }
     }
-    public class DefaultLogManager : Splat.ILogManager
+    public sealed class DefaultLogManager : Splat.ILogManager
     {
         public DefaultLogManager(Splat.IReadonlyDependencyResolver dependencyResolver = null) { }
         public Splat.IFullLogger GetLogger(System.Type type) { }
@@ -640,14 +640,14 @@ namespace Splat
     {
         public static Splat.IFullLogger GetLogger<T>(this Splat.ILogManager logManager) { }
     }
-    public class MemoizingMRUCache<TParam, TVal>
+    public sealed class MemoizingMRUCache<TParam, TVal>
     {
         public MemoizingMRUCache(System.Func<TParam, object, TVal> calculationFunc, int maxSize, System.Action<TVal> onRelease = null) { }
         public System.Collections.Generic.IEnumerable<TVal> CachedValues() { }
         public TVal Get(TParam key) { }
         public TVal Get(TParam key, object context = null) { }
         public void Invalidate(TParam key) { }
-        public void InvalidateAll() { }
+        public void InvalidateAll(bool aggregateReleaseExceptions = False) { }
         public bool TryGet(TParam key, out TVal result) { }
     }
     public class static ModeDetector

--- a/src/Splat.Tests/MemoizingMRUCacheTests.cs
+++ b/src/Splat.Tests/MemoizingMRUCacheTests.cs
@@ -38,7 +38,7 @@ namespace Splat.Tests
         /// Checks to ensure a value is returned for 2 duplicate calls.
         /// </summary>
         [Fact]
-        public void ReturnsSameValue()
+        public void GetReturnsSameValue()
         {
             var instance = GetTestInstance();
             var result1 = instance.Get("Test1");
@@ -52,7 +52,7 @@ namespace Splat.Tests
         /// Checks to ensure 2 different values are returned for 2 different calls.
         /// </summary>
         [Fact]
-        public void ReturnsDifferentValues()
+        public void GetReturnsDifferentValues()
         {
             var instance = GetTestInstance();
             var result1 = instance.Get("Test1");
@@ -60,6 +60,41 @@ namespace Splat.Tests
             var result2 = instance.Get("Test2");
             Assert.NotNull(result2);
             Assert.NotSame(result1, result2);
+        }
+
+        /// <summary>
+        /// Checks to ensure a value is returned for 2 duplicate calls.
+        /// </summary>
+        [Fact]
+        public void TryGetReturnsSameValue()
+        {
+            var instance = GetTestInstance();
+            var result1 = instance.Get("Test1");
+            Assert.NotNull(result1);
+            instance.TryGet("Test1", out var result2);
+            Assert.NotNull(result2);
+            Assert.Same(result1, result2);
+        }
+
+        /// <summary>
+        /// Checks to ensure 2 different values are returned for 2 different calls.
+        /// </summary>
+        [Fact]
+        public void TryGetReturnsDifferentValues()
+        {
+            var instance = GetTestInstance();
+            var p1 = instance.Get("Test1");
+            var p2 = instance.Get("Test2");
+
+            var result1 = instance.Get("Test1");
+            Assert.NotNull(result1);
+
+            var result2 = instance.Get("Test2");
+            Assert.NotNull(result2);
+
+            Assert.NotSame(result1, result2);
+            Assert.Same(p1, result1);
+            Assert.Same(p2, result2);
         }
 
         /// <summary>
@@ -83,7 +118,7 @@ namespace Splat.Tests
         }
 
         /// <summary>
-        /// Crude test for checking thread safety when using Get.
+        /// Crude test for checking thread safety when using Get and TryGet.
         /// </summary>
         [Fact]
         public void ThreadSafeRetrievalTestWithGetAndTryGet()

--- a/src/Splat.Tests/MemoizingMRUCacheTests.cs
+++ b/src/Splat.Tests/MemoizingMRUCacheTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Splat.Tests.Mocks;
+using Xunit;
+
+namespace Splat.Tests
+{
+    /// <summary>
+    /// Unit Tests for the Memoizing MRU Cache.
+    /// </summary>
+    public class MemoizingMRUCacheTests
+    {
+        /// <summary>
+        /// Checks to ensure an Argument Null Exception is thrown.
+        /// </summary>
+        [Fact]
+        public void ThrowsArgumentNullException()
+        {
+            var instance = GetTestInstance();
+            Assert.Throws<ArgumentNullException>(() => instance.Get(null));
+        }
+
+        /// <summary>
+        /// Checks to ensure a value is returned.
+        /// </summary>
+        [Fact]
+        public void ReturnsValue()
+        {
+            var instance = GetTestInstance();
+            var result = instance.Get("Test1");
+            Assert.NotNull(result);
+        }
+
+        /// <summary>
+        /// Checks to ensure a value is returned for 2 duplicate calls.
+        /// </summary>
+        [Fact]
+        public void ReturnsSameValue()
+        {
+            var instance = GetTestInstance();
+            var result1 = instance.Get("Test1");
+            Assert.NotNull(result1);
+            var result2 = instance.Get("Test1");
+            Assert.NotNull(result2);
+            Assert.Same(result1, result2);
+        }
+
+        /// <summary>
+        /// Checks to ensure 2 different values are returned for 2 different calls.
+        /// </summary>
+        [Fact]
+        public void ReturnsDifferentValues()
+        {
+            var instance = GetTestInstance();
+            var result1 = instance.Get("Test1");
+            Assert.NotNull(result1);
+            var result2 = instance.Get("Test2");
+            Assert.NotNull(result2);
+            Assert.NotSame(result1, result2);
+        }
+
+        /// <summary>
+        /// Crude test for checking thread safety when using Get.
+        /// </summary>
+        [Fact]
+        public void ThreadSafeRetrievalTest()
+        {
+            var instance = GetTestInstance();
+
+            var tests = Enumerable.Range(0, 100);
+
+            var results = tests.AsParallel().Select(_ => instance.Get("Test1")).ToList();
+
+            var first = results.First();
+
+            foreach (var dummyObjectClass1 in results)
+            {
+                Assert.Same(first, dummyObjectClass1);
+            }
+        }
+
+        private MemoizingMRUCache<string, DummyObjectClass1> GetTestInstance()
+        {
+            return new MemoizingMRUCache<string, DummyObjectClass1>(
+                (param, o) => new DummyObjectClass1(),
+                256);
+        }
+    }
+}

--- a/src/Splat.Tests/MemoizingMRUCacheTests.cs
+++ b/src/Splat.Tests/MemoizingMRUCacheTests.cs
@@ -82,6 +82,38 @@ namespace Splat.Tests
             }
         }
 
+        /// <summary>
+        /// Crude test for checking thread safety when using Get.
+        /// </summary>
+        [Fact]
+        public void ThreadSafeRetrievalTestWithGetAndTryGet()
+        {
+            var instance = GetTestInstance();
+
+            var tests = Enumerable.Range(0, 100);
+
+            var results = tests.AsParallel().Select(i =>
+            {
+                if (i % 2 == 0)
+                {
+                    return instance.Get("Test1");
+                }
+
+                instance.TryGet("Test1", out var result);
+                return result;
+            }).ToList();
+
+            var first = results.First(x => x != null);
+
+            foreach (var dummyObjectClass1 in results)
+            {
+                if (dummyObjectClass1 != null)
+                {
+                    Assert.Same(first, dummyObjectClass1);
+                }
+            }
+        }
+
         private MemoizingMRUCache<string, DummyObjectClass1> GetTestInstance()
         {
             return new MemoizingMRUCache<string, DummyObjectClass1>(

--- a/src/Splat.Tests/MemoizingMRUCacheTests.cs
+++ b/src/Splat.Tests/MemoizingMRUCacheTests.cs
@@ -150,10 +150,60 @@ namespace Splat.Tests
         }
 
         /// <summary>
+        /// Check that invalidate plays nicely.
+        /// </summary>
+        [Fact]
+        public void GetsResultsFromCacheValuesWhenInvalidateAndGetAreUsed()
+        {
+            var instance = GetTestInstance();
+
+            var tests = Enumerable.Range(0, 100);
+
+            var results = tests.AsParallel().Select(i =>
+            {
+                instance.Invalidate("Test1");
+                instance.Get("Test1");
+
+                return instance.CachedValues();
+            }).ToList();
+
+            // This is actually a crude test of a misuse case.
+            // There's no guarantee what comes out is entirely different for every task\thread.
+            // Just make sure it doesn't throw an exception.
+            Assert.NotNull(results);
+        }
+
+        /// <summary>
+        /// Check that invalidate plays nicely.
+        /// </summary>
+        [Fact]
+        public void GetsResultsWhenInvalidateAndGetAreUsed()
+        {
+            var instance = GetTestInstance();
+
+            var tests = Enumerable.Range(0, 100);
+
+            var results = tests.AsParallel().Select(i =>
+            {
+                instance.Invalidate("Test1");
+                var result = instance.Get("Test1");
+
+                // this is here just simply to test cache values plays nicely as well.
+                var cachedValues = instance.CachedValues();
+                return result;
+            }).ToList();
+
+            // This is actually a crude test of a misuse case.
+            // There's no guarantee what comes out is entirely different for every task\thread.
+            // Just make sure it doesn't throw an exception.
+            Assert.NotNull(results);
+        }
+
+        /// <summary>
         /// Check that invalidate all plays nicely.
         /// </summary>
         [Fact]
-        public void GetsDifferentInstancesWhenInvalidateAllAndGetAreUsed()
+        public void GetsResultsWhenInvalidateAllAndGetAreUsed()
         {
             var instance = GetTestInstance();
 
@@ -165,7 +215,10 @@ namespace Splat.Tests
                 return instance.Get("Test1");
             }).ToList();
 
-            Assert.Equal(results.Count, results.Cast<object>().Distinct().Count());
+            // This is actually a crude test of a misuse case.
+            // There's no guarantee what comes out is entirely different for every task\thread.
+            // Just make sure it doesn't throw an exception.
+            Assert.NotNull(results);
         }
 
         private MemoizingMRUCache<string, DummyObjectClass1> GetTestInstance()

--- a/src/Splat.Tests/MemoizingMRUCacheTests.cs
+++ b/src/Splat.Tests/MemoizingMRUCacheTests.cs
@@ -149,6 +149,25 @@ namespace Splat.Tests
             }
         }
 
+        /// <summary>
+        /// Check that invalidate all plays nicely.
+        /// </summary>
+        [Fact]
+        public void GetsDifferentInstancesWhenInvalidateAllAndGetAreUsed()
+        {
+            var instance = GetTestInstance();
+
+            var tests = Enumerable.Range(0, 100);
+
+            var results = tests.AsParallel().Select(i =>
+            {
+                instance.InvalidateAll();
+                return instance.Get("Test1");
+            }).ToList();
+
+            Assert.Equal(results.Count, results.Cast<object>().Distinct().Count());
+        }
+
         private MemoizingMRUCache<string, DummyObjectClass1> GetTestInstance()
         {
             return new MemoizingMRUCache<string, DummyObjectClass1>(

--- a/src/Splat/Logging/DefaultLogManager.cs
+++ b/src/Splat/Logging/DefaultLogManager.cs
@@ -12,7 +12,7 @@ namespace Splat
     /// This log manager will cache the loggers for each type,
     /// This will use the default registered <see cref="ILogger"/> inside the <see cref="Locator"/>.
     /// </summary>
-    public sealed class DefaultLogManager : ILogManager, IDisposable
+    public sealed class DefaultLogManager : ILogManager
     {
         private static readonly IFullLogger _nullLogger = new WrappingFullLogger(new NullLogger());
         private readonly MemoizingMRUCache<Type, IFullLogger> _loggerCache;
@@ -36,12 +36,6 @@ namespace Splat
 
                     return new WrappingFullLogger(new WrappingPrefixLogger(ret, type));
                 }, 64);
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            _loggerCache?.Dispose();
         }
 
         /// <inheritdoc />

--- a/src/Splat/Logging/DefaultLogManager.cs
+++ b/src/Splat/Logging/DefaultLogManager.cs
@@ -12,7 +12,7 @@ namespace Splat
     /// This log manager will cache the loggers for each type,
     /// This will use the default registered <see cref="ILogger"/> inside the <see cref="Locator"/>.
     /// </summary>
-    public class DefaultLogManager : ILogManager
+    public sealed class DefaultLogManager : ILogManager, IDisposable
     {
         private static readonly IFullLogger _nullLogger = new WrappingFullLogger(new NullLogger());
         private readonly MemoizingMRUCache<Type, IFullLogger> _loggerCache;
@@ -36,6 +36,12 @@ namespace Splat
 
                     return new WrappingFullLogger(new WrappingPrefixLogger(ret, type));
                 }, 64);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _loggerCache?.Dispose();
         }
 
         /// <inheritdoc />

--- a/src/Splat/MemoizingMRUCache.cs
+++ b/src/Splat/MemoizingMRUCache.cs
@@ -127,18 +127,27 @@ namespace Splat
             Contract.Requires(key != null);
 
             Tuple<LinkedListNode<TParam>, TVal> output;
-            var ret = _cacheEntries.TryGetValue(key, out output);
-            if (ret && output != null)
-            {
-                RefreshEntry(output.Item1);
-                result = output.Item2;
-            }
-            else
-            {
-                result = default(TVal);
-            }
 
-            return ret;
+            _readerWriterLock.EnterReadLock();
+            try
+            {
+                var ret = _cacheEntries.TryGetValue(key, out output);
+                if (ret && output != null)
+                {
+                    RefreshEntry(output.Item1);
+                    result = output.Item2;
+                }
+                else
+                {
+                    result = default(TVal);
+                }
+
+                return ret;
+            }
+            finally
+            {
+                _readerWriterLock.ExitReadLock();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

This fixes #266 around threading in the MRU Cache

**What is the current behavior? (You can also link to an open issue here)**

Wasn't thread safe.

**What is the new behavior (if this is a feature change)?**

Thread safe via ReaderWriterLockSlim
Invalidate calls the release func AFTER removing item from the cache so an exception won't leave the item in the cache in a dodgy state.
InvalidateAll has slightly different behaviour for releasing everything now.it creates new lists then clears up after releasing the lock using a temp variable.
InvalidateAll also has an option to Aggregate Exceptions (default false)

**What might this PR break?**

Has made MRU Cache disposable, and the DefaultLogManager.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

