### PR TITLE
feature: Use IComponentContext in Splat.Autofac

### DIFF
--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -20,15 +20,15 @@ namespace Splat.Autofac
     /// </summary>
     public class AutofacDependencyResolver : IDependencyResolver
     {
-        private IContainer _container;
+        private readonly IComponentContext _componentContext;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="AutofacDependencyResolver"/> class.
+        /// Initializes a new instance of the <see cref="AutofacDependencyResolver" /> class.
         /// </summary>
-        /// <param name="container">The container.</param>
-        public AutofacDependencyResolver(IContainer container)
+        /// <param name="componentContext">The component context.</param>
+        public AutofacDependencyResolver(IComponentContext componentContext)
         {
-            _container = container;
+            _componentContext = componentContext;
         }
 
         /// <inheritdoc />
@@ -37,8 +37,8 @@ namespace Splat.Autofac
             try
             {
                 return string.IsNullOrEmpty(contract)
-                    ? _container.Resolve(serviceType)
-                    : _container.ResolveNamed(contract, serviceType);
+                    ? _componentContext.Resolve(serviceType)
+                    : _componentContext.ResolveNamed(contract, serviceType);
             }
             catch (DependencyResolutionException)
             {
@@ -53,8 +53,8 @@ namespace Splat.Autofac
             {
                 var enumerableType = typeof(IEnumerable<>).MakeGenericType(serviceType);
                 object instance = string.IsNullOrEmpty(contract)
-                    ? _container.Resolve(enumerableType)
-                    : _container.ResolveNamed(contract, enumerableType);
+                    ? _componentContext.Resolve(enumerableType)
+                    : _componentContext.ResolveNamed(contract, enumerableType);
                 return ((IEnumerable)instance).Cast<object>();
             }
             catch (DependencyResolutionException)
@@ -85,7 +85,7 @@ namespace Splat.Autofac
                 builder.Register(x => factory()).Named(contract, serviceType).AsImplementedInterfaces();
             }
 
-            builder.Update(_container);
+            builder.Update(_componentContext.ComponentRegistry);
         }
 
         /// <summary>
@@ -136,8 +136,7 @@ namespace Splat.Autofac
         {
             if (disposing)
             {
-                _container?.Dispose();
-                _container = null;
+                _componentContext.ComponentRegistry?.Dispose();
             }
         }
     }

--- a/src/Splat.Autofac/SplatAutofacExtensions.cs
+++ b/src/Splat.Autofac/SplatAutofacExtensions.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System;
 using Autofac;
 
 namespace Splat.Autofac
@@ -15,9 +16,9 @@ namespace Splat.Autofac
         /// <summary>
         /// Initializes an instance of <see cref="AutofacDependencyResolver"/> that overrides the default <see cref="Locator"/>.
         /// </summary>
-        /// <param name="container">Autofac container.</param>
-        public static void UseAutofacDependencyResolver(this IContainer container) =>
-            Locator.SetLocator(new AutofacDependencyResolver(container));
+        /// <param name="componentContext">Autofac component context.</param>
+        public static void UseAutofacDependencyResolver(this IComponentContext componentContext) =>
+            Locator.SetLocator(new AutofacDependencyResolver(componentContext));
 
         /// <summary>
         /// Initializes an instance of <see cref="AutofacDependencyResolver"/> that overrides the default <see cref="Locator"/>.


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Resolves: #302 

**What is the current behavior? (You can also link to an open issue here)**

`UseAutofacDependencyResolver` and `AutofacDependencyResolver` take an `IContainer` instance.

**What is the new behavior (if this is a feature change)?**

`UseAutofacDependencyResolver` and `AutofacDependencyResolver` take an `IComponentContext` instance.

**What might this PR break?**

Splat.Autofac

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

