### PR TITLE
WIP: android bitmap skip dynamic and handle exceptions

### DIFF
--- a/src/Splat/Platforms/Android/Bitmaps/PlatformBitmapLoader.cs
+++ b/src/Splat/Platforms/Android/Bitmaps/PlatformBitmapLoader.cs
@@ -104,7 +104,6 @@ namespace Splat
         {
             // VS2019 onward
             var assemblies = AppDomain.CurrentDomain.GetAssemblies()
-                .Where(t => !t.IsDynamic)
                 .SelectMany(GetTypesFromAssembly)
                 .Where(x => x.Name == "Resource" && x.GetNestedType("Drawable") != null)
                 .Select(x => x.GetNestedType("Drawable"))


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**

Mitigates type load exceptions as described in #330

**What is the current behavior? (You can also link to an open issue here)**
Can throw exceptions and not handled as graceful as they could be.

**What is the new behavior (if this is a feature change)?**
skip dynamic assemblies
catch exceptions, log them and return the types we did manage to load.

**What might this PR break?**
If dynamic assemblies are used for generating drawable resources, these will no longer load.
behaviour change that it logs out reflection type load exceptions but will continue if it can.


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Needs a sense check
Also I've queried whether GetExportedTypes should be used instead?