### PR TITLE
feature: splat init checks for pre registrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,6 @@ There are 2 parts to the locator design:
 * **Locator.Current** The property to use to **retrieve** services. Locator.Current is a static variable that can be set on startup, to adapt Splat to other DI/IoC frameworks. We're currently working from v7 onward to make it easier to use your DI/IoC framework of choice. (see below)
 * **Locator.CurrentMutable** The property to use to **register** services
 
-**Note:** Currently these properties point to the same object and you can use CurrentMutable to also GetServices, but this is not the intention and the interfaces may be adjusted in future to lock this down (and make it more obvious what the use cases are).
-
 To get a service:
 
 ```cs
@@ -131,6 +129,10 @@ Locator.CurrentMutable.RegisterLazySingleton(() => new LazyToaster(), typeof(ITo
 
 ### Dependency Resolver Packages
 For each of the provided dependency resolver adapters, there is a specific package that allows the service locator to be implemented by another ioc container.
+
+Please note: If you are adjusting behaviours of Splat by working with your custom container directly. Please read the relevant projects documentation on
+REPLACING the registration. If the container supports appending\ multiple registrations you may get undesired behaviours, such as the wrong logger factory
+being used.
 
 | Container | NuGet | Read Me
 |---------|-------|-------|

--- a/src/Splat.Autofac.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Autofac.Tests/DependencyResolverTests.cs
@@ -133,5 +133,44 @@ namespace Splat.Autofac.Tests
 
             result.ShouldBeOfType<NotImplementedException>();
         }
+
+        /// <summary>
+        /// Check to ensure the correct logger is returned.
+        /// </summary>
+        /// <remarks>
+        /// Introduced for Splat #331.
+        /// </remarks>
+        [Fact]
+        public void AutofacDependencyResolver_Should_ReturnRegisteredLogger()
+        {
+            var container = new ContainerBuilder();
+            container.UseAutofacDependencyResolver();
+
+            Locator.CurrentMutable.RegisterConstant(
+                new FuncLogManager(type => new WrappingFullLogger(new ConsoleLogger())),
+                typeof(ILogManager));
+
+            var d = Splat.Locator.Current.GetService<ILogManager>();
+            Assert.IsType<FuncLogManager>(d);
+        }
+
+        /// <summary>
+        /// Test that a pre-init logger isn't overriden.
+        /// </summary>
+        /// <remarks>
+        /// Introduced for Splat #331.
+        /// </remarks>
+        [Fact]
+        public void AutofacDependencyResolver_PreInit_Should_ReturnRegisteredLogger()
+        {
+            var builder = new ContainerBuilder();
+            builder.Register(_ => new FuncLogManager(type => new WrappingFullLogger(new ConsoleLogger()))).As(typeof(ILogManager))
+                .AsImplementedInterfaces();
+
+            builder.UseAutofacDependencyResolver();
+
+            var d = Splat.Locator.Current.GetService<ILogManager>();
+            Assert.IsType<FuncLogManager>(d);
+        }
     }
 }

--- a/src/Splat.Autofac.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Autofac.Tests/DependencyResolverTests.cs
@@ -94,36 +94,6 @@ namespace Splat.Autofac.Tests
         /// Should throw an exception if service registration call back called.
         /// </summary>
         [Fact]
-        public void AutofacDependencyResolver_Should_Throw_If_UnregisterCurrent_Called()
-        {
-            var container = new ContainerBuilder();
-            container.UseAutofacDependencyResolver();
-
-            var result = Record.Exception(() =>
-                Locator.CurrentMutable.UnregisterCurrent(typeof(IScreen)));
-
-            result.ShouldBeOfType<NotImplementedException>();
-        }
-
-        /// <summary>
-        /// Should unregister all.
-        /// </summary>
-        [Fact]
-        public void AutofacDependencyResolver_Should_UnregisterAll_Called()
-        {
-            var container = new ContainerBuilder();
-            container.UseAutofacDependencyResolver();
-
-            var result = Record.Exception(() =>
-                Locator.CurrentMutable.UnregisterCurrent(typeof(IScreen)));
-
-            result.ShouldBeOfType<NotImplementedException>();
-        }
-
-        /// <summary>
-        /// Should throw an exception if service registration call back called.
-        /// </summary>
-        [Fact]
         public void AutofacDependencyResolver_Should_Throw_If_ServiceRegistionCallback_Called()
         {
             var container = new ContainerBuilder();

--- a/src/Splat.Autofac.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Autofac.Tests/DependencyResolverTests.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using Autofac;
 using Shouldly;
 using Splat.Common.Test;
+using Splat.Tests.ServiceLocation;
 using Xunit;
 
 namespace Splat.Autofac.Tests
@@ -17,7 +18,7 @@ namespace Splat.Autofac.Tests
     /// <summary>
     /// Tests to show the <see cref="AutofacDependencyResolver"/> works correctly.
     /// </summary>
-    public class DependencyResolverTests
+    public class DependencyResolverTests : BaseDependencyResolverTests<AutofacDependencyResolver>
     {
         /// <summary>
         /// Shoulds the resolve views.
@@ -171,6 +172,13 @@ namespace Splat.Autofac.Tests
 
             var d = Splat.Locator.Current.GetService<ILogManager>();
             Assert.IsType<FuncLogManager>(d);
+        }
+
+        /// <inheritdoc />
+        protected override AutofacDependencyResolver GetDependencyResolver()
+        {
+            var container = new ContainerBuilder();
+            return new AutofacDependencyResolver(container.Build());
         }
     }
 }

--- a/src/Splat.Autofac.Tests/Splat.Autofac.Tests.csproj
+++ b/src/Splat.Autofac.Tests/Splat.Autofac.Tests.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Splat.Autofac\Splat.Autofac.csproj" />
     <ProjectReference Include="..\Splat.Common.Test\Splat.Common.Test.csproj" />
+    <ProjectReference Include="..\Splat.Tests\Splat.Tests.csproj" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -21,6 +21,7 @@ namespace Splat.Autofac
     /// </summary>
     public class AutofacDependencyResolver : IDependencyResolver
     {
+        private readonly object _lockObject = new object();
         private IComponentContext _componentContext;
 
         /// <summary>
@@ -35,39 +36,48 @@ namespace Splat.Autofac
         /// <inheritdoc />
         public virtual object GetService(Type serviceType, string contract = null)
         {
-            try
+            lock (_lockObject)
             {
-                return string.IsNullOrEmpty(contract)
-                    ? _componentContext.Resolve(serviceType)
-                    : _componentContext.ResolveNamed(contract, serviceType);
-            }
-            catch (DependencyResolutionException)
-            {
-                return null;
+                try
+                {
+                    return string.IsNullOrEmpty(contract)
+                        ? _componentContext.Resolve(serviceType)
+                        : _componentContext.ResolveNamed(contract, serviceType);
+                }
+                catch (DependencyResolutionException)
+                {
+                    return null;
+                }
             }
         }
 
         /// <inheritdoc />
         public virtual IEnumerable<object> GetServices(Type serviceType, string contract = null)
         {
-            try
+            lock (_lockObject)
             {
-                var enumerableType = typeof(IEnumerable<>).MakeGenericType(serviceType);
-                object instance = string.IsNullOrEmpty(contract)
-                    ? _componentContext.Resolve(enumerableType)
-                    : _componentContext.ResolveNamed(contract, enumerableType);
-                return ((IEnumerable)instance).Cast<object>();
-            }
-            catch (DependencyResolutionException)
-            {
-                return null;
+                try
+                {
+                    var enumerableType = typeof(IEnumerable<>).MakeGenericType(serviceType);
+                    object instance = string.IsNullOrEmpty(contract)
+                        ? _componentContext.Resolve(enumerableType)
+                        : _componentContext.ResolveNamed(contract, enumerableType);
+                    return ((IEnumerable)instance).Cast<object>();
+                }
+                catch (DependencyResolutionException)
+                {
+                    return null;
+                }
             }
         }
 
         /// <inheritdoc />
         public bool HasRegistration(Type serviceType)
         {
-            return _componentContext.IsRegistered(serviceType);
+            lock (_lockObject)
+            {
+                return _componentContext.IsRegistered(serviceType);
+            }
         }
 
         /// <summary>
@@ -82,17 +92,20 @@ namespace Splat.Autofac
         /// <param name="contract">A optional contract value which will indicates to only generate the value if this contract is specified.</param>
         public virtual void Register(Func<object> factory, Type serviceType, string contract = null)
         {
-            var builder = new ContainerBuilder();
-            if (string.IsNullOrEmpty(contract))
+            lock (_lockObject)
             {
-                builder.Register(x => factory()).As(serviceType).AsImplementedInterfaces();
-            }
-            else
-            {
-                builder.Register(x => factory()).Named(contract, serviceType).AsImplementedInterfaces();
-            }
+                var builder = new ContainerBuilder();
+                if (string.IsNullOrEmpty(contract))
+                {
+                    builder.Register(x => factory()).As(serviceType).AsImplementedInterfaces();
+                }
+                else
+                {
+                    builder.Register(x => factory()).Named(contract, serviceType).AsImplementedInterfaces();
+                }
 
-            builder.Update(_componentContext.ComponentRegistry);
+                builder.Update(_componentContext.ComponentRegistry);
+            }
         }
 
         /// <summary>
@@ -105,76 +118,78 @@ namespace Splat.Autofac
         /// <inheritdoc />
         public virtual void UnregisterCurrent(Type serviceType, string contract = null)
         {
-            // TODO: Thread safety
-            var registrations = _componentContext.ComponentRegistry.Registrations.ToList();
-            var registrationCount = registrations.Count;
-            if (registrationCount < 1)
+            lock (_lockObject)
             {
-                return;
-            }
-
-            var candidatesForRemoval = new List<IComponentRegistration>(registrationCount);
-            var registrationIndex = 0;
-            while (registrationIndex < registrationCount)
-            {
-                var componentRegistration = registrations[registrationIndex];
-
-                var isCandidateForRemoval = GetWhetherServiceIsCandidateForRemoval(
-                    componentRegistration.Services,
-                    serviceType,
-                    contract);
-                if (isCandidateForRemoval)
+                var registrations = _componentContext.ComponentRegistry.Registrations.ToList();
+                var registrationCount = registrations.Count;
+                if (registrationCount < 1)
                 {
-                    registrations.RemoveAt(registrationIndex);
-                    candidatesForRemoval.Add(componentRegistration);
-                    registrationCount--;
+                    return;
                 }
-                else
+
+                var candidatesForRemoval = new List<IComponentRegistration>(registrationCount);
+                var registrationIndex = 0;
+                while (registrationIndex < registrationCount)
                 {
-                    registrationIndex++;
+                    var componentRegistration = registrations[registrationIndex];
+
+                    var isCandidateForRemoval = GetWhetherServiceIsCandidateForRemoval(
+                        componentRegistration.Services,
+                        serviceType,
+                        contract);
+                    if (isCandidateForRemoval)
+                    {
+                        registrations.RemoveAt(registrationIndex);
+                        candidatesForRemoval.Add(componentRegistration);
+                        registrationCount--;
+                    }
+                    else
+                    {
+                        registrationIndex++;
+                    }
                 }
-            }
 
-            if (candidatesForRemoval.Count == 0)
-            {
-                // nothing to remove
-                return;
-            }
-
-            if (candidatesForRemoval.Count > 1)
-            {
-                // need to re-add some registrations
-                var reAdd = candidatesForRemoval.Take(candidatesForRemoval.Count - 1);
-                registrations.AddRange(reAdd);
-
-                /*
-                // check for multi service registration
-                // in future might want to just remove a single service from a component
-                // rather than do the whole component.
-                var lastCandidate = candidatesForRemoval.Last();
-                var lastCandidateRegisteredServices = lastCandidate.Services.ToArray();
-                if (lastCandidateRegisteredServices.Length > 1)
+                if (candidatesForRemoval.Count == 0)
                 {
-                    //
-                    // builder.RegisterType<CallLogger>()
-                    //    .AsSelf()
-                    //    .As<ILogger>()
-                    //    .As<ICallInterceptor>();
-                    var survivingServices = lastCandidateRegisteredServices.Where(s => s.GetType() != serviceType);
-                    var newRegistration = new ComponentRegistration(
-                        lastCandidate.Id,
-                        lastCandidate.Activator,
-                        lastCandidate.Lifetime,
-                        lastCandidate.Sharing,
-                        lastCandidate.Ownership,
-                        survivingServices,
-                        lastCandidate.Metadata);
-                    registrations.Add(newRegistration);
+                    // nothing to remove
+                    return;
                 }
-                */
-            }
 
-            RemoveAndRebuild(registrations);
+                if (candidatesForRemoval.Count > 1)
+                {
+                    // need to re-add some registrations
+                    var reAdd = candidatesForRemoval.Take(candidatesForRemoval.Count - 1);
+                    registrations.AddRange(reAdd);
+
+                    /*
+                    // check for multi service registration
+                    // in future might want to just remove a single service from a component
+                    // rather than do the whole component.
+                    var lastCandidate = candidatesForRemoval.Last();
+                    var lastCandidateRegisteredServices = lastCandidate.Services.ToArray();
+                    if (lastCandidateRegisteredServices.Length > 1)
+                    {
+                        //
+                        // builder.RegisterType<CallLogger>()
+                        //    .AsSelf()
+                        //    .As<ILogger>()
+                        //    .As<ICallInterceptor>();
+                        var survivingServices = lastCandidateRegisteredServices.Where(s => s.GetType() != serviceType);
+                        var newRegistration = new ComponentRegistration(
+                            lastCandidate.Id,
+                            lastCandidate.Activator,
+                            lastCandidate.Lifetime,
+                            lastCandidate.Sharing,
+                            lastCandidate.Ownership,
+                            survivingServices,
+                            lastCandidate.Metadata);
+                        registrations.Add(newRegistration);
+                    }
+                    */
+                }
+
+                RemoveAndRebuild(registrations);
+            }
         }
 
         /// <summary>
@@ -187,18 +202,33 @@ namespace Splat.Autofac
         /// <inheritdoc />
         public virtual void UnregisterAll(Type serviceType, string contract = null)
         {
-            // TODO: Thread safety
-
-            // prevent multiple enumerations
-            var registrations = _componentContext.ComponentRegistry.Registrations.ToList();
-            var registrationCount = registrations.Count;
-            if (registrationCount < 1)
+            lock (_lockObject)
             {
-                return;
-            }
+                // prevent multiple enumerations
+                var registrations = _componentContext.ComponentRegistry.Registrations.ToList();
+                var registrationCount = registrations.Count;
+                if (registrationCount < 1)
+                {
+                    return;
+                }
 
-            if (!string.IsNullOrEmpty(contract))
-            {
+                if (!string.IsNullOrEmpty(contract))
+                {
+                    RemoveAndRebuild(
+                        registrationCount,
+                        registrations,
+                        x => x.Services.All(s =>
+                        {
+                            if (!(s is TypedService typedService))
+                            {
+                                return false;
+                            }
+
+                            return typedService.ServiceType != serviceType || !HasMatchingContract(s, contract);
+                        }));
+                    return;
+                }
+
                 RemoveAndRebuild(
                     registrationCount,
                     registrations,
@@ -209,23 +239,9 @@ namespace Splat.Autofac
                             return false;
                         }
 
-                        return typedService.ServiceType != serviceType || !HasMatchingContract(s, contract);
+                        return typedService.ServiceType != serviceType;
                     }));
-                return;
             }
-
-            RemoveAndRebuild(
-                registrationCount,
-                registrations,
-                x => x.Services.All(s =>
-                {
-                    if (!(s is TypedService typedService))
-                    {
-                        return false;
-                    }
-
-                    return typedService.ServiceType != serviceType;
-                }));
         }
 
         /// <inheritdoc />
@@ -248,9 +264,12 @@ namespace Splat.Autofac
         /// <param name="disposing">Whether or not the instance is disposing.</param>
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
+            lock (_lockObject)
             {
-                _componentContext.ComponentRegistry?.Dispose();
+                if (disposing)
+                {
+                    _componentContext.ComponentRegistry?.Dispose();
+                }
             }
         }
 

--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -63,6 +63,12 @@ namespace Splat.Autofac
             }
         }
 
+        /// <inheritdoc />
+        public bool HasRegistration(Type serviceType)
+        {
+            return _componentContext.IsRegistered(serviceType);
+        }
+
         /// <summary>
         /// Register a function with the resolver which will generate a object
         /// for the specified service type.

--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -202,14 +202,30 @@ namespace Splat.Autofac
                 RemoveAndRebuild(
                     registrationCount,
                     registrations,
-                    x => x.Services.All(s => s.GetType() != serviceType || !HasMatchingContract(s, contract)));
+                    x => x.Services.All(s =>
+                    {
+                        if (!(s is TypedService typedService))
+                        {
+                            return false;
+                        }
+
+                        return typedService.ServiceType != serviceType || !HasMatchingContract(s, contract);
+                    }));
                 return;
             }
 
             RemoveAndRebuild(
                 registrationCount,
                 registrations,
-                x => x.Services.All(s => s.GetType() != serviceType));
+                x => x.Services.All(s =>
+                {
+                    if (!(s is TypedService typedService))
+                    {
+                        return false;
+                    }
+
+                    return typedService.ServiceType != serviceType;
+                }));
         }
 
         /// <inheritdoc />
@@ -245,7 +261,12 @@ namespace Splat.Autofac
         {
             foreach (var componentRegistrationService in componentRegistrationServices)
             {
-                if (componentRegistrationService.GetType() != serviceType)
+                if (!(componentRegistrationService is TypedService typedService))
+                {
+                    continue;
+                }
+
+                if (typedService.ServiceType != serviceType)
                 {
                     continue;
                 }
@@ -262,7 +283,7 @@ namespace Splat.Autofac
                     return true;
                 }
 
-                if (!HasMatchingContract(componentRegistrationService, contract))
+                if (!HasMatchingContract(typedService, contract))
                 {
                     continue;
                 }

--- a/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
+++ b/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
@@ -170,5 +170,37 @@ namespace Splat.DryIoc.Tests
 
             result.ShouldBeOfType<NotImplementedException>();
         }
+
+        /// <summary>
+        /// Check to ensure the correct logger is returned.
+        /// </summary>
+        /// <remarks>
+        /// Introduced for Splat #331.
+        /// </remarks>
+        [Fact]
+        public void DryIocDependencyResolver_Should_ReturnRegisteredLogger()
+        {
+            var c = new Container();
+            c.UseDryIocDependencyResolver();
+            c.Register<ILogger, ConsoleLogger>(ifAlreadyRegistered: IfAlreadyRegistered.Replace);
+            var d = Splat.Locator.Current.GetService<ILogger>();
+            Assert.IsType<ConsoleLogger>(d);
+        }
+
+        /// <summary>
+        /// Test that a pre-init logger isn't overriden.
+        /// </summary>
+        /// <remarks>
+        /// Introduced for Splat #331.
+        /// </remarks>
+        [Fact]
+        public void DryIocDependencyResolver_PreInit_Should_ReturnRegisteredLogger()
+        {
+            var c = new Container();
+            c.Register<ILogger, ConsoleLogger>();
+            c.UseDryIocDependencyResolver();
+            var d = Splat.Locator.Current.GetService<ILogger>();
+            Assert.IsType<ConsoleLogger>(d);
+        }
     }
 }

--- a/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
+++ b/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
@@ -183,8 +183,12 @@ namespace Splat.DryIoc.Tests
             var c = new Container();
             c.UseDryIocDependencyResolver();
             c.Register<ILogger, ConsoleLogger>(ifAlreadyRegistered: IfAlreadyRegistered.Replace);
-            var d = Splat.Locator.Current.GetService<ILogger>();
-            Assert.IsType<ConsoleLogger>(d);
+            Locator.CurrentMutable.RegisterConstant(
+                new FuncLogManager(type => new WrappingFullLogger(new ConsoleLogger())),
+                typeof(ILogManager));
+
+            var d = Splat.Locator.Current.GetService<ILogManager>();
+            Assert.IsType<FuncLogManager>(d);
         }
 
         /// <summary>
@@ -197,10 +201,11 @@ namespace Splat.DryIoc.Tests
         public void DryIocDependencyResolver_PreInit_Should_ReturnRegisteredLogger()
         {
             var c = new Container();
-            c.Register<ILogger, ConsoleLogger>();
+            c.UseInstance(typeof(ILogManager), new FuncLogManager(type => new WrappingFullLogger(new ConsoleLogger())));
             c.UseDryIocDependencyResolver();
-            var d = Splat.Locator.Current.GetService<ILogger>();
-            Assert.IsType<ConsoleLogger>(d);
+
+            var d = Splat.Locator.Current.GetService<ILogManager>();
+            Assert.IsType<FuncLogManager>(d);
         }
     }
 }

--- a/src/Splat.DryIoc/DryIocDependencyResolver.cs
+++ b/src/Splat.DryIoc/DryIocDependencyResolver.cs
@@ -31,8 +31,8 @@ namespace Splat.DryIoc
         /// <inheritdoc />
         public virtual object GetService(Type serviceType, string contract = null) =>
             string.IsNullOrEmpty(contract)
-                ? _container.Resolve(serviceType, IfUnresolved.ReturnDefault)
-                : _container.Resolve(serviceType, contract, IfUnresolved.ReturnDefault);
+                ? _container.ResolveMany(serviceType).LastOrDefault()
+                : _container.ResolveMany(serviceType, serviceKey: contract).LastOrDefault();
 
         /// <inheritdoc />
         public virtual IEnumerable<object> GetServices(Type serviceType, string contract = null) =>
@@ -51,11 +51,11 @@ namespace Splat.DryIoc
         {
             if (string.IsNullOrEmpty(contract))
             {
-                _container.UseInstance(serviceType, factory(), IfAlreadyRegistered.Replace);
+                _container.UseInstance(serviceType, factory(), IfAlreadyRegistered.AppendNewImplementation);
             }
             else
             {
-                _container.UseInstance(serviceType, factory(), IfAlreadyRegistered.Replace, serviceKey: contract);
+                _container.UseInstance(serviceType, factory(), IfAlreadyRegistered.AppendNewImplementation, serviceKey: contract);
             }
         }
 

--- a/src/Splat.DryIoc/DryIocDependencyResolver.cs
+++ b/src/Splat.DryIoc/DryIocDependencyResolver.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using DryIoc;
 
 namespace Splat.DryIoc
@@ -40,15 +41,21 @@ namespace Splat.DryIoc
                 : _container.ResolveMany(serviceType, serviceKey: contract);
 
         /// <inheritdoc />
+        public bool HasRegistration(Type serviceType)
+        {
+            return _container.GetServiceRegistrations().Any(x => x.ServiceType == serviceType);
+        }
+
+        /// <inheritdoc />
         public virtual void Register(Func<object> factory, Type serviceType, string contract = null)
         {
             if (string.IsNullOrEmpty(contract))
             {
-                _container.UseInstance(serviceType, factory(), IfAlreadyRegistered.AppendNewImplementation);
+                _container.UseInstance(serviceType, factory(), IfAlreadyRegistered.Replace);
             }
             else
             {
-                _container.UseInstance(serviceType, factory(), IfAlreadyRegistered.AppendNewImplementation, serviceKey: contract);
+                _container.UseInstance(serviceType, factory(), IfAlreadyRegistered.Replace, serviceKey: contract);
             }
         }
 

--- a/src/Splat.Ninject/NinjectDependencyResolver.cs
+++ b/src/Splat.Ninject/NinjectDependencyResolver.cs
@@ -39,6 +39,12 @@ namespace Splat.Ninject
                 : _kernel.GetAll(serviceType, contract);
 
         /// <inheritdoc />
+        public bool HasRegistration(Type serviceType)
+        {
+            return _kernel.CanResolve(serviceType);
+        }
+
+        /// <inheritdoc />
         public virtual void Register(Func<object> factory, Type serviceType, string contract = null) =>
             _kernel.Bind(serviceType).ToMethod(_ => factory());
 

--- a/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
+++ b/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using SimpleInjector;
 
 namespace Splat.SimpleInjector
@@ -27,11 +28,20 @@ namespace Splat.SimpleInjector
         }
 
         /// <inheritdoc />
-        public object GetService(Type serviceType, string contract = null) => _container.GetInstance(serviceType);
+        public object GetService(Type serviceType, string contract = null)
+        {
+            return _container.GetInstance(serviceType);
+        }
 
         /// <inheritdoc />
         public IEnumerable<object> GetServices(Type serviceType, string contract = null) =>
             _container.GetAllInstances(serviceType);
+
+        /// <inheritdoc />
+        public bool HasRegistration(Type serviceType)
+        {
+            return _container.GetCurrentRegistrations().Any(x => x.ServiceType == serviceType);
+        }
 
         /// <inheritdoc />
         public void Register(Func<object> factory, Type serviceType, string contract = null) =>

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
@@ -217,6 +217,7 @@ namespace Splat
         protected virtual void Dispose(bool isDisposing) { }
         public object GetService(System.Type serviceType, string contract = null) { }
         public System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string contract = null) { }
+        public bool HasRegistration(System.Type serviceType) { }
         public void Register(System.Func<object> factory, System.Type serviceType, string contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string contract, System.Action<System.IDisposable> callback) { }
         public void UnregisterAll(System.Type serviceType, string contract = null) { }
@@ -440,6 +441,7 @@ namespace Splat
     }
     public interface IMutableDependencyResolver
     {
+        bool HasRegistration(System.Type serviceType);
         void Register(System.Func<object> factory, System.Type serviceType, string contract = null);
         System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string contract, System.Action<System.IDisposable> callback);
         void UnregisterAll(System.Type serviceType, string contract = null);
@@ -689,6 +691,7 @@ namespace Splat
         public Splat.ModernDependencyResolver Duplicate() { }
         public object GetService(System.Type serviceType, string contract = null) { }
         public System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string contract = null) { }
+        public bool HasRegistration(System.Type serviceType) { }
         public void Register(System.Func<object> factory, System.Type serviceType, string contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string contract, System.Action<System.IDisposable> callback) { }
         public void UnregisterAll(System.Type serviceType, string contract = null) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
@@ -685,7 +685,9 @@ namespace Splat
     public class ModernDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
         public ModernDependencyResolver() { }
-        protected ModernDependencyResolver(System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>> registry) { }
+        protected ModernDependencyResolver([System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+                "serviceType",
+                "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>> registry) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
         public Splat.ModernDependencyResolver Duplicate() { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
@@ -181,7 +181,6 @@ namespace Splat
     {
         public static T GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string contract = null) { }
         public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string contract = null) { }
-        public static void InitializeSplat(this Splat.IMutableDependencyResolver resolver) { }
         public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> factory, string contract = null) { }
         public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object value, System.Type serviceType, string contract = null) { }
         public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T value, string contract = null) { }
@@ -760,6 +759,10 @@ namespace Splat
         public static System.Tuple<System.Drawing.RectangleF, System.Drawing.RectangleF> Divide(this System.Drawing.RectangleF value, float amount, Splat.RectEdge fromEdge) { }
         public static System.Tuple<System.Drawing.RectangleF, System.Drawing.RectangleF> DivideWithPadding(this System.Drawing.RectangleF value, float sliceAmount, float padding, Splat.RectEdge fromEdge) { }
         public static System.Drawing.RectangleF InvertWithin(this System.Drawing.RectangleF value, System.Drawing.RectangleF containingRect) { }
+    }
+    public class static ServiceLocationInitialization
+    {
+        public static void InitializeSplat(this Splat.IMutableDependencyResolver resolver) { }
     }
     public class static SizeExtensions
     {

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net472.approved.txt
@@ -685,7 +685,7 @@ namespace Splat
     public class ModernDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
         public ModernDependencyResolver() { }
-        protected ModernDependencyResolver(System.Collections.Generic.Dictionary<System.Tuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>> registry) { }
+        protected ModernDependencyResolver(System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>> registry) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
         public Splat.ModernDependencyResolver Duplicate() { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
@@ -170,7 +170,6 @@ namespace Splat
     {
         public static T GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string contract = null) { }
         public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string contract = null) { }
-        public static void InitializeSplat(this Splat.IMutableDependencyResolver resolver) { }
         public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> factory, string contract = null) { }
         public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object value, System.Type serviceType, string contract = null) { }
         public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T value, string contract = null) { }
@@ -724,6 +723,10 @@ namespace Splat
         public static System.Tuple<System.Drawing.RectangleF, System.Drawing.RectangleF> Divide(this System.Drawing.RectangleF value, float amount, Splat.RectEdge fromEdge) { }
         public static System.Tuple<System.Drawing.RectangleF, System.Drawing.RectangleF> DivideWithPadding(this System.Drawing.RectangleF value, float sliceAmount, float padding, Splat.RectEdge fromEdge) { }
         public static System.Drawing.RectangleF InvertWithin(this System.Drawing.RectangleF value, System.Drawing.RectangleF containingRect) { }
+    }
+    public class static ServiceLocationInitialization
+    {
+        public static void InitializeSplat(this Splat.IMutableDependencyResolver resolver) { }
     }
     public class static SizeMathExtensions
     {

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
@@ -206,6 +206,7 @@ namespace Splat
         protected virtual void Dispose(bool isDisposing) { }
         public object GetService(System.Type serviceType, string contract = null) { }
         public System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string contract = null) { }
+        public bool HasRegistration(System.Type serviceType) { }
         public void Register(System.Func<object> factory, System.Type serviceType, string contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string contract, System.Action<System.IDisposable> callback) { }
         public void UnregisterAll(System.Type serviceType, string contract = null) { }
@@ -429,6 +430,7 @@ namespace Splat
     }
     public interface IMutableDependencyResolver
     {
+        bool HasRegistration(System.Type serviceType);
         void Register(System.Func<object> factory, System.Type serviceType, string contract = null);
         System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string contract, System.Action<System.IDisposable> callback);
         void UnregisterAll(System.Type serviceType, string contract = null);
@@ -678,6 +680,7 @@ namespace Splat
         public Splat.ModernDependencyResolver Duplicate() { }
         public object GetService(System.Type serviceType, string contract = null) { }
         public System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string contract = null) { }
+        public bool HasRegistration(System.Type serviceType) { }
         public void Register(System.Func<object> factory, System.Type serviceType, string contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string contract, System.Action<System.IDisposable> callback) { }
         public void UnregisterAll(System.Type serviceType, string contract = null) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
@@ -674,7 +674,7 @@ namespace Splat
     public class ModernDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
         public ModernDependencyResolver() { }
-        protected ModernDependencyResolver(System.Collections.Generic.Dictionary<System.Tuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>> registry) { }
+        protected ModernDependencyResolver(System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>> registry) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
         public Splat.ModernDependencyResolver Duplicate() { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp2.1.approved.txt
@@ -674,7 +674,9 @@ namespace Splat
     public class ModernDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
         public ModernDependencyResolver() { }
-        protected ModernDependencyResolver(System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>> registry) { }
+        protected ModernDependencyResolver([System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+                "serviceType",
+                "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>> registry) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
         public Splat.ModernDependencyResolver Duplicate() { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.0.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.0.approved.txt
@@ -217,6 +217,7 @@ namespace Splat
         protected virtual void Dispose(bool isDisposing) { }
         public object GetService(System.Type serviceType, string contract = null) { }
         public System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string contract = null) { }
+        public bool HasRegistration(System.Type serviceType) { }
         public void Register(System.Func<object> factory, System.Type serviceType, string contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string contract, System.Action<System.IDisposable> callback) { }
         public void UnregisterAll(System.Type serviceType, string contract = null) { }
@@ -440,6 +441,7 @@ namespace Splat
     }
     public interface IMutableDependencyResolver
     {
+        bool HasRegistration(System.Type serviceType);
         void Register(System.Func<object> factory, System.Type serviceType, string contract = null);
         System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string contract, System.Action<System.IDisposable> callback);
         void UnregisterAll(System.Type serviceType, string contract = null);
@@ -689,6 +691,7 @@ namespace Splat
         public Splat.ModernDependencyResolver Duplicate() { }
         public object GetService(System.Type serviceType, string contract = null) { }
         public System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string contract = null) { }
+        public bool HasRegistration(System.Type serviceType) { }
         public void Register(System.Func<object> factory, System.Type serviceType, string contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string contract, System.Action<System.IDisposable> callback) { }
         public void UnregisterAll(System.Type serviceType, string contract = null) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.0.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.0.approved.txt
@@ -685,7 +685,9 @@ namespace Splat
     public class ModernDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
         public ModernDependencyResolver() { }
-        protected ModernDependencyResolver(System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>> registry) { }
+        protected ModernDependencyResolver([System.Runtime.CompilerServices.TupleElementNamesAttribute(new string[] {
+                "serviceType",
+                "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>> registry) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
         public Splat.ModernDependencyResolver Duplicate() { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.0.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.0.approved.txt
@@ -181,7 +181,6 @@ namespace Splat
     {
         public static T GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string contract = null) { }
         public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string contract = null) { }
-        public static void InitializeSplat(this Splat.IMutableDependencyResolver resolver) { }
         public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> factory, string contract = null) { }
         public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object value, System.Type serviceType, string contract = null) { }
         public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T value, string contract = null) { }
@@ -760,6 +759,10 @@ namespace Splat
         public static System.Tuple<System.Drawing.RectangleF, System.Drawing.RectangleF> Divide(this System.Drawing.RectangleF value, float amount, Splat.RectEdge fromEdge) { }
         public static System.Tuple<System.Drawing.RectangleF, System.Drawing.RectangleF> DivideWithPadding(this System.Drawing.RectangleF value, float sliceAmount, float padding, Splat.RectEdge fromEdge) { }
         public static System.Drawing.RectangleF InvertWithin(this System.Drawing.RectangleF value, System.Drawing.RectangleF containingRect) { }
+    }
+    public class static ServiceLocationInitialization
+    {
+        public static void InitializeSplat(this Splat.IMutableDependencyResolver resolver) { }
     }
     public class static SizeExtensions
     {

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.0.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.0.approved.txt
@@ -685,7 +685,7 @@ namespace Splat
     public class ModernDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
         public ModernDependencyResolver() { }
-        protected ModernDependencyResolver(System.Collections.Generic.Dictionary<System.Tuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>> registry) { }
+        protected ModernDependencyResolver(System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>> registry) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
         public Splat.ModernDependencyResolver Duplicate() { }

--- a/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
+++ b/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
@@ -27,6 +27,42 @@ namespace Splat.Tests.ServiceLocation
         }
 
         /// <summary>
+        /// Test to ensure UnregisterCurrent removes last entry.
+        /// </summary>
+        [Fact]
+        public void UnregisterCurrent_Remove_Last()
+        {
+            var resolver = GetDependencyResolver();
+            var type = typeof(ILogManager);
+            resolver.Register(() => new DefaultLogManager(), type);
+            resolver.Register(() => new FuncLogManager(_ => new WrappingFullLogger(new DebugLogger())), type);
+            resolver.Register(() => new DefaultLogManager(), type, "named");
+
+            var service = resolver.GetService(type);
+            Assert.IsType<FuncLogManager>(service);
+
+            resolver.UnregisterCurrent(type);
+
+            service = resolver.GetService(type);
+            Assert.IsType<DefaultLogManager>(service);
+        }
+
+        /// <summary>
+        /// Test to ensure Unregister doesn't cause an IndexOutOfRangeException.
+        /// </summary>
+        [Fact]
+        public void UnregisterCurrentByName_Doesnt_Throw_When_List_Empty()
+        {
+            var resolver = GetDependencyResolver();
+            var type = typeof(ILogManager);
+            var contract = "named";
+            resolver.Register(() => new DefaultLogManager(), type);
+            resolver.Register(() => new DefaultLogManager(), type, contract);
+            resolver.UnregisterCurrent(type, contract);
+            resolver.UnregisterCurrent(type, contract);
+        }
+
+        /// <summary>
         /// Test to ensure Unregister doesn't cause an IndexOutOfRangeException.
         /// </summary>
         [Fact]
@@ -38,6 +74,21 @@ namespace Splat.Tests.ServiceLocation
             resolver.Register(() => new DefaultLogManager(), type, "named");
             resolver.UnregisterAll(type);
             resolver.UnregisterCurrent(type);
+        }
+
+        /// <summary>
+        /// Test to ensure Unregister doesn't cause an IndexOutOfRangeException.
+        /// </summary>
+        [Fact]
+        public void UnregisterAllByContract_UnregisterCurrent_Doesnt_Throw_When_List_Empty()
+        {
+            var resolver = GetDependencyResolver();
+            var type = typeof(ILogManager);
+            var contract = "named";
+            resolver.Register(() => new DefaultLogManager(), type);
+            resolver.Register(() => new DefaultLogManager(), type, contract);
+            resolver.UnregisterAll(type, contract);
+            resolver.UnregisterCurrent(type, contract);
         }
 
         /// <summary>

--- a/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
+++ b/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Splat.Tests.ServiceLocation
+{
+    /// <summary>
+    /// Common tests for Dependency Resolver interaction with Splat.
+    /// </summary>
+    /// <typeparam name="T">The dependency resolver to test.</typeparam>
+    public abstract class BaseDependencyResolverTests<T>
+        where T : IDependencyResolver
+    {
+        /// <summary>
+        /// Test to ensure Unregister doesn't cause an IndexOutOfRangeException.
+        /// </summary>
+        [Fact]
+        public void UnregisterCurrent_Doesnt_Throw_When_List_Empty()
+        {
+            var resolver = GetDependencyResolver();
+            var type = typeof(ILogManager);
+            resolver.Register(() => new DefaultLogManager(), type);
+            resolver.Register(() => new DefaultLogManager(), type, "named");
+            resolver.UnregisterCurrent(type);
+            resolver.UnregisterCurrent(type);
+        }
+
+        /// <summary>
+        /// Test to ensure Unregister doesn't cause an IndexOutOfRangeException.
+        /// </summary>
+        [Fact]
+        public void UnregisterAll_UnregisterCurrent_Doesnt_Throw_When_List_Empty()
+        {
+            var resolver = GetDependencyResolver();
+            var type = typeof(ILogManager);
+            resolver.Register(() => new DefaultLogManager(), type);
+            resolver.Register(() => new DefaultLogManager(), type, "named");
+            resolver.UnregisterAll(type);
+            resolver.UnregisterCurrent(type);
+        }
+
+        /// <summary>
+        /// Gets an instance of a dependency resolver to test.
+        /// </summary>
+        /// <returns>Dependency Resolver.</returns>
+        protected abstract T GetDependencyResolver();
+    }
+}

--- a/src/Splat.Tests/ServiceLocation/ModernDependencyResolverTests.cs
+++ b/src/Splat.Tests/ServiceLocation/ModernDependencyResolverTests.cs
@@ -8,32 +8,9 @@ namespace Splat.Tests.ServiceLocation
     /// <summary>
     /// Unit Tests for the Modern Dependency Resolver.
     /// </summary>
-    public sealed class ModernDependencyResolverTests
+    public sealed class ModernDependencyResolverTests : BaseDependencyResolverTests<ModernDependencyResolver>
     {
-        /// <summary>
-        /// Test to ensure Unregister doesn't cause an IndexOutOfRangeException.
-        /// </summary>
-        [Fact]
-        public void UnregisterCurrent_Doesnt_Throw_When_List_Empty()
-        {
-            var resolver = new ModernDependencyResolver();
-            var type = typeof(ILogManager);
-            resolver.Register(() => new DefaultLogManager(), type);
-            resolver.UnregisterCurrent(type);
-            resolver.UnregisterCurrent(type);
-        }
-
-        /// <summary>
-        /// Test to ensure Unregister doesn't cause an IndexOutOfRangeException.
-        /// </summary>
-        [Fact]
-        public void UnregisterAll_UnregisterCurrent_Doesnt_Throw_When_List_Empty()
-        {
-            var resolver = new ModernDependencyResolver();
-            var type = typeof(ILogManager);
-            resolver.Register(() => new DefaultLogManager(), type);
-            resolver.UnregisterAll(type);
-            resolver.UnregisterCurrent(type);
-        }
+        /// <inheritdoc />
+        protected override ModernDependencyResolver GetDependencyResolver() => new ModernDependencyResolver();
     }
 }

--- a/src/Splat.Tests/ServiceLocation/ModernDependencyResolverTests.cs
+++ b/src/Splat.Tests/ServiceLocation/ModernDependencyResolverTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Splat.Tests.ServiceLocation
+{
+    /// <summary>
+    /// Unit Tests for the Modern Dependency Resolver.
+    /// </summary>
+    public sealed class ModernDependencyResolverTests
+    {
+        /// <summary>
+        /// Test to ensure Unregister doesn't cause an IndexOutOfRangeException.
+        /// </summary>
+        [Fact]
+        public void UnregisterCurrent_Doesnt_Throw_When_List_Empty()
+        {
+            var resolver = new ModernDependencyResolver();
+            var type = typeof(ILogManager);
+            resolver.Register(() => new DefaultLogManager(), type);
+            resolver.UnregisterCurrent(type);
+            resolver.UnregisterCurrent(type);
+        }
+
+        /// <summary>
+        /// Test to ensure Unregister doesn't cause an IndexOutOfRangeException.
+        /// </summary>
+        [Fact]
+        public void UnregisterAll_UnregisterCurrent_Doesnt_Throw_When_List_Empty()
+        {
+            var resolver = new ModernDependencyResolver();
+            var type = typeof(ILogManager);
+            resolver.Register(() => new DefaultLogManager(), type);
+            resolver.UnregisterAll(type);
+            resolver.UnregisterCurrent(type);
+        }
+    }
+}

--- a/src/Splat/ServiceLocation/DependencyResolverMixins.cs
+++ b/src/Splat/ServiceLocation/DependencyResolverMixins.cs
@@ -155,45 +155,5 @@ namespace Splat
         {
             resolver.UnregisterAll(typeof(T), contract);
         }
-
-        /// <summary>
-        /// Registers all the default registrations that are needed by the Splat module.
-        /// </summary>
-        /// <param name="resolver">The resolver to register the needed service types against.</param>
-        public static void InitializeSplat(this IMutableDependencyResolver resolver)
-        {
-            RegisterDefaultLogManager(resolver);
-            RegisterLogger(resolver);
-#if !NETSTANDARD
-            RegisterPlatformBitmapLoader(resolver);
-#endif
-        }
-
-        private static void RegisterDefaultLogManager(IMutableDependencyResolver resolver)
-        {
-            if (!resolver.HasRegistration(typeof(ILogManager)))
-            {
-                resolver.Register(() => new DefaultLogManager(), typeof(ILogManager));
-            }
-        }
-
-        private static void RegisterLogger(IMutableDependencyResolver resolver)
-        {
-            if (!resolver.HasRegistration(typeof(ILogger)))
-            {
-                resolver.RegisterConstant(new DebugLogger(), typeof(ILogger));
-            }
-        }
-
-#if !NETSTANDARD
-        private static void RegisterPlatformBitmapLoader(IMutableDependencyResolver resolver)
-        {
-            // not supported in netstandard2.0
-            if (!resolver.HasRegistration(typeof(IBitmapLoader)))
-            {
-                resolver.RegisterLazySingleton(() => new PlatformBitmapLoader(), typeof(IBitmapLoader));
-            }
-        }
-#endif
     }
 }

--- a/src/Splat/ServiceLocation/DependencyResolverMixins.cs
+++ b/src/Splat/ServiceLocation/DependencyResolverMixins.cs
@@ -162,13 +162,38 @@ namespace Splat
         /// <param name="resolver">The resolver to register the needed service types against.</param>
         public static void InitializeSplat(this IMutableDependencyResolver resolver)
         {
-            resolver.Register(() => new DefaultLogManager(), typeof(ILogManager));
-            resolver.RegisterConstant(new DebugLogger(), typeof(ILogger));
-
+            RegisterDefaultLogManager(resolver);
+            RegisterLogger(resolver);
 #if !NETSTANDARD
-            // not supported in netstandard2.0
-            resolver.RegisterLazySingleton(() => new PlatformBitmapLoader(), typeof(IBitmapLoader));
+            RegisterPlatformBitmapLoader(resolver);
 #endif
         }
+
+        private static void RegisterDefaultLogManager(IMutableDependencyResolver resolver)
+        {
+            if (!resolver.HasRegistration(typeof(ILogManager)))
+            {
+                resolver.Register(() => new DefaultLogManager(), typeof(ILogManager));
+            }
+        }
+
+        private static void RegisterLogger(IMutableDependencyResolver resolver)
+        {
+            if (!resolver.HasRegistration(typeof(ILogger)))
+            {
+                resolver.RegisterConstant(new DebugLogger(), typeof(ILogger));
+            }
+        }
+
+#if !NETSTANDARD
+        private static void RegisterPlatformBitmapLoader(IMutableDependencyResolver resolver)
+        {
+            // not supported in netstandard2.0
+            if (!resolver.HasRegistration(typeof(IBitmapLoader)))
+            {
+                resolver.RegisterLazySingleton(() => new PlatformBitmapLoader(), typeof(IBitmapLoader));
+            }
+        }
+#endif
     }
 }

--- a/src/Splat/ServiceLocation/FuncDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/FuncDependencyResolver.cs
@@ -61,6 +61,12 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public bool HasRegistration(Type serviceType)
+        {
+            return _innerGetServices(serviceType, null) != null;
+        }
+
+        /// <inheritdoc />
         public void Register(Func<object> factory, Type serviceType, string contract = null)
         {
             if (_innerRegister == null)

--- a/src/Splat/ServiceLocation/IMutableDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/IMutableDependencyResolver.cs
@@ -13,6 +13,13 @@ namespace Splat
     public interface IMutableDependencyResolver
     {
         /// <summary>
+        /// Check to see if a resolvers has a registration for a type.
+        /// </summary>
+        /// <param name="serviceType">The type to check for registration.</param>
+        /// <returns>Whether there is a registration for the type.</returns>
+        bool HasRegistration(Type serviceType);
+
+        /// <summary>
         /// Register a function with the resolver which will generate a object
         /// for the specified service type.
         /// Optionally a contract can be registered which will indicate

--- a/src/Splat/ServiceLocation/ModernDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/ModernDependencyResolver.cs
@@ -52,7 +52,8 @@ namespace Splat
         /// <inheritdoc />
         public bool HasRegistration(Type serviceType)
         {
-            return _registry.Any(x => x.Key.Item1 == serviceType);
+            var pair = Tuple.Create(serviceType, string.Empty);
+            return _registry.ContainsKey(pair);
         }
 
         /// <inheritdoc />

--- a/src/Splat/ServiceLocation/ModernDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/ModernDependencyResolver.cs
@@ -50,6 +50,12 @@ namespace Splat
         }
 
         /// <inheritdoc />
+        public bool HasRegistration(Type serviceType)
+        {
+            return _registry.Any(x => x.Key.Item1 == serviceType);
+        }
+
+        /// <inheritdoc />
         public void Register(Func<object> factory, Type serviceType, string contract = null)
         {
             var pair = Tuple.Create(serviceType, contract ?? string.Empty);

--- a/src/Splat/ServiceLocation/ModernDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/ModernDependencyResolver.cs
@@ -23,8 +23,8 @@ namespace Splat
     /// </summary>
     public class ModernDependencyResolver : IDependencyResolver
     {
-        private Dictionary<Tuple<Type, string>, List<Func<object>>> _registry;
-        private Dictionary<Tuple<Type, string>, List<Action<IDisposable>>> _callbackRegistry;
+        private Dictionary<ValueTuple<Type, string>, List<Func<object>>> _registry;
+        private Dictionary<ValueTuple<Type, string>, List<Action<IDisposable>>> _callbackRegistry;
 
         private bool _isDisposed;
 
@@ -40,26 +40,26 @@ namespace Splat
         /// Initializes a new instance of the <see cref="ModernDependencyResolver"/> class.
         /// </summary>
         /// <param name="registry">A registry of services.</param>
-        protected ModernDependencyResolver(Dictionary<Tuple<Type, string>, List<Func<object>>> registry)
+        protected ModernDependencyResolver(Dictionary<ValueTuple<Type, string>, List<Func<object>>> registry)
         {
             _registry = registry != null ?
                 registry.ToDictionary(k => k.Key, v => v.Value.ToList()) :
-                new Dictionary<Tuple<Type, string>, List<Func<object>>>();
+                new Dictionary<ValueTuple<Type, string>, List<Func<object>>>();
 
-            _callbackRegistry = new Dictionary<Tuple<Type, string>, List<Action<IDisposable>>>();
+            _callbackRegistry = new Dictionary<ValueTuple<Type, string>, List<Action<IDisposable>>>();
         }
 
         /// <inheritdoc />
         public bool HasRegistration(Type serviceType)
         {
-            var pair = Tuple.Create(serviceType, string.Empty);
+            var pair = ValueTuple.Create(serviceType, string.Empty);
             return _registry.ContainsKey(pair);
         }
 
         /// <inheritdoc />
         public void Register(Func<object> factory, Type serviceType, string contract = null)
         {
-            var pair = Tuple.Create(serviceType, contract ?? string.Empty);
+            var pair = ValueTuple.Create(serviceType, contract ?? string.Empty);
             if (!_registry.ContainsKey(pair))
             {
                 _registry[pair] = new List<Func<object>>();
@@ -101,7 +101,7 @@ namespace Splat
         /// <inheritdoc />
         public object GetService(Type serviceType, string contract = null)
         {
-            var pair = Tuple.Create(serviceType, contract ?? string.Empty);
+            var pair = ValueTuple.Create(serviceType, contract ?? string.Empty);
             if (!_registry.ContainsKey(pair))
             {
                 return default(object);
@@ -114,7 +114,7 @@ namespace Splat
         /// <inheritdoc />
         public IEnumerable<object> GetServices(Type serviceType, string contract = null)
         {
-            var pair = Tuple.Create(serviceType, contract ?? string.Empty);
+            var pair = ValueTuple.Create(serviceType, contract ?? string.Empty);
             if (!_registry.ContainsKey(pair))
             {
                 return Enumerable.Empty<object>();
@@ -126,7 +126,7 @@ namespace Splat
         /// <inheritdoc />
         public void UnregisterCurrent(Type serviceType, string contract = null)
         {
-            var pair = Tuple.Create(serviceType, contract ?? string.Empty);
+            var pair = ValueTuple.Create(serviceType, contract ?? string.Empty);
 
             if (!_registry.TryGetValue(pair, out var list))
             {
@@ -139,7 +139,7 @@ namespace Splat
         /// <inheritdoc />
         public void UnregisterAll(Type serviceType, string contract = null)
         {
-            var pair = Tuple.Create(serviceType, contract ?? string.Empty);
+            var pair = ValueTuple.Create(serviceType, contract ?? string.Empty);
 
             _registry[pair] = new List<Func<object>>();
         }
@@ -147,7 +147,7 @@ namespace Splat
         /// <inheritdoc />
         public IDisposable ServiceRegistrationCallback(Type serviceType, string contract, Action<IDisposable> callback)
         {
-            var pair = Tuple.Create(serviceType, contract ?? string.Empty);
+            var pair = ValueTuple.Create(serviceType, contract ?? string.Empty);
 
             if (!_callbackRegistry.ContainsKey(pair))
             {

--- a/src/Splat/ServiceLocation/ModernDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/ModernDependencyResolver.cs
@@ -133,7 +133,13 @@ namespace Splat
                 return;
             }
 
-            list.RemoveAt(list.Count - 1);
+            var position = list.Count - 1;
+            if (position < 0)
+            {
+                return;
+            }
+
+            list.RemoveAt(position);
         }
 
         /// <inheritdoc />

--- a/src/Splat/ServiceLocation/ServiceLocationInitialization.cs
+++ b/src/Splat/ServiceLocation/ServiceLocationInitialization.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) 2019 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Splat
+{
+    /// <summary>
+    /// Initialization logic for Splat interacting with Dependency Resolvers.
+    /// </summary>
+    public static class ServiceLocationInitialization
+    {
+        /// <summary>
+        /// Registers all the default registrations that are needed by the Splat module.
+        /// </summary>
+        /// <param name="resolver">The resolver to register the needed service types against.</param>
+        public static void InitializeSplat(this IMutableDependencyResolver resolver)
+        {
+            RegisterDefaultLogManager(resolver);
+            RegisterLogger(resolver);
+#if !NETSTANDARD
+            RegisterPlatformBitmapLoader(resolver);
+#endif
+        }
+
+        private static void RegisterDefaultLogManager(IMutableDependencyResolver resolver)
+        {
+            if (!resolver.HasRegistration(typeof(ILogManager)))
+            {
+                resolver.Register(() => new DefaultLogManager(), typeof(ILogManager));
+            }
+        }
+
+        private static void RegisterLogger(IMutableDependencyResolver resolver)
+        {
+            if (!resolver.HasRegistration(typeof(ILogger)))
+            {
+                resolver.RegisterConstant(new DebugLogger(), typeof(ILogger));
+            }
+        }
+
+#if !NETSTANDARD
+        private static void RegisterPlatformBitmapLoader(IMutableDependencyResolver resolver)
+        {
+            // not supported in netstandard2.0
+            if (!resolver.HasRegistration(typeof(IBitmapLoader)))
+            {
+                resolver.RegisterLazySingleton(() => new PlatformBitmapLoader(), typeof(IBitmapLoader));
+            }
+        }
+#endif
+    }
+}

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.0",
+  "version": "8.1",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/preview/.*", // we release previews


### PR DESCRIPTION
**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Resolves #331
I've changed the splat init logic to check if the resolver it is being hooked up to has already got registrations to types we're interested in (LogManager, Logger, BitmapLoader)


**What is the current behavior? (You can also link to an open issue here)**
depending on the nuance of the container involved. logging would be overridden or appended with no guaranteed order of retrieval.


**What is the new behavior (if this is a feature change)?**
tried to apply some consistency between dryioc and moderndependencyresolver. developers still have control within dryioc etc to get undesired behaviour. added documentation to that effect.


**What might this PR break?**
I've added a HasRegistration method call to the Mutable Resolver interface
- [x] I've changed DryIoc to replace registrations instead of append - can someone sense check this please :)



**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

