### PR TITLE
feature: Add a MS Logging Extensions provider

### DIFF
--- a/src/Splat.Microsoft.Extensions.Logging/MicrosoftExtensionsLogProvider.cs
+++ b/src/Splat.Microsoft.Extensions.Logging/MicrosoftExtensionsLogProvider.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace Splat.Microsoft.Extensions.Logging
+{
+    /// <summary>
+    /// A logging provider which talks to Splat.
+    /// </summary>
+    public sealed class MicrosoftExtensionsLogProvider : ILoggerProvider
+    {
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+
+        /// <inheritdoc />
+        public global::Microsoft.Extensions.Logging.ILogger CreateLogger(string categoryName)
+        {
+            return new SplatLoggingAdapter(categoryName);
+        }
+
+        private class SplatLoggingAdapter : global::Microsoft.Extensions.Logging.ILogger
+        {
+            private readonly string _categoryName;
+
+            public SplatLoggingAdapter(string categoryName)
+            {
+                _categoryName = categoryName;
+            }
+
+            /// <inheritdoc />
+            public void Log<TState>(global::Microsoft.Extensions.Logging.LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+            {
+                if (!IsEnabled(logLevel))
+                {
+                    return;
+                }
+
+                if (formatter == null)
+                {
+                    throw new ArgumentNullException(nameof(formatter));
+                }
+
+                var splatLogLevel = MsLoggingHelpers.MsLog2SplatDictionary[logLevel];
+
+                var message = formatter(state, exception);
+
+                LogHost.Default.Write(exception, message, splatLogLevel);
+            }
+
+            /// <inheritdoc />
+            public bool IsEnabled(global::Microsoft.Extensions.Logging.LogLevel logLevel)
+            {
+                return logLevel != global::Microsoft.Extensions.Logging.LogLevel.None;
+            }
+
+            /// <inheritdoc />
+            public IDisposable BeginScope<TState>(TState state)
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/src/Splat.Microsoft.Extensions.Logging/MicrosoftExtensionsLoggingExtensions.cs
+++ b/src/Splat.Microsoft.Extensions.Logging/MicrosoftExtensionsLoggingExtensions.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Splat.Microsoft.Extensions.Logging
@@ -10,7 +11,7 @@ namespace Splat.Microsoft.Extensions.Logging
     /// <summary>
     /// Microsoft.Extensions.Logging specific extensions for the Mutable Dependency Resolver.
     /// </summary>
-    public static class MutableDependencyResolverExtensions
+    public static class MicrosoftExtensionsLoggingExtensions
     {
         /// <summary>
         /// Simple helper to initialize Microsoft.Extensions.Logging within Splat with the Wrapping Full Logger.
@@ -41,6 +42,29 @@ namespace Splat.Microsoft.Extensions.Logging
             });
 
             instance.RegisterConstant(funcLogManager, typeof(ILogManager));
+        }
+
+        /// <summary>
+        /// Registers a <see cref="MicrosoftExtensionsLogProvider"/> with the service collection.
+        /// </summary>
+        /// <param name="builder">The logging builder to register.</param>
+        /// <returns>The logging builder.</returns>
+        public static ILoggingBuilder AddSplat(this ILoggingBuilder builder)
+        {
+            builder.Services.AddSingleton<ILoggerProvider, MicrosoftExtensionsLogProvider>();
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds a <see cref="MicrosoftExtensionsLogProvider"/> to the logger factory.
+        /// </summary>
+        /// <param name="loggerFactory">Our logger provider.</param>
+        /// <returns>The factory.</returns>
+        public static ILoggerFactory AddSplat(this ILoggerFactory loggerFactory)
+        {
+            loggerFactory.AddProvider(new MicrosoftExtensionsLogProvider());
+            return loggerFactory;
         }
     }
 }

--- a/src/Splat.Microsoft.Extensions.Logging/MicrosoftExtensionsLoggingLogger.cs
+++ b/src/Splat.Microsoft.Extensions.Logging/MicrosoftExtensionsLoggingLogger.cs
@@ -17,17 +17,6 @@ namespace Splat.Microsoft.Extensions.Logging
     [DebuggerDisplay("Name={_inner.GetType()} Level={Level}")]
     public sealed class MicrosoftExtensionsLoggingLogger : ILogger
     {
-        private static readonly KeyValuePair<LogLevel, global::Microsoft.Extensions.Logging.LogLevel>[] _mappings =
-        {
-            new KeyValuePair<LogLevel, global::Microsoft.Extensions.Logging.LogLevel>(LogLevel.Debug, global::Microsoft.Extensions.Logging.LogLevel.Debug),
-            new KeyValuePair<LogLevel, global::Microsoft.Extensions.Logging.LogLevel>(LogLevel.Info, global::Microsoft.Extensions.Logging.LogLevel.Information),
-            new KeyValuePair<LogLevel, global::Microsoft.Extensions.Logging.LogLevel>(LogLevel.Warn, global::Microsoft.Extensions.Logging.LogLevel.Warning),
-            new KeyValuePair<LogLevel, global::Microsoft.Extensions.Logging.LogLevel>(LogLevel.Error, global::Microsoft.Extensions.Logging.LogLevel.Error),
-            new KeyValuePair<LogLevel, global::Microsoft.Extensions.Logging.LogLevel>(LogLevel.Fatal, global::Microsoft.Extensions.Logging.LogLevel.Critical)
-        };
-
-        private static readonly ImmutableDictionary<LogLevel, global::Microsoft.Extensions.Logging.LogLevel> _mappingsDictionary = _mappings.ToImmutableDictionary();
-
         private readonly global::Microsoft.Extensions.Logging.ILogger _inner;
 
         /// <summary>
@@ -45,7 +34,7 @@ namespace Splat.Microsoft.Extensions.Logging
         {
             get
             {
-                foreach (var mapping in _mappings)
+                foreach (var mapping in MsLoggingHelpers.Mappings)
                 {
                     if (_inner.IsEnabled(mapping.Value))
                     {
@@ -61,13 +50,13 @@ namespace Splat.Microsoft.Extensions.Logging
         /// <inheritdoc />
         public void Write(string message, LogLevel logLevel)
         {
-            _inner.Log(_mappingsDictionary[logLevel], message);
+            _inner.Log(MsLoggingHelpers.Splat2MsLogDictionary[logLevel], message);
         }
 
         /// <inheritdoc />
         public void Write(Exception exception, string message, LogLevel logLevel)
         {
-            _inner.Log(_mappingsDictionary[logLevel], exception, message);
+            _inner.Log(MsLoggingHelpers.Splat2MsLogDictionary[logLevel], exception, message);
         }
 
         /// <inheritdoc />
@@ -75,7 +64,7 @@ namespace Splat.Microsoft.Extensions.Logging
         {
             using (_inner.BeginScope(type.ToString()))
             {
-                _inner.Log(_mappingsDictionary[logLevel], message);
+                _inner.Log(MsLoggingHelpers.Splat2MsLogDictionary[logLevel], message);
             }
         }
 
@@ -84,7 +73,7 @@ namespace Splat.Microsoft.Extensions.Logging
         {
             using (_inner.BeginScope(type.ToString()))
             {
-                _inner.Log(_mappingsDictionary[logLevel], exception, message);
+                _inner.Log(MsLoggingHelpers.Splat2MsLogDictionary[logLevel], exception, message);
             }
         }
     }

--- a/src/Splat.Microsoft.Extensions.Logging/MsLoggingHelpers.cs
+++ b/src/Splat.Microsoft.Extensions.Logging/MsLoggingHelpers.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+
+namespace Splat.Microsoft.Extensions.Logging
+{
+    internal static class MsLoggingHelpers
+    {
+        public static KeyValuePair<LogLevel, global::Microsoft.Extensions.Logging.LogLevel>[] Mappings { get; } =
+        {
+            new KeyValuePair<LogLevel, global::Microsoft.Extensions.Logging.LogLevel>(LogLevel.Debug, global::Microsoft.Extensions.Logging.LogLevel.Debug),
+            new KeyValuePair<LogLevel, global::Microsoft.Extensions.Logging.LogLevel>(LogLevel.Info, global::Microsoft.Extensions.Logging.LogLevel.Information),
+            new KeyValuePair<LogLevel, global::Microsoft.Extensions.Logging.LogLevel>(LogLevel.Warn, global::Microsoft.Extensions.Logging.LogLevel.Warning),
+            new KeyValuePair<LogLevel, global::Microsoft.Extensions.Logging.LogLevel>(LogLevel.Error, global::Microsoft.Extensions.Logging.LogLevel.Error),
+            new KeyValuePair<LogLevel, global::Microsoft.Extensions.Logging.LogLevel>(LogLevel.Fatal, global::Microsoft.Extensions.Logging.LogLevel.Critical)
+        };
+
+        public static ImmutableDictionary<LogLevel, global::Microsoft.Extensions.Logging.LogLevel> Splat2MsLogDictionary { get; } = Mappings.ToImmutableDictionary();
+
+        public static ImmutableDictionary<global::Microsoft.Extensions.Logging.LogLevel, LogLevel> MsLog2SplatDictionary { get; } = Mappings.ToImmutableDictionary(x => x.Value, x => x.Key);
+    }
+}

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "7.2",
+  "version": "7.3",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/develop$", // we release out of develop


### PR DESCRIPTION
Adding a logging provider, which allows a log target to be Splat. Which will output to any of the splat logging providers.