### PR TITLE
fix: Android DesignTimeBuild issue with MsBuild.Sdk.Extras

### DIFF
--- a/src/Splat.Tests/Splat.Tests.csproj
+++ b/src/Splat.Tests/Splat.Tests.csproj
@@ -6,6 +6,12 @@
     <NoWarn>$(NoWarn);1591;CA1707;SA1633</NoWarn>
   </PropertyGroup>
 
+  <Target Name="_RemoveNonExistingResgenFile" BeforeTargets="CoreCompile" Condition="'$(_SdkSetAndroidResgenFile)' == 'true' And '$(AndroidResgenFile)' != '' And !Exists('$(AndroidResgenFile)')">
+    <ItemGroup>
+      <Compile Remove="$(AndroidResgenFile)"/>
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <PackageReference Include="Serilog.Exceptions" Version="5.3.0" />
   </ItemGroup>

--- a/src/Splat/Splat.csproj
+++ b/src/Splat/Splat.csproj
@@ -15,6 +15,12 @@
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
+  <Target Name="_RemoveNonExistingResgenFile" BeforeTargets="CoreCompile" Condition="'$(_SdkSetAndroidResgenFile)' == 'true' And '$(AndroidResgenFile)' != '' And !Exists('$(AndroidResgenFile)')">
+    <ItemGroup>
+      <Compile Remove="$(AndroidResgenFile)"/>
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <Compile Remove="Platforms\**\*.cs" />
     <EmbeddedResource Remove="Platforms\**\*.*" />


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Working around an Android build issue with MsBuild.Sdk.Extras

**What is the current behavior?**
Splat doesn't build.

**What is the new behavior?**
Splat builds.

**What might this PR break?**
Nothing that isn't already broken.
