### PR TITLE
performance: Added Benchmarks

### DIFF
--- a/src/Benchmarks/CurrentBenchmark.cs
+++ b/src/Benchmarks/CurrentBenchmark.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+namespace Splat.Benchmarks
+{
+    /// <summary>
+    /// Benchmarks for the current locator.
+    /// </summary>
+    [ClrJob]
+    [CoreJob]
+    [MemoryDiagnoser]
+    [MarkdownExporterAttribute.GitHub]
+    public class CurrentBenchmark
+    {
+        /// <summary>
+        /// Setup method for when running all bench marks.
+        /// </summary>
+        [GlobalSetup]
+        public void Setup()
+        {
+            Locator.CurrentMutable.Register(() => new ViewModel());
+        }
+
+        /// <summary>
+        /// Benchamrks returning an object.
+        /// </summary>
+        /// <returns>The object.</returns>
+        [Benchmark]
+        public ViewModel GetService() => (ViewModel)Locator.Current.GetService(typeof(ViewModel));
+
+        /// <summary>
+        /// Benchamrks returning an object.
+        /// </summary>
+        /// <returns>The object.</returns>
+        [Benchmark]
+        public ViewModel GetServiceWithContract() => (ViewModel)Locator.Current.GetService(typeof(ViewModel), nameof(ViewModel));
+
+        /// <summary>
+        /// Benchamrks returning an object.
+        /// </summary>
+        /// <returns>The object.</returns>
+        [Benchmark]
+        public ViewModel GetServiceGeneric() => Locator.Current.GetService<ViewModel>();
+
+        /// <summary>
+        /// Benchamrks returning an object.
+        /// </summary>
+        /// <returns>The object.</returns>
+        [Benchmark]
+        public ViewModel GetServiceGenericWithContract() => Locator.Current.GetService<ViewModel>(nameof(ViewModel));
+
+        /// <summary>
+        /// Benchamrks returning an enumerable of objects.
+        /// </summary>
+        /// <returns>The object.</returns>
+        [Benchmark]
+        public List<ViewModel> GetServices() => (List<ViewModel>)Locator.Current.GetServices(typeof(ViewModel));
+
+        /// <summary>
+        /// Benchamrks returning an enumerable of objects.
+        /// </summary>
+        /// <returns>The object.</returns>
+        [Benchmark]
+        public List<ViewModel> GetServicesWithContract() => (List<ViewModel>)Locator.Current.GetServices(typeof(ViewModel), nameof(ViewModel));
+
+        /// <summary>
+        /// Benchamrks returning an enumerable of objects.
+        /// </summary>
+        /// <returns>The object.</returns>
+        [Benchmark]
+        public List<ViewModel> GetServicesGeneric() => Locator.Current.GetServices<ViewModel>().ToList();
+
+        /// <summary>
+        /// Benchamrks returning an enumerable of objects.
+        /// </summary>
+        /// <returns>The object.</returns>
+        [Benchmark]
+        public List<ViewModel> GetServicesGenericWithContract() => Locator.Current.GetServices<ViewModel>(nameof(ViewModel)).ToList();
+    }
+}

--- a/src/Benchmarks/CurrentMutableBenchmark.cs
+++ b/src/Benchmarks/CurrentMutableBenchmark.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+
+namespace Splat.Benchmarks
+{
+    /// <summary>
+    /// Benchmarks for the current mutable locator.
+    /// </summary>
+    [ClrJob]
+    [CoreJob]
+    [MemoryDiagnoser]
+    [MarkdownExporterAttribute.GitHub]
+    public class CurrentMutableBenchmark
+    {
+        /// <summary>
+        /// Setup method for when running all bench marks.
+        /// </summary>
+        [GlobalSetup]
+        public void Setup()
+        {
+        }
+
+        /// <summary>
+        /// Benchamrks registering an object.
+        /// </summary>
+        [Benchmark]
+        public void Register() => Locator.CurrentMutable.Register(() => new ViewModel());
+
+        /// <summary>
+        /// Benchamrks registering an object.
+        /// </summary>
+        [Benchmark]
+        public void RegisterWithContract() => Locator.CurrentMutable.Register(() => new ViewModel(), nameof(ViewModel));
+
+        /// <summary>
+        /// Benchamrks registering an object.
+        /// </summary>
+        [Benchmark]
+        public void RegisterConstant() => Locator.CurrentMutable.RegisterConstant(new ViewModel());
+
+        /// <summary>
+        /// Benchamrks registering an object.
+        /// </summary>
+        [Benchmark]
+        public void RegisterConstantWithContract() => Locator.CurrentMutable.RegisterConstant(new ViewModel(), nameof(ViewModel));
+
+        /// <summary>
+        /// Benchamrks registering an object.
+        /// </summary>
+        [Benchmark]
+        public void RegisterLazySingleton() => Locator.CurrentMutable.RegisterLazySingleton(() => new ViewModel());
+
+        /// <summary>
+        /// Benchamrks registering an object.
+        /// </summary>
+        [Benchmark]
+        public void RegisterLazySingletonWithContract() => Locator.CurrentMutable.RegisterLazySingleton(() => new ViewModel(), nameof(ViewModel));
+    }
+}

