### PR TITLE
feature: Use IContainer in Splat.DryIoc

### DIFF
--- a/src/Splat.DryIoc/DryIocDependencyResolver.cs
+++ b/src/Splat.DryIoc/DryIocDependencyResolver.cs
@@ -16,13 +16,13 @@ namespace Splat.DryIoc
     /// <seealso cref="Splat.IDependencyResolver" />
     public class DryIocDependencyResolver : IDependencyResolver
     {
-        private Container _container;
+        private IContainer _container;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DryIocDependencyResolver" /> class.
         /// </summary>
         /// <param name="container">The container.</param>
-        public DryIocDependencyResolver(Container container = null)
+        public DryIocDependencyResolver(IContainer container = null)
         {
             _container = container ?? new Container();
         }

--- a/src/Splat.DryIoc/SplatDryIocExtensions.cs
+++ b/src/Splat.DryIoc/SplatDryIocExtensions.cs
@@ -19,7 +19,7 @@ namespace Splat.DryIoc
         /// Initializes an instance of <see cref="DryIocDependencyResolver"/> that overrides the default <see cref="Locator"/>.
         /// </summary>
         /// <param name="container">The container.</param>
-        public static void UseDryIocDependencyResolver(this Container container) =>
+        public static void UseDryIocDependencyResolver(this IContainer container) =>
             Locator.SetLocator(new DryIocDependencyResolver(container));
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Resolves: #311 

**What is the current behavior? (You can also link to an open issue here)**

`UseDryIocDependencyResolver` and `DryIocDependencyResolver` takes a `Container` instance.

**What is the new behavior (if this is a feature change)?**

`UseDryIocDependencyResolver` and `DryIocDependencyResolver` takes a `IContainer` instance.

**What might this PR break?**

Splat.DryIoc

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
