### PR TITLE
#483 ninject now does tryget service

### DIFF
--- a/src/Splat.Ninject.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Ninject.Tests/DependencyResolverTests.cs
@@ -42,6 +42,34 @@ namespace Splat.Ninject.Tests
         /// Should resolve views.
         /// </summary>
         [Fact]
+        public void NinjectDependencyResolver_Should_Return_Null()
+        {
+            var container = new StandardKernel();
+            container.UseNinjectDependencyResolver();
+
+            var viewOne = Locator.Current.GetService(typeof(IViewFor<ViewModelOne>));
+
+            viewOne.ShouldBeNull();
+        }
+
+        /// <summary>
+        /// Should resolve views.
+        /// </summary>
+        [Fact]
+        public void NinjectDependencyResolver_GetServices_Should_Return_Empty_Collection()
+        {
+            var container = new StandardKernel();
+            container.UseNinjectDependencyResolver();
+
+            var viewOne = Locator.Current.GetServices(typeof(IViewFor<ViewModelOne>));
+
+            viewOne.ShouldBeEmpty();
+        }
+
+        /// <summary>
+        /// Should resolve views.
+        /// </summary>
+        [Fact]
         public void NinjectDependencyResolver_Should_Resolve_Named_View()
         {
             var container = new StandardKernel();
@@ -120,10 +148,8 @@ namespace Splat.Ninject.Tests
 
             Locator.CurrentMutable.UnregisterAll(typeof(IScreen));
 
-            var result = Record.Exception(() => Locator.Current.GetService<IScreen>());
-
-            result.ShouldBeOfType<ActivationException>();
-            result.Message.ShouldStartWith("Error activating IScreen");
+            var result = Locator.Current.GetService<IScreen>();
+            result.ShouldBeNull();
         }
 
         /// <summary>

--- a/src/Splat.Ninject/NinjectDependencyResolver.cs
+++ b/src/Splat.Ninject/NinjectDependencyResolver.cs
@@ -29,8 +29,8 @@ namespace Splat.Ninject
         /// <inheritdoc />
         public virtual object GetService(Type serviceType, string contract = null) =>
             string.IsNullOrEmpty(contract)
-                ? _kernel.Get(serviceType)
-                : _kernel.Get(serviceType, contract);
+                ? _kernel.TryGet(serviceType)
+                : _kernel.TryGet(serviceType, contract);
 
         /// <inheritdoc />
         public virtual IEnumerable<object> GetServices(Type serviceType, string contract = null) =>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix, ninject getservice no longer throws if no service registration for type.
closes #483

**What is the current behavior?**
Throws if no registration



**What is the new behavior?**
returns null. brings in line with moderndependencyresolver


**What might this PR break?**
anyone not checking for null and using try\catch.

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