--- a/src/Benchmarks/DependencyResolver.cs
+++ b/src/Benchmarks/DependencyResolver.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Splat.Benchmarks
+{
+#pragma warning disable CA1001, CA1063
+    /// <summary>
+    /// <see cref="IDependencyResolver"/> implementation for benchmarking the Locator.
+    /// </summary>
+    /// <seealso cref="Splat.IDependencyResolver" />
+    public class DependencyResolver : IDependencyResolver
+    {
+        /// <inheritdoc />
+        public object GetService(Type serviceType, string contract = null) => default(object);
+
+        /// <inheritdoc />
+        public IEnumerable<object> GetServices(Type serviceType, string contract = null) => Enumerable.Empty<object>();
+
+        /// <inheritdoc />
+        public void Register(Func<object> factory, Type serviceType, string contract = null)
+        {
+        }
+
+        /// <inheritdoc />
+        public void UnregisterCurrent(Type serviceType, string contract = null)
+        {
+        }
+
+        /// <inheritdoc />
+        public void UnregisterAll(Type serviceType, string contract = null)
+        {
+        }
+
+        /// <inheritdoc />
+        public IDisposable ServiceRegistrationCallback(Type serviceType, string contract, Action<IDisposable> callback) => Disposable.Empty;
+
+        /// <inheritdoc />
+        public virtual void Dispose()
+        {
+        }
+    }
+#pragma warning restore CA1001, CA1063
+}

--- a/src/Benchmarks/LocatorBenchmark.cs
+++ b/src/Benchmarks/LocatorBenchmark.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Splat;
+
+namespace Splat.Benchmarks
+{
+#pragma warning disable CA1001 // Types that own disposable fields should be disposable
+    /// <summary>
+    /// Benchmarks for the service locator.
+    /// </summary>
+    [ClrJob]
+    [CoreJob]
+    [MemoryDiagnoser]
+    [MarkdownExporterAttribute.GitHub]
+    public class LocatorBenchmark
+    {
+        private DependencyResolver _dependencyResolver;
+
+        /// <summary>
+        /// Setup method for when running all bench marks.
+        /// </summary>
+        [GlobalSetup]
+        public void Setup()
+        {
+            _dependencyResolver = new DependencyResolver();
+        }
+
+        /// <summary>
+        /// Benchmarks getting the current locator.
+        /// </summary>
+        /// <returns>The dependency resolver.</returns>
+        [Benchmark]
+        public IReadonlyDependencyResolver Current() => Locator.Current;
+
+        /// <summary>
+        /// Benchmarks getting the current mutable locator.
+        /// </summary>
+        /// <returns>The dependency resolver.</returns>
+        [Benchmark]
+        public IMutableDependencyResolver CurrentMutable() => Locator.CurrentMutable;
+
+        /// <summary>
+        /// Benchmarks setting the dependency resolver.
+        /// </summary>
+        [Benchmark]
+        public void SetLocator() => Locator.SetLocator(_dependencyResolver);
+
+        /// <summary>
+        /// Benchmarks setting the call back for changes.
+        /// </summary>
+        /// <returns>A disposable.</returns>
+        [Benchmark]
+        public IDisposable RegisterResolverCallbackChanged() => Locator.RegisterResolverCallbackChanged(() =>
+        {
+            var foo = "bar";
+        });
+
+        /// <summary>
+        /// Suppresses the resolver callback changed notifications.
+        /// </summary>
+        /// <returns>A disposable.</returns>
+        [Benchmark]
+        public IDisposable SuppressResolverCallbackChangedNotifications() => Locator.SuppressResolverCallbackChangedNotifications();
+
+        /// <summary>
+        /// Ares the resolver callback changed notifications enabled.
+        /// </summary>
+        /// <returns>Whether the change notifications are enabled.</returns>
+        [Benchmark]
+        public bool AreResolverCallbackChangedNotificationsEnabled() => Locator.AreResolverCallbackChangedNotificationsEnabled();
+    }
+#pragma warning restore CA1001 // Types that own disposable fields should be disposable
+}

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using BenchmarkDotNet.Running;
+
+namespace Splat.Benchmarks
+{
+    /// <summary>
+    /// Class which hosts the main entry point into the application.
+    /// </summary>
+    public static class Program
+    {
+        /// <summary>
+        /// The main entry point into the benchmarking application.
+        /// </summary>
+        /// <param name="args">Arguments from the command line.</param>
+        public static void Main(string[] args)
+        {
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        }
+    }
+}

