### PR TITLE
feature: Add prism xml:ns to PrismApplication

### DIFF
--- a/src/Splat.Prism.Forms/PrismApplication.cs
+++ b/src/Splat.Prism.Forms/PrismApplication.cs
@@ -9,6 +9,8 @@ using System.Text;
 using Prism;
 using Prism.Ioc;
 
+[assembly: Xamarin.Forms.XmlnsDefinition("http://prismlibrary.com", "Prism.DryIoc")]
+
 namespace Splat.Prism.Forms
 {
     /// <summary>

--- a/src/Splat.Prism.Forms/PrismApplication.cs
+++ b/src/Splat.Prism.Forms/PrismApplication.cs
@@ -9,7 +9,7 @@ using System.Text;
 using Prism;
 using Prism.Ioc;
 
-[assembly: Xamarin.Forms.XmlnsDefinition("http://prismlibrary.com", "Prism.DryIoc")]
+[assembly: Xamarin.Forms.XmlnsDefinition("http://prismlibrary.com", "Splat.Prism.Forms")]
 
 namespace Splat.Prism.Forms
 {


### PR DESCRIPTION
Add the prism ns to allow for easy swapping in/out of PrismApplication's of different frameworks.