### PR TITLE
Fix ExceptionMessageFormat Typo?

### DIFF
--- a/src/Splat/Logging/ConsoleLogger.cs
+++ b/src/Splat/Logging/ConsoleLogger.cs
@@ -18,7 +18,7 @@ namespace Splat
         /// Gets or sets the exception message format.
         /// First parameter will be the message, second will be the exception.
         /// </summary>
-        public string ExceptionMessageFormat { get; set; } = "{0] - {1}";
+        public string ExceptionMessageFormat { get; set; } = "{0} - {1}";
 
         /// <inheritdoc />
         public LogLevel Level { get; set; }


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug Fix

**What is the current behavior?**
The current format of ExceptionMessageFormat 
 "{0] - {1}"

causes an error 

> System.FormatException: 'Input string was not in a correct format.'

on line 45/67: 
`Console.WriteLine(string.Format(CultureInfo.InvariantCulture, ExceptionMessageFormat, message, exception));`

**Fix**
 "{0} - {1}"