--- a/src/Benchmarks/Splat.Benchmarks.csproj
+++ b/src/Benchmarks/Splat.Benchmarks.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <OutputType>Exe</OutputType>
+    <NoWarn>;1591;1701;1702;1705;CA1822</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="*" />
+    <PackageReference Include="System.Reactive" Version="4.*" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Splat\Splat.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Benchmarks/Splat.Benchmarks.sln
+++ b/src/Benchmarks/Splat.Benchmarks.sln
@@ -1,0 +1,39 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.329
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Benchmarks", "Splat.Benchmarks.csproj", "{4FDA89BA-2364-49C9-B028-16EEFFF321D5}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{BC92BB8B-EE02-4EBC-BAE5-FEEF3F5C6C77}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", "{8C2A8595-B0D8-482A-BA20-D0DD08070F33}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat", "..\Splat\Splat.csproj", "{BE855F74-28F3-47C9-BCA9-957287356FB6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{4FDA89BA-2364-49C9-B028-16EEFFF321D5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FDA89BA-2364-49C9-B028-16EEFFF321D5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FDA89BA-2364-49C9-B028-16EEFFF321D5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FDA89BA-2364-49C9-B028-16EEFFF321D5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE855F74-28F3-47C9-BCA9-957287356FB6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE855F74-28F3-47C9-BCA9-957287356FB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE855F74-28F3-47C9-BCA9-957287356FB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE855F74-28F3-47C9-BCA9-957287356FB6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{4FDA89BA-2364-49C9-B028-16EEFFF321D5} = {8C2A8595-B0D8-482A-BA20-D0DD08070F33}
+		{BE855F74-28F3-47C9-BCA9-957287356FB6} = {BC92BB8B-EE02-4EBC-BAE5-FEEF3F5C6C77}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {65D72301-907A-4438-AA68-5A98B6EA8041}
+	EndGlobalSection
+EndGlobal

--- a/src/Benchmarks/ViewModel.cs
+++ b/src/Benchmarks/ViewModel.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Splat.Benchmarks
+{
+    /// <summary>
+    /// A plain object for registration.
+    /// </summary>
+    public class ViewModel
+    {
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Resolves: #297 

**What is the current behavior? (You can also link to an open issue here)**

There are currently no benchmarks.

**What is the new behavior (if this is a feature change)?**

There is a Splat.Benchmarks solution for executing benchmarks.

**What might this PR break?**

Nothing.

** Added Benchmarks for the following**
- Locator.Current
- Locator.CurrentMutable
- Locator.RegisterResolverCallbackChanged
- Locator.SuppressResolverCallbackChangedNotifications
- Locator.AreResolverCallbackChangedNotificationsEnabled
- Locator.CurrentMutable.Register
- Locator.CurrentMutable.RegisterWithContract
- Locator.CurrentMutable.RegisterConstant
- Locator.CurrentMutable.RegisterConstantWithContract
- Locator.CurrentMutable.RegisterLazySingleton
- Locator.CurrentMutable.RegisterLazySingletonWithContract
- Locator.Current.GetService
- Locator.Current.GetServiceWithContract
- Locator.Current.GetServiceGeneric
- Locator.Current.GetServiceGenericWithContract
- Locator.Current.GetServices
- Locator.Current.GetServicesWithContract
- Locator.Current.GetServicesGeneric
- Locator.Current.GetServicesGenericWithContract