### PR TITLE
Fix an exception when loading bitmap on Android from file

### DIFF
--- a/src/Splat.Drawing/Platforms/Android/Bitmaps/PlatformBitmapLoader.cs
+++ b/src/Splat.Drawing/Platforms/Android/Bitmaps/PlatformBitmapLoader.cs
@@ -210,7 +210,7 @@ namespace Splat
 
         private void AttemptStreamByteCorrection(Stream sourceStream)
         {
-            if (sourceStream.CanWrite)
+            if (!sourceStream.CanWrite)
             {
                 this.Log().Warn("Stream missing terminating bytes but is read only.");
             }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Bug fix.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

`BitmapLoader.Current.Load()` throws exception `(NotSupportedException) Stream does not support writing` when load the bitmap from the `FileStream`.

**What is the new behavior?**
<!-- If this is a feature change -->

No exception.

**What might this PR break?**

Nothing. It's flawless.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

