### PR TITLE
Ninject 553 last service registration and contracts

### DIFF
--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/Splat.Microsoft.Extensions.DependencyInjection.Tests.csproj
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/Splat.Microsoft.Extensions.DependencyInjection.Tests.csproj
@@ -11,10 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Splat.NLog\Splat.NLog.csproj" />
     <ProjectReference Include="..\Splat.Common.Test\Splat.Common.Test.csproj" />
     <ProjectReference Include="..\Splat.Microsoft.Extensions.DependencyInjection\Splat.Microsoft.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
-  
-  
+
+
 
 </Project>

--- a/src/Splat.Ninject.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Ninject.Tests/DependencyResolverTests.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using Ninject;
 using Shouldly;
 using Splat.Common.Test;
+using Splat.Tests.ServiceLocation;
 using Xunit;
 
 namespace Splat.Ninject.Tests

--- a/src/Splat.Ninject.Tests/NInjectDependencyResolverTests.cs
+++ b/src/Splat.Ninject.Tests/NInjectDependencyResolverTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Ninject;
+using Splat.Tests.ServiceLocation;
+using Xunit;
+
+namespace Splat.Ninject.Tests
+{
+    /// <summary>
+    /// Unit Tests for the Modern Dependency Resolver.
+    /// </summary>
+    public sealed class NInjectDependencyResolverTests : BaseDependencyResolverTests<NinjectDependencyResolver>
+    {
+        /// <summary>
+        /// Test to ensure container allows registration with null service type.
+        /// Should really be brought down to the <see cref="BaseDependencyResolverTests{T}"/>,
+        /// it fails for some of the DIs.
+        /// </summary>
+        [Fact]
+        public void Can_Register_And_Resolve_Null_Types()
+        {
+            var resolver = GetDependencyResolver();
+            var foo = 5;
+            resolver.Register(() => foo, null);
+
+            var value = resolver.GetService(null);
+            Assert.Equal(foo, value);
+
+            var bar = 4;
+            var contract = "foo";
+            resolver.Register(() => bar, null, contract);
+
+            value = resolver.GetService(null, contract);
+            Assert.Equal(bar, value);
+        }
+
+        /// <inheritdoc />
+        protected override NinjectDependencyResolver GetDependencyResolver() => new NinjectDependencyResolver(new StandardKernel());
+    }
+}

--- a/src/Splat.Ninject.Tests/Splat.Ninject.Tests.csproj
+++ b/src/Splat.Ninject.Tests/Splat.Ninject.Tests.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Splat.Tests\ServiceLocation\BaseDependencyResolverTests.cs" Link="BaseDependencyResolverTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Splat.NLog\Splat.NLog.csproj" />
     <ProjectReference Include="..\Splat.Common.Test\Splat.Common.Test.csproj" />
     <ProjectReference Include="..\Splat.Ninject\Splat.Ninject.csproj" />
   </ItemGroup>

--- a/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
+++ b/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Splat.NLog;
 using Xunit;
 
 namespace Splat.Tests.ServiceLocation
@@ -134,6 +135,23 @@ namespace Splat.Tests.ServiceLocation
             Assert.False(resolver.HasRegistration(type));
             Assert.False(resolver.HasRegistration(type, contractOne));
             Assert.True(resolver.HasRegistration(type, contractTwo));
+        }
+
+        /// <summary>
+        /// Tests to ensure NLog registers correctly with different service locators.
+        /// Based on issue reported in #553.
+        /// </summary>
+        [Fact]
+        public void ILogManager_Resolvable()
+        {
+            var resolver = GetDependencyResolver();
+
+            // Setup NLog for Logging (doesn't matter if I actually configure NLog or not)
+            resolver.UseNLogWithWrappingFullLogger();
+
+            // Get the ILogManager instance (this should succeed, but fails in current code)
+            ILogManager lm = Locator.Current.GetService<ILogManager>();
+            Assert.NotNull(lm);
         }
 
         /// <summary>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Closes #553 Ninject issue with multiple registration returning null instead of last registration
Adds the common unit tests to ninject
adds a nlog resolver test to common tests
Adds logic for contract based resolution in ninject
Adds ability for null type registration in ninject.


**What is the current behavior?**
ninject features not on a par to other resolvers,

**What is the new behavior?**
closes gaps in dependency resolvers

**What might this PR break?**
potentially any nuances\workarounds people are using in ninject

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

