### PR TITLE
Using TryResolve instead of Resolve with Autofac

### DIFF
--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -38,16 +38,7 @@ namespace Splat.Autofac
         {
             lock (_lockObject)
             {
-                try
-                {
-                    return string.IsNullOrEmpty(contract)
-                        ? _componentContext.Resolve(serviceType)
-                        : _componentContext.ResolveNamed(contract, serviceType);
-                }
-                catch (DependencyResolutionException)
-                {
-                    return null;
-                }
+                return Resolve(serviceType, contract);
             }
         }
 
@@ -59,9 +50,7 @@ namespace Splat.Autofac
                 try
                 {
                     var enumerableType = typeof(IEnumerable<>).MakeGenericType(serviceType);
-                    object instance = string.IsNullOrEmpty(contract)
-                        ? _componentContext.Resolve(enumerableType)
-                        : _componentContext.ResolveNamed(contract, enumerableType);
+                    var instance = Resolve(enumerableType, contract);
                     return ((IEnumerable)instance).Cast<object>();
                 }
                 catch (DependencyResolutionException)
@@ -335,6 +324,22 @@ namespace Splat.Autofac
         private static bool HasNoContract(Service service)
         {
             return !(service is KeyedService);
+        }
+
+        private object Resolve(Type serviceType, string contract)
+        {
+            object serviceInstance;
+
+            if (string.IsNullOrEmpty(contract))
+            {
+                _componentContext.TryResolve(serviceType, out serviceInstance);
+            }
+            else
+            {
+                _componentContext.TryResolveNamed(contract, serviceType, out serviceInstance);
+            }
+
+            return serviceInstance;
         }
 
         private void RemoveAndRebuild(


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->
**What kind of change does this PR introduce?**
Fixing `AutofacDependencyResolver` so it does not throw, catch and swallow exceptions while resolving services.

**What is the current behavior?**
I'm currently using `AutofacDependencyResolver` with `ViewModelViewHost` in a `ListView` and noticed the massive lag while debugging and the bloat of `ComponentNotRegisteredException`s being thrown even though my code works.

**What is the new behavior?**
The new behavior should be the same, except faster when using Autofac and debugging.

**What might this PR break?**
Nothing I can think of.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
