### PR TITLE
housekeeping: unit tests coverage

### DIFF
--- a/src/Splat.Tests/Colors/KnownColorTests.cs
+++ b/src/Splat.Tests/Colors/KnownColorTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Splat.Tests.Colors
+{
+    /// <summary>
+    /// Unit Tests for Known Color logic.
+    /// </summary>
+    public class KnownColorTests
+    {
+        /// <summary>
+        /// Test data for FromKnownColor.
+        /// </summary>
+        public static IEnumerable<object[]> KnownColorEnums = XUnitHelpers.GetEnumAsTestTheory<KnownColor>();
+
+        /// <summary>
+        /// Tests to ensure a name is returned from a number akin to a KnownColor.
+        /// </summary>
+        /// <param name="knownColor">Known Color Enum to check.</param>
+        [Theory]
+        [MemberData(nameof(KnownColorEnums))]
+        public void GetNameReturnsName(KnownColor knownColor)
+        {
+#if !NET_2_0
+            if ((short)knownColor > 167)
+            {
+                // can't assess these.
+                return;
+            }
+#endif
+
+            var name = KnownColors.GetName(knownColor);
+            Assert.False(string.IsNullOrWhiteSpace(name));
+        }
+    }
+}

--- a/src/Splat.Tests/Colors/SplatColorTests.cs
+++ b/src/Splat.Tests/Colors/SplatColorTests.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+[module: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1401:FieldShouldBePrivate", Justification = "XUnit Theories.")]
+
+namespace Splat.Tests.Colors
+{
+    /// <summary>
+    /// Unit Tests for the Splat Color logic.
+    /// </summary>
+    public class SplatColorTests
+    {
+        /// <summary>
+        /// Test data for FromKnownColor.
+        /// </summary>
+        public static IEnumerable<object[]> KnownColorEnums = XUnitHelpers.GetEnumAsTestTheory<KnownColor>();
+
+        /// <summary>
+        /// Tests to check you can get a SplatColor from a KnownColor.
+        /// </summary>
+        /// <param name="knownColor">The Known Colour to convert.</param>
+        [Theory]
+        [MemberData(nameof(KnownColorEnums))]
+        public void FromKnownColorTests(KnownColor knownColor)
+        {
+            var splatColor = SplatColor.FromKnownColor(knownColor);
+
+            Assert.NotNull(splatColor.Name);
+        }
+
+        /// <summary>
+        /// Tests to check you can get a SplatColor from a name.
+        /// </summary>
+        /// <param name="knownColor">The Known Colour to convert.</param>
+        [Theory]
+        [MemberData(nameof(KnownColorEnums))]
+        public void FromNameTests(KnownColor knownColor)
+        {
+            var splatColor = SplatColor.FromName(knownColor.ToString());
+
+            Assert.NotNull(splatColor.Name);
+        }
+
+        private static IEnumerable<object[]> GetEnumAsTestTheory()
+        {
+            var values = Enum.GetValues(typeof(KnownColor));
+            var results = new List<object[]>(values.Length);
+            foreach (var value in values)
+            {
+                results.Add(new object[] { value });
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/Splat.Tests/TargetFrameworkExtensionsTests.cs
+++ b/src/Splat.Tests/TargetFrameworkExtensionsTests.cs
@@ -1,0 +1,168 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using Xunit;
+
+namespace Splat.Tests
+{
+    /// <summary>
+    /// Unit Tests for Target Framework Extensions.
+    /// </summary>
+    public class TargetFrameworkExtensionsTests
+    {
+        /// <summary>
+        /// Test source data for Framework names.
+        /// </summary>
+        public static IEnumerable<object[]> FrameworkNamesTestSource = new[]
+        {
+            new object[]
+            {
+                ".NETCoreApp,Version=v2.2",
+                "netcoreapp2.2",
+            },
+            new object[]
+            {
+                ".NETCoreApp,Version=v2.1",
+                "netcoreapp2.1",
+            },
+            new object[]
+            {
+                ".NETCoreApp,Version=v2.0",
+                "netcoreapp2.0",
+            },
+            new object[]
+            {
+                ".NETCoreApp,Version=v1.1",
+                "netcoreapp1.1",
+            },
+            new object[]
+            {
+                ".NETCoreApp,Version=v1.0",
+                "netcoreapp1.0",
+            },
+            new object[]
+            {
+                ".NETStandard,Version=v2.0",
+                "netstandard2.0",
+            },
+            new object[]
+            {
+                ".NETStandard,Version=v1.6",
+                "netstandard1.6",
+            },
+            new object[]
+            {
+                ".NETStandard,Version=v1.5",
+                "netstandard1.5",
+            },
+            new object[]
+            {
+                ".NETStandard,Version=v1.4",
+                "netstandard1.4",
+            },
+            new object[]
+            {
+                ".NETStandard,Version=v1.3",
+                "netstandard1.3",
+            },
+            new object[]
+            {
+                ".NETStandard,Version=v1.2",
+                "netstandard1.2",
+            },
+            new object[]
+            {
+                ".NETStandard,Version=v1.1",
+                "netstandard1.1",
+            },
+            new object[]
+            {
+                ".NETStandard,Version=v1.0",
+                "netstandard1.0",
+            },
+            new object[]
+            {
+                ".NETFramework,Version=v4.7.2",
+                "net472",
+            },
+            new object[]
+            {
+                ".NETFramework,Version=v4.7.1",
+                "net471",
+            },
+            new object[]
+            {
+                ".NETFramework,Version=v4.7",
+                "net47",
+            },
+            new object[]
+            {
+                ".NETFramework,Version=v4.6.2",
+                "net462",
+            },
+            new object[]
+            {
+                ".NETFramework,Version=v4.6.1",
+                "net461",
+            },
+            new object[]
+            {
+                ".NETFramework,Version=v4.6",
+                "net46",
+            },
+            new object[]
+            {
+                ".NETFramework,Version=v4.5.2",
+                "net452",
+            },
+            new object[]
+            {
+                ".NETFramework,Version=v4.5.1",
+                "net451",
+            },
+            new object[]
+            {
+                ".NETFramework,Version=v4.5",
+                "net45",
+            },
+            new object[]
+            {
+                ".NETFramework,Version=v4.0.3",
+                "net403",
+            },
+            new object[]
+            {
+                ".NETFramework,Version=v4.0",
+                "net40",
+            },
+            new object[]
+            {
+                ".NETFramework,Version=v3.5",
+                "net35",
+            },
+            new object[]
+            {
+                ".NETFramework,Version=v2.0",
+                "net20",
+            },
+            new object[]
+            {
+                ".NETFramework,Version=v1.1",
+                "net11",
+            }
+        };
+
+        /// <summary>
+        /// Checks to ensure the framework name is returned.
+        /// </summary>
+        /// <param name="frameworkName">The framework name.</param>
+        /// <param name="expected">The expected result.</param>
+        [Theory]
+        [MemberData(nameof(FrameworkNamesTestSource))]
+        public void ReturnsName(string frameworkName, string expected)
+        {
+            Assert.Equal(expected, TargetFrameworkExtensions.GetTargetFrameworkName(frameworkName));
+        }
+    }
+}

--- a/src/Splat.Tests/XUnitHelpers.cs
+++ b/src/Splat.Tests/XUnitHelpers.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Splat.Tests
+{
+    /// <summary>
+    /// Helpers for XUnit.
+    /// </summary>
+    public static class XUnitHelpers
+    {
+        /// <summary>
+        /// Gets Theory Permutations for all the values in an enum.
+        /// </summary>
+        /// <typeparam name="TEnum">The type of enum.</typeparam>
+        /// <returns>An XUnit theory data source.</returns>
+        public static IEnumerable<object[]> GetEnumAsTestTheory<TEnum>()
+        {
+            var values = Enum.GetValues(typeof(TEnum));
+            var results = new List<object[]>(values.Length);
+            foreach (var value in values)
+            {
+                results.Add(new object[] { value });
+            }
+
+            return results;
+        }
+    }
+}

--- a/src/Splat/TargetFrameworkExtensions.cs
+++ b/src/Splat/TargetFrameworkExtensions.cs
@@ -22,7 +22,12 @@ namespace Splat
         {
             var targetFrameworkAttribute = assembly.GetCustomAttribute<TargetFrameworkAttribute>();
 
-            switch (targetFrameworkAttribute.FrameworkName)
+            return GetTargetFrameworkName(targetFrameworkAttribute.FrameworkName);
+        }
+
+        internal static string GetTargetFrameworkName(string frameworkName)
+        {
+            switch (frameworkName)
             {
                 case ".NETCoreApp,Version=v2.2":
                     return "netcoreapp2.2";


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

housekeeping for unit tests

**What is the current behavior? (You can also link to an open issue here)**

#293 coverage has crept up, this is to push it up on the high scoring methods (according to resharper)

**What is the new behavior (if this is a feature change)?**

more tests

**What might this PR break?**

hopefully nothing

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

