### PR TITLE
housekeeping: Keep users from breaking with a runtime constructor change

### DIFF
--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
@@ -663,7 +663,10 @@ namespace Splat
     }
     public sealed class MemoizingMRUCache<TParam, TVal>
     {
-        public MemoizingMRUCache(System.Func<TParam, object, TVal> calculationFunc, int maxSize, System.Action<TVal> onRelease = null, System.Collections.Generic.IEqualityComparer<TParam> paramComparer = null) { }
+        public MemoizingMRUCache(System.Func<TParam, object, TVal> calculationFunc, int maxSize) { }
+        public MemoizingMRUCache(System.Func<TParam, object, TVal> calculationFunc, int maxSize, System.Action<TVal> onRelease) { }
+        public MemoizingMRUCache(System.Func<TParam, object, TVal> calculationFunc, int maxSize, System.Collections.Generic.IEqualityComparer<TParam> paramComparer) { }
+        public MemoizingMRUCache(System.Func<TParam, object, TVal> calculationFunc, int maxSize, System.Action<TVal> onRelease, System.Collections.Generic.IEqualityComparer<TParam> paramComparer) { }
         public System.Collections.Generic.IEnumerable<TVal> CachedValues() { }
         public TVal Get(TParam key) { }
         public TVal Get(TParam key, object context = null) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
@@ -652,7 +652,10 @@ namespace Splat
     }
     public sealed class MemoizingMRUCache<TParam, TVal>
     {
-        public MemoizingMRUCache(System.Func<TParam, object, TVal> calculationFunc, int maxSize, System.Action<TVal> onRelease = null, System.Collections.Generic.IEqualityComparer<TParam> paramComparer = null) { }
+        public MemoizingMRUCache(System.Func<TParam, object, TVal> calculationFunc, int maxSize) { }
+        public MemoizingMRUCache(System.Func<TParam, object, TVal> calculationFunc, int maxSize, System.Action<TVal> onRelease) { }
+        public MemoizingMRUCache(System.Func<TParam, object, TVal> calculationFunc, int maxSize, System.Collections.Generic.IEqualityComparer<TParam> paramComparer) { }
+        public MemoizingMRUCache(System.Func<TParam, object, TVal> calculationFunc, int maxSize, System.Action<TVal> onRelease, System.Collections.Generic.IEqualityComparer<TParam> paramComparer) { }
         public System.Collections.Generic.IEnumerable<TVal> CachedValues() { }
         public TVal Get(TParam key) { }
         public TVal Get(TParam key, object context = null) { }

--- a/src/Splat/MemoizingMRUCache.cs
+++ b/src/Splat/MemoizingMRUCache.cs
@@ -43,11 +43,54 @@ namespace Splat
         /// user-defined.</param>
         /// <param name="maxSize">The size of the cache to maintain, after which old
         /// items will start to be thrown out.</param>
+        public MemoizingMRUCache(Func<TParam, object, TVal> calculationFunc, int maxSize)
+            : this(calculationFunc, maxSize, null, EqualityComparer<TParam>.Default)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoizingMRUCache{TParam, TVal}"/> class.
+        /// </summary>
+        /// <param name="calculationFunc">The function whose results you want to cache,
+        /// which is provided the key value, and an Tag object that is
+        /// user-defined.</param>
+        /// <param name="maxSize">The size of the cache to maintain, after which old
+        /// items will start to be thrown out.</param>
+        /// <param name="onRelease">A function to call when a result gets
+        /// evicted from the cache (i.e. because Invalidate was called or the
+        /// cache is full).</param>
+        public MemoizingMRUCache(Func<TParam, object, TVal> calculationFunc, int maxSize, Action<TVal> onRelease)
+            : this(calculationFunc, maxSize, onRelease, EqualityComparer<TParam>.Default)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoizingMRUCache{TParam, TVal}"/> class.
+        /// </summary>
+        /// <param name="calculationFunc">The function whose results you want to cache,
+        /// which is provided the key value, and an Tag object that is
+        /// user-defined.</param>
+        /// <param name="maxSize">The size of the cache to maintain, after which old
+        /// items will start to be thrown out.</param>
+        /// <param name="paramComparer">A comparer for the parameter.</param>
+        public MemoizingMRUCache(Func<TParam, object, TVal> calculationFunc, int maxSize, IEqualityComparer<TParam> paramComparer)
+            : this(calculationFunc, maxSize, null, paramComparer)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoizingMRUCache{TParam, TVal}"/> class.
+        /// </summary>
+        /// <param name="calculationFunc">The function whose results you want to cache,
+        /// which is provided the key value, and an Tag object that is
+        /// user-defined.</param>
+        /// <param name="maxSize">The size of the cache to maintain, after which old
+        /// items will start to be thrown out.</param>
         /// <param name="onRelease">A function to call when a result gets
         /// evicted from the cache (i.e. because Invalidate was called or the
         /// cache is full).</param>
         /// <param name="paramComparer">A comparer for the parameter.</param>
-        public MemoizingMRUCache(Func<TParam, object, TVal> calculationFunc, int maxSize, Action<TVal> onRelease = null, IEqualityComparer<TParam> paramComparer = null)
+        public MemoizingMRUCache(Func<TParam, object, TVal> calculationFunc, int maxSize, Action<TVal> onRelease, IEqualityComparer<TParam> paramComparer)
         {
             Contract.Requires(calculationFunc != null);
             Contract.Requires(maxSize > 0);


### PR DESCRIPTION
Resolves issue in https://github.com/reactiveui/ReactiveUI/issues/2081