### PR TITLE
feature: Update Splat.Autofac to work with Autofac 5.0 (#465)

### DIFF
--- a/src/Splat.Autofac.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Autofac.Tests/DependencyResolverTests.cs
@@ -99,7 +99,7 @@ namespace Splat.Autofac.Tests
         /// Should throw an exception if service registration call back called.
         /// </summary>
         [Fact]
-        public void AutofacDependencyResolver_Should_Throw_If_ServiceRegistionCallback_Called()
+        public void AutofacDependencyResolver_Should_Throw_If_ServiceRegistrationCallback_Called()
         {
             var containerBuilder = new ContainerBuilder();
 

--- a/src/Splat.Autofac.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Autofac.Tests/DependencyResolverTests.cs
@@ -23,12 +23,12 @@ namespace Splat.Autofac.Tests
         [Fact]
         public void AutofacDependencyResolver_Should_Resolve_Views()
         {
-            var containerBuilder = new ContainerBuilder();
-            containerBuilder.RegisterType<ViewOne>().As<IViewFor<ViewModelOne>>();
-            containerBuilder.RegisterType<ViewTwo>().As<IViewFor<ViewModelTwo>>();
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ViewOne>().As<IViewFor<ViewModelOne>>();
+            builder.RegisterType<ViewTwo>().As<IViewFor<ViewModelTwo>>();
 
-            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
-            autofacResolver.SetLifetimeScope(containerBuilder.Build());
+            var autofacResolver = builder.UseAutofacDependencyResolver();
+            autofacResolver.SetLifetimeScope(builder.Build());
 
             var viewOne = Locator.Current.GetService(typeof(IViewFor<ViewModelOne>));
             var viewTwo = Locator.Current.GetService(typeof(IViewFor<ViewModelTwo>));
@@ -45,11 +45,11 @@ namespace Splat.Autofac.Tests
         [Fact]
         public void AutofacDependencyResolver_Should_Resolve_Named_View()
         {
-            var containerBuilder = new ContainerBuilder();
-            containerBuilder.RegisterType<ViewTwo>().Named<IViewFor<ViewModelTwo>>("Other");
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ViewTwo>().Named<IViewFor<ViewModelTwo>>("Other");
 
-            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
-            autofacResolver.SetLifetimeScope(containerBuilder.Build());
+            var autofacResolver = builder.UseAutofacDependencyResolver();
+            autofacResolver.SetLifetimeScope(builder.Build());
 
             var viewTwo = Locator.Current.GetService(typeof(IViewFor<ViewModelTwo>), "Other");
 
@@ -63,12 +63,12 @@ namespace Splat.Autofac.Tests
         [Fact]
         public void AutofacDependencyResolver_Should_Resolve_View_Models()
         {
-            var containerBuilder = new ContainerBuilder();
-            containerBuilder.RegisterType<ViewModelOne>().AsSelf();
-            containerBuilder.RegisterType<ViewModelTwo>().AsSelf();
+            var builder = new ContainerBuilder();
+            builder.RegisterType<ViewModelOne>().AsSelf();
+            builder.RegisterType<ViewModelTwo>().AsSelf();
 
-            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
-            autofacResolver.SetLifetimeScope(containerBuilder.Build());
+            var autofacResolver = builder.UseAutofacDependencyResolver();
+            autofacResolver.SetLifetimeScope(builder.Build());
 
             var vmOne = Locator.Current.GetService<ViewModelOne>();
             var vmTwo = Locator.Current.GetService<ViewModelTwo>();
@@ -83,11 +83,11 @@ namespace Splat.Autofac.Tests
         [Fact]
         public void AutofacDependencyResolver_Should_Resolve_Screen()
         {
-            var containerBuilder = new ContainerBuilder();
-            containerBuilder.RegisterType<MockScreen>().As<IScreen>().SingleInstance();
+            var builder = new ContainerBuilder();
+            builder.RegisterType<MockScreen>().As<IScreen>().SingleInstance();
 
-            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
-            autofacResolver.SetLifetimeScope(containerBuilder.Build());
+            var autofacResolver = builder.UseAutofacDependencyResolver();
+            autofacResolver.SetLifetimeScope(builder.Build());
 
             var screen = Locator.Current.GetService<IScreen>();
 
@@ -101,10 +101,10 @@ namespace Splat.Autofac.Tests
         [Fact]
         public void AutofacDependencyResolver_Should_Throw_If_ServiceRegistrationCallback_Called()
         {
-            var containerBuilder = new ContainerBuilder();
+            var builder = new ContainerBuilder();
 
-            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
-            autofacResolver.SetLifetimeScope(containerBuilder.Build());
+            var autofacResolver = builder.UseAutofacDependencyResolver();
+            autofacResolver.SetLifetimeScope(builder.Build());
 
             var result = Record.Exception(() =>
                 Locator.CurrentMutable.ServiceRegistrationCallback(typeof(IScreen), disposable => { }));
@@ -121,15 +121,15 @@ namespace Splat.Autofac.Tests
         [Fact]
         public void AutofacDependencyResolver_Should_ReturnRegisteredLogger()
         {
-            var containerBuilder = new ContainerBuilder();
+            var builder = new ContainerBuilder();
 
-            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
+            var autofacResolver = builder.UseAutofacDependencyResolver();
 
             Locator.CurrentMutable.RegisterConstant(
                 new FuncLogManager(type => new WrappingFullLogger(new ConsoleLogger())),
                 typeof(ILogManager));
 
-            autofacResolver.SetLifetimeScope(containerBuilder.Build());
+            autofacResolver.SetLifetimeScope(builder.Build());
 
             var logManager = Locator.Current.GetService<ILogManager>();
             Assert.IsType<FuncLogManager>(logManager);
@@ -144,14 +144,14 @@ namespace Splat.Autofac.Tests
         [Fact]
         public void AutofacDependencyResolver_PreInit_Should_ReturnRegisteredLogger()
         {
-            var containerBuilder = new ContainerBuilder();
+            var builder = new ContainerBuilder();
 
-            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
+            var autofacResolver = builder.UseAutofacDependencyResolver();
 
-            containerBuilder.Register(_ => new FuncLogManager(type => new WrappingFullLogger(new ConsoleLogger()))).As(typeof(ILogManager))
+            builder.Register(_ => new FuncLogManager(type => new WrappingFullLogger(new ConsoleLogger()))).As(typeof(ILogManager))
                 .AsImplementedInterfaces();
 
-            autofacResolver.SetLifetimeScope(containerBuilder.Build());
+            autofacResolver.SetLifetimeScope(builder.Build());
 
             var logManager = Locator.Current.GetService<ILogManager>();
             Assert.IsType<FuncLogManager>(logManager);
@@ -232,9 +232,9 @@ namespace Splat.Autofac.Tests
         /// <inheritdoc />
         protected override AutofacDependencyResolver GetDependencyResolver()
         {
-            var containerBuilder = new ContainerBuilder();
+            var builder = new ContainerBuilder();
 
-            return containerBuilder.UseAutofacDependencyResolver();
+            return builder.UseAutofacDependencyResolver();
         }
     }
 }

--- a/src/Splat.Autofac.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Autofac.Tests/DependencyResolverTests.cs
@@ -23,10 +23,12 @@ namespace Splat.Autofac.Tests
         [Fact]
         public void AutofacDependencyResolver_Should_Resolve_Views()
         {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<ViewOne>().As<IViewFor<ViewModelOne>>();
-            builder.RegisterType<ViewTwo>().As<IViewFor<ViewModelTwo>>();
-            builder.Build().UseAutofacDependencyResolver();
+            var containerBuilder = new ContainerBuilder();
+            containerBuilder.RegisterType<ViewOne>().As<IViewFor<ViewModelOne>>();
+            containerBuilder.RegisterType<ViewTwo>().As<IViewFor<ViewModelTwo>>();
+
+            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
+            autofacResolver.SetLifetimeScope(containerBuilder.Build());
 
             var viewOne = Locator.Current.GetService(typeof(IViewFor<ViewModelOne>));
             var viewTwo = Locator.Current.GetService(typeof(IViewFor<ViewModelTwo>));
@@ -43,9 +45,11 @@ namespace Splat.Autofac.Tests
         [Fact]
         public void AutofacDependencyResolver_Should_Resolve_Named_View()
         {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<ViewTwo>().Named<IViewFor<ViewModelTwo>>("Other");
-            builder.Build().UseAutofacDependencyResolver();
+            var containerBuilder = new ContainerBuilder();
+            containerBuilder.RegisterType<ViewTwo>().Named<IViewFor<ViewModelTwo>>("Other");
+
+            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
+            autofacResolver.SetLifetimeScope(containerBuilder.Build());
 
             var viewTwo = Locator.Current.GetService(typeof(IViewFor<ViewModelTwo>), "Other");
 
@@ -59,10 +63,12 @@ namespace Splat.Autofac.Tests
         [Fact]
         public void AutofacDependencyResolver_Should_Resolve_View_Models()
         {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<ViewModelOne>().AsSelf();
-            builder.RegisterType<ViewModelTwo>().AsSelf();
-            builder.Build().UseAutofacDependencyResolver();
+            var containerBuilder = new ContainerBuilder();
+            containerBuilder.RegisterType<ViewModelOne>().AsSelf();
+            containerBuilder.RegisterType<ViewModelTwo>().AsSelf();
+
+            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
+            autofacResolver.SetLifetimeScope(containerBuilder.Build());
 
             var vmOne = Locator.Current.GetService<ViewModelOne>();
             var vmTwo = Locator.Current.GetService<ViewModelTwo>();
@@ -77,9 +83,11 @@ namespace Splat.Autofac.Tests
         [Fact]
         public void AutofacDependencyResolver_Should_Resolve_Screen()
         {
-            var builder = new ContainerBuilder();
-            builder.RegisterType<MockScreen>().As<IScreen>().SingleInstance();
-            builder.Build().UseAutofacDependencyResolver();
+            var containerBuilder = new ContainerBuilder();
+            containerBuilder.RegisterType<MockScreen>().As<IScreen>().SingleInstance();
+
+            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
+            autofacResolver.SetLifetimeScope(containerBuilder.Build());
 
             var screen = Locator.Current.GetService<IScreen>();
 
@@ -93,8 +101,10 @@ namespace Splat.Autofac.Tests
         [Fact]
         public void AutofacDependencyResolver_Should_Throw_If_ServiceRegistionCallback_Called()
         {
-            var container = new ContainerBuilder();
-            container.UseAutofacDependencyResolver();
+            var containerBuilder = new ContainerBuilder();
+
+            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
+            autofacResolver.SetLifetimeScope(containerBuilder.Build());
 
             var result = Record.Exception(() =>
                 Locator.CurrentMutable.ServiceRegistrationCallback(typeof(IScreen), disposable => { }));
@@ -111,15 +121,17 @@ namespace Splat.Autofac.Tests
         [Fact]
         public void AutofacDependencyResolver_Should_ReturnRegisteredLogger()
         {
-            var container = new ContainerBuilder();
-            container.UseAutofacDependencyResolver();
+            var containerBuilder = new ContainerBuilder();
+
+            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
+            autofacResolver.SetLifetimeScope(containerBuilder.Build());
 
             Locator.CurrentMutable.RegisterConstant(
                 new FuncLogManager(type => new WrappingFullLogger(new ConsoleLogger())),
                 typeof(ILogManager));
 
-            var d = Splat.Locator.Current.GetService<ILogManager>();
-            Assert.IsType<FuncLogManager>(d);
+            var logManager = Locator.Current.GetService<ILogManager>();
+            Assert.IsType<FuncLogManager>(logManager);
         }
 
         /// <summary>
@@ -131,21 +143,25 @@ namespace Splat.Autofac.Tests
         [Fact]
         public void AutofacDependencyResolver_PreInit_Should_ReturnRegisteredLogger()
         {
-            var builder = new ContainerBuilder();
-            builder.Register(_ => new FuncLogManager(type => new WrappingFullLogger(new ConsoleLogger()))).As(typeof(ILogManager))
+            var containerBuilder = new ContainerBuilder();
+            containerBuilder.Register(_ => new FuncLogManager(type => new WrappingFullLogger(new ConsoleLogger()))).As(typeof(ILogManager))
                 .AsImplementedInterfaces();
 
-            builder.UseAutofacDependencyResolver();
+            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
+            autofacResolver.SetLifetimeScope(containerBuilder.Build());
 
-            var d = Splat.Locator.Current.GetService<ILogManager>();
-            Assert.IsType<FuncLogManager>(d);
+            var logManager = Locator.Current.GetService<ILogManager>();
+            Assert.IsType<FuncLogManager>(logManager);
         }
 
         /// <inheritdoc />
         protected override AutofacDependencyResolver GetDependencyResolver()
         {
-            var container = new ContainerBuilder();
-            return new AutofacDependencyResolver(container.Build());
+            var containerBuilder = new ContainerBuilder();
+            var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
+            autofacResolver.SetLifetimeScope(containerBuilder.Build());
+
+            return autofacResolver;
         }
     }
 }

--- a/src/Splat.Autofac.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Autofac.Tests/DependencyResolverTests.cs
@@ -158,11 +158,42 @@ namespace Splat.Autofac.Tests
         }
 
         /// <summary>
-        ///     Because <see href="https://autofaccn.readthedocs.io/en/latest/best-practices/#consider-a-container-as-immutable">Autofac 5+ containers are immutable</see>,
-        ///     UnregisterAll method is not available anymore.
+        ///     <inheritdoc cref="AutofacDependencyResolver.UnregisterCurrent"/>
+        /// </summary>
+        [Fact]
+        public override void UnregisterCurrent_Doesnt_Throw_When_List_Empty()
+        {
+        }
+
+        /// <summary>
+        ///     <inheritdoc cref="AutofacDependencyResolver.UnregisterCurrent"/>
+        /// </summary>
+        [Fact]
+        public override void UnregisterCurrent_Remove_Last()
+        {
+        }
+
+        /// <summary>
+        ///     <inheritdoc cref="AutofacDependencyResolver.UnregisterCurrent"/>
+        /// </summary>
+        [Fact]
+        public override void UnregisterCurrentByName_Doesnt_Throw_When_List_Empty()
+        {
+        }
+
+        /// <summary>
+        ///     <inheritdoc cref="AutofacDependencyResolver.UnregisterAll"/>
         /// </summary>
         [Fact]
         public override void UnregisterAll_UnregisterCurrent_Doesnt_Throw_When_List_Empty()
+        {
+        }
+
+        /// <summary>
+        ///     <inheritdoc cref="AutofacDependencyResolver.UnregisterAll"/>
+        /// </summary>
+        [Fact]
+        public override void UnregisterAllByContract_UnregisterCurrent_Doesnt_Throw_When_List_Empty()
         {
         }
 

--- a/src/Splat.Autofac.Tests/Splat.Autofac.Tests.csproj
+++ b/src/Splat.Autofac.Tests/Splat.Autofac.Tests.csproj
@@ -9,10 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="4.9.4" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Splat.Autofac\Splat.Autofac.csproj" />
     <ProjectReference Include="..\Splat.Common.Test\Splat.Common.Test.csproj" />
     <ProjectReference Include="..\Splat.Tests\Splat.Tests.csproj" />

--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -42,10 +42,10 @@ namespace Splat.Autofac
         /// <summary>
         /// Initializes a new instance of the <see cref="AutofacDependencyResolver" /> class.
         /// </summary>
-        /// <param name="containerBuilder">Autofac container builder.</param>
-        public AutofacDependencyResolver(ContainerBuilder containerBuilder)
+        /// <param name="builder">Autofac container builder.</param>
+        public AutofacDependencyResolver(ContainerBuilder builder)
         {
-            _builder = containerBuilder;
+            _builder = builder;
 
             _internalContainer = new ContainerBuilder().Build();
             _internalLifetimeScope = _internalContainer.BeginLifetimeScope();
@@ -167,26 +167,32 @@ namespace Splat.Autofac
         /// <summary>
         ///     Because <see href="https://autofaccn.readthedocs.io/en/latest/best-practices/#consider-a-container-as-immutable">Autofac 5+ containers are immutable</see>,
         ///     UnregisterCurrent method is not available anymore.
+        ///     Instead, simply <see href="https://autofaccn.readthedocs.io/en/latest/register/registration.html#default-registrations">register your service after InitializeReactiveUI</see> to override it.
         /// </summary>
         /// <param name="serviceType">The service type to unregister.</param>
         /// <param name="contract">The optional contract value, which will only remove the value associated with the contract.</param>
         /// <exception cref="System.NotImplementedException">This is not implemented by default.</exception>
         /// <inheritdoc />
-        [Obsolete("Because Autofac 5+ containers are immutable, UnregisterCurrent method is not available anymore.")]
+        [Obsolete("Because Autofac 5+ containers are immutable, UnregisterCurrent method is not available anymore. " +
+                  "Instead, simply register your service after InitializeReactiveUI to override it https://autofaccn.readthedocs.io/en/latest/register/registration.html#default-registrations.")]
         public virtual void UnregisterCurrent(Type serviceType, string contract = null) =>
-            throw new NotImplementedException("Because Autofac 5+ containers are immutable, UnregisterCurrent method is not available anymore.");
+            throw new NotImplementedException("Because Autofac 5+ containers are immutable, UnregisterCurrent method is not available anymore. " +
+                                              "Instead, simply register your service after InitializeReactiveUI to override it https://autofaccn.readthedocs.io/en/latest/register/registration.html#default-registrations.");
 
         /// <summary>
         ///     Because <see href="https://autofaccn.readthedocs.io/en/latest/best-practices/#consider-a-container-as-immutable">Autofac 5+ containers are immutable</see>,
         ///     UnregisterAll method is not available anymore.
+        ///     Instead, simply <see href="https://autofaccn.readthedocs.io/en/latest/register/registration.html#default-registrations">register your service after InitializeReactiveUI</see> to override it.
         /// </summary>
         /// <param name="serviceType">The service type to unregister.</param>
         /// <param name="contract">The optional contract value, which will only remove the value associated with the contract.</param>
         /// <exception cref="System.NotImplementedException">This is not implemented by default.</exception>
         /// <inheritdoc />
-        [Obsolete("Because Autofac 5+ containers are immutable, UnregisterAll method is not available anymore.")]
+        [Obsolete("Because Autofac 5+ containers are immutable, UnregisterAll method is not available anymore. " +
+                  "Instead, simply register your service after InitializeReactiveUI to override it https://autofaccn.readthedocs.io/en/latest/register/registration.html#default-registrations.")]
         public virtual void UnregisterAll(Type serviceType, string contract = null) =>
-            throw new NotImplementedException("Because Autofac 5+ containers are immutable, UnregisterAll method is not available anymore.");
+            throw new NotImplementedException("Because Autofac 5+ containers are immutable, UnregisterAll method is not available anymore. " +
+                                              "Instead, simply register your service after InitializeReactiveUI to override it https://autofaccn.readthedocs.io/en/latest/register/registration.html#default-registrations.");
 
         /// <inheritdoc />
         public virtual IDisposable ServiceRegistrationCallback(Type serviceType, string contract, Action<IDisposable> callback) =>

--- a/src/Splat.Autofac/README.md
+++ b/src/Splat.Autofac/README.md
@@ -7,17 +7,34 @@ Splat.Autofac is an adapter for `IMutableDependencyResolver`.  It allows you to 
 ### Register the Container
 
 ```cs
-var container = new ContainerBuilder();
-container.RegisterType<MainPage>().As<IViewFor<MainViewModel>>();
-container.RegisterType<SecondaryPage>().As<IViewFor<SecondaryViewModel>>();
-container.RegisterType<MainViewModel>().AsSelf();
-container.RegisterType<SecondaryViewModel>().AsSelf();
+var containerBuilder = new ContainerBuilder();
+containerBuilder.RegisterType<MainPage>().As<IViewFor<MainViewModel>>();
+containerBuilder.RegisterType<SecondaryPage>().As<IViewFor<SecondaryViewModel>>();
+containerBuilder.RegisterType<MainViewModel>().AsSelf();
+containerBuilder.RegisterType<SecondaryViewModel>().AsSelf();
+// etc.
 ```
 
 ### Register the Adapter to Splat
 
 ```cs
-container.UseAutofacDependencyResolver();
+// Creates and sets the Autofac resolver as the Locator
+var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
+
+// Register the resolver in Autofac so it can be later resolved
+containerBuilder.RegisterInstance(autofacResolver);
+
+// Initialize ReactiveUI components
+autofacResolver.InitializeReactiveUI();
+```
+
+### Set Autofac Locator's lifetime after the ContainerBuilder has been built
+
+```cs
+var autofacResolver = container.Resolve<AutofacDependencyResolver>();
+
+// Set a lifetime scope (either the root or any of the child ones) to Autofac resolver
+autofacResolver.SetLifetimeScope(container);`
 ```
 
 ### Use the Locator

--- a/src/Splat.Autofac/README.md
+++ b/src/Splat.Autofac/README.md
@@ -7,11 +7,11 @@ Splat.Autofac is an adapter for `IMutableDependencyResolver`.  It allows you to 
 ### Register the Container
 
 ```cs
-var containerBuilder = new ContainerBuilder();
-containerBuilder.RegisterType<MainPage>().As<IViewFor<MainViewModel>>();
-containerBuilder.RegisterType<SecondaryPage>().As<IViewFor<SecondaryViewModel>>();
-containerBuilder.RegisterType<MainViewModel>().AsSelf();
-containerBuilder.RegisterType<SecondaryViewModel>().AsSelf();
+var builder = new ContainerBuilder();
+builder.RegisterType<MainPage>().As<IViewFor<MainViewModel>>();
+builder.RegisterType<SecondaryPage>().As<IViewFor<SecondaryViewModel>>();
+builder.RegisterType<MainViewModel>().AsSelf();
+builder.RegisterType<SecondaryViewModel>().AsSelf();
 // etc.
 ```
 
@@ -19,13 +19,17 @@ containerBuilder.RegisterType<SecondaryViewModel>().AsSelf();
 
 ```cs
 // Creates and sets the Autofac resolver as the Locator
-var autofacResolver = containerBuilder.UseAutofacDependencyResolver();
+var autofacResolver = builder.UseAutofacDependencyResolver();
 
 // Register the resolver in Autofac so it can be later resolved
-containerBuilder.RegisterInstance(autofacResolver);
+builder.RegisterInstance(autofacResolver);
 
 // Initialize ReactiveUI components
 autofacResolver.InitializeReactiveUI();
+
+// If you need to override any service (such as the ViewLocator), register it after InitializeReactiveUI
+// https://autofaccn.readthedocs.io/en/latest/register/registration.html#default-registrations
+// builder.RegisterType<MyCustomViewLocator>().As<IViewLocator>().SingleInstance();
 ```
 
 ### Set Autofac Locator's lifetime after the ContainerBuilder has been built
@@ -34,6 +38,8 @@ autofacResolver.InitializeReactiveUI();
 var autofacResolver = container.Resolve<AutofacDependencyResolver>();
 
 // Set a lifetime scope (either the root or any of the child ones) to Autofac resolver
+// This is needed, because the previous steps did not Update the ContainerBuilder since they became immutable in Autofac 5+
+// https://github.com/autofac/Autofac/issues/811
 autofacResolver.SetLifetimeScope(container);`
 ```
 

--- a/src/Splat.Autofac/Splat.Autofac.csproj
+++ b/src/Splat.Autofac/Splat.Autofac.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="[5, 6)" />
+    <PackageReference Include="Autofac" Version="5.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Splat.Autofac/Splat.Autofac.csproj
+++ b/src/Splat.Autofac/Splat.Autofac.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Autofac" Version="[4,5)" />
+    <PackageReference Include="Autofac" Version="[5, 6)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Splat.Autofac/SplatAutofacExtensions.cs
+++ b/src/Splat.Autofac/SplatAutofacExtensions.cs
@@ -16,12 +16,12 @@ namespace Splat.Autofac
         /// <summary>
         /// Initializes an instance of <see cref="AutofacDependencyResolver"/> that overrides the default <see cref="Locator"/>.
         /// </summary>
-        /// <param name="containerBuilder">Autofac container builder.</param>
+        /// <param name="builder">Autofac container builder.</param>
         /// <returns>The Autofac dependency resolver.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Dispose handled by locator.")]
-        public static AutofacDependencyResolver UseAutofacDependencyResolver(this ContainerBuilder containerBuilder)
+        public static AutofacDependencyResolver UseAutofacDependencyResolver(this ContainerBuilder builder)
         {
-            var autofacResolver = new AutofacDependencyResolver(containerBuilder);
+            var autofacResolver = new AutofacDependencyResolver(builder);
             Locator.SetLocator(autofacResolver);
             return autofacResolver;
         }

--- a/src/Splat.Autofac/SplatAutofacExtensions.cs
+++ b/src/Splat.Autofac/SplatAutofacExtensions.cs
@@ -16,24 +16,14 @@ namespace Splat.Autofac
         /// <summary>
         /// Initializes an instance of <see cref="AutofacDependencyResolver"/> that overrides the default <see cref="Locator"/>.
         /// </summary>
-        /// <param name="componentContext">Autofac component context.</param>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Dispose handled by locator.")]
-        public static void UseAutofacDependencyResolver(this IComponentContext componentContext) =>
-            Locator.SetLocator(new AutofacDependencyResolver(componentContext));
-
-        /// <summary>
-        /// Initializes an instance of <see cref="AutofacDependencyResolver"/> that overrides the default <see cref="Locator"/>.
-        /// </summary>
         /// <param name="containerBuilder">Autofac container builder.</param>
+        /// <returns>The Autofac dependency resolver.</returns>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Reliability", "CA2000:Dispose objects before losing scope", Justification = "Dispose handled by locator.")]
-        public static void UseAutofacDependencyResolver(this ContainerBuilder containerBuilder)
+        public static AutofacDependencyResolver UseAutofacDependencyResolver(this ContainerBuilder containerBuilder)
         {
-            if (containerBuilder is null)
-            {
-                throw new ArgumentNullException(nameof(containerBuilder));
-            }
-
-            Locator.SetLocator(new AutofacDependencyResolver(containerBuilder.Build()));
+            var autofacResolver = new AutofacDependencyResolver(containerBuilder);
+            Locator.SetLocator(autofacResolver);
+            return autofacResolver;
         }
     }
 }

--- a/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
+++ b/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
@@ -17,7 +17,7 @@ namespace Splat.Tests.ServiceLocation
         /// Test to ensure Unregister doesn't cause an IndexOutOfRangeException.
         /// </summary>
         [Fact]
-        public void UnregisterCurrent_Doesnt_Throw_When_List_Empty()
+        public virtual void UnregisterCurrent_Doesnt_Throw_When_List_Empty()
         {
             var resolver = GetDependencyResolver();
             var type = typeof(ILogManager);
@@ -31,7 +31,7 @@ namespace Splat.Tests.ServiceLocation
         /// Test to ensure UnregisterCurrent removes last entry.
         /// </summary>
         [Fact]
-        public void UnregisterCurrent_Remove_Last()
+        public virtual void UnregisterCurrent_Remove_Last()
         {
             var resolver = GetDependencyResolver();
             var type = typeof(ILogManager);
@@ -52,7 +52,7 @@ namespace Splat.Tests.ServiceLocation
         /// Test to ensure Unregister doesn't cause an IndexOutOfRangeException.
         /// </summary>
         [Fact]
-        public void UnregisterCurrentByName_Doesnt_Throw_When_List_Empty()
+        public virtual void UnregisterCurrentByName_Doesnt_Throw_When_List_Empty()
         {
             var resolver = GetDependencyResolver();
             var type = typeof(ILogManager);
@@ -81,7 +81,7 @@ namespace Splat.Tests.ServiceLocation
         /// Test to ensure Unregister doesn't cause an IndexOutOfRangeException.
         /// </summary>
         [Fact]
-        public void UnregisterAllByContract_UnregisterCurrent_Doesnt_Throw_When_List_Empty()
+        public virtual void UnregisterAllByContract_UnregisterCurrent_Doesnt_Throw_When_List_Empty()
         {
             var resolver = GetDependencyResolver();
             var type = typeof(ILogManager);

--- a/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
+++ b/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
@@ -108,7 +108,7 @@ namespace Splat.Tests.ServiceLocation
         /// Tests for ensuring hasregistration behaves when using contracts.
         /// </summary>
         [Fact]
-        public void HasRegistration()
+        public virtual void HasRegistration()
         {
             var type = typeof(string);
             const string contractOne = "ContractOne";


### PR DESCRIPTION
Raises Autofac version to 5.x in Splat.Autofac, and deprecates or removes method that mutate the container (since that is supposed to be immutable from now on).
Register method is to be used only by the ReactiveUI initialization procedure, which modifies the container by creating a child scope for each service registration.
Thanks to "skaman" for coming up with the workaround.

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature: Update Splat.Autofac to work with Autofac 5.x [#465](https://github.com/reactiveui/splat/issues/465)

**What is the current behavior?**
<!-- You can also link to an open issue here. -->
Splat.Autofac is currently locked to at most 4.9.6 version.

**What is the new behavior?**
<!-- If this is a feature change -->
Autofac dependency now targets version 5.x
It now (mostly) conforms to Autofac 5 container immutability.

**What might this PR break?**
Setup procedure is different. Before, everything was done on the IContainer (after the application's container has been built). Now (since containers are not mutable anymore), part of the setup happens earlier, on the ContainerBuilder.
Before:
`/* After the ContainerBuilder has been built */
container.UseAutofacDependencyResolver();

Locator.CurrentMutable.InitializeSplat();

Locator.CurrentMutable.InitializeReactiveUI();`

Now:
`/* While we still have the ContainerBuilder */
// Creates and sets the Autofac resolver as the Locator
var autofacResolver = containerBuilder.UseAutofacDependencyResolver();

// Register the resolver in Autofac so it can be later resolved
containerBuilder.RegisterInstance(autofacResolver);

// Initialize ReactiveUI components
autofacResolver.InitializeReactiveUI();

/* After the ContainerBuilder has been built */
var autofacResolver = container.Resolve&lt;AutofacDependencyResolver&gt;();

// Set a lifetime scope (either the root or any of the child ones) to Autofac resolver
autofacResolver.SetLifetimeScope(container);`

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

I would appreciate if further testing could be done. I used this with a rather big application I am developing, and nothing broke. This of course does not mean, that no mistakes have been made.

**Other information**:

