### PR TITLE
fix: Microsoft dependency injection IDependencyResolver.GetServices returns null

### DIFF
--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/MicrosoftDependencyResolverTests.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/MicrosoftDependencyResolverTests.cs
@@ -8,6 +8,7 @@ namespace Splat.Tests.ServiceLocation
 {
     /// <summary>
     /// Unit Tests for the Modern Dependency Resolver.
+    /// The tests from here should really be brought down to the base test and be tested in all DIs.
     /// </summary>
     public sealed class MicrosoftDependencyResolverTests : BaseDependencyResolverTests<MicrosoftDependencyResolver>
     {
@@ -30,6 +31,18 @@ namespace Splat.Tests.ServiceLocation
 
             value = resolver.GetService(null, contract);
             Assert.Equal(bar, value);
+        }
+
+        /// <summary>
+        /// Ensures <see cref="IReadonlyDependencyResolver.GetServices(Type, string)"/> never returns null.
+        /// </summary>
+        [Fact]
+        public void GetServices_ShouldNeverReturnNull()
+        {
+            var resolver = GetDependencyResolver();
+
+            Assert.NotNull(resolver.GetServices<string>());
+            Assert.NotNull(resolver.GetServices<string>("Landscape"));
         }
 
         /// <inheritdoc />

--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/MicrosoftDependencyResolverTests.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/MicrosoftDependencyResolverTests.cs
@@ -8,12 +8,13 @@ namespace Splat.Tests.ServiceLocation
 {
     /// <summary>
     /// Unit Tests for the Modern Dependency Resolver.
-    /// The tests from here should really be brought down to the base test and be tested in all DIs.
     /// </summary>
     public sealed class MicrosoftDependencyResolverTests : BaseDependencyResolverTests<MicrosoftDependencyResolver>
     {
         /// <summary>
         /// Test to ensure container allows registration with null service type.
+        /// Should really be brought down to the <see cref="BaseDependencyResolverTests{T}"/>,
+        /// it fails for some of the DIs.
         /// </summary>
         [Fact]
         public void Can_Register_And_Resolve_Null_Types()
@@ -31,18 +32,6 @@ namespace Splat.Tests.ServiceLocation
 
             value = resolver.GetService(null, contract);
             Assert.Equal(bar, value);
-        }
-
-        /// <summary>
-        /// Ensures <see cref="IReadonlyDependencyResolver.GetServices(Type, string)"/> never returns null.
-        /// </summary>
-        [Fact]
-        public void GetServices_ShouldNeverReturnNull()
-        {
-            var resolver = GetDependencyResolver();
-
-            Assert.NotNull(resolver.GetServices<string>());
-            Assert.NotNull(resolver.GetServices<string>("Landscape"));
         }
 
         /// <inheritdoc />

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
@@ -115,7 +115,8 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
                 var dic = GetContractDictionary(serviceType, false);
                 services = dic?
                     .GetFactories(contract)
-                    .Select(f => f());
+                    .Select(f => f())
+                    ?? Enumerable.Empty<object>();
             }
 
             return services;

--- a/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
+++ b/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
@@ -92,6 +92,18 @@ namespace Splat.Tests.ServiceLocation
         }
 
         /// <summary>
+        /// Ensures <see cref="IReadonlyDependencyResolver.GetServices(Type, string)"/> never returns null.
+        /// </summary>
+        [Fact]
+        public void GetServices_ShouldNeverReturnNull()
+        {
+            var resolver = GetDependencyResolver();
+
+            Assert.NotNull(resolver.GetServices<string>());
+            Assert.NotNull(resolver.GetServices<string>("Landscape"));
+        }
+
+        /// <summary>
         /// Gets an instance of a dependency resolver to test.
         /// </summary>
         /// <returns>Dependency Resolver.</returns>

--- a/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
+++ b/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
@@ -95,7 +95,7 @@ namespace Splat.Tests.ServiceLocation
         /// Ensures <see cref="IReadonlyDependencyResolver.GetServices(Type, string)"/> never returns null.
         /// </summary>
         [Fact]
-        public void GetServices_ShouldNeverReturnNull()
+        public void GetServices_Should_Never_Return_Null()
         {
             var resolver = GetDependencyResolver();
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Another test case with bug-fix, GetServices should never return null


**What is the current behavior?**
`MicrosoftDependencyResolver.GetServices` returns `null` when trying to resolve a non-registered service with a contract.

**What is the new behavior?**
It returns an empty enumerable instead.

**What might this PR break?**
None.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)