### PR TITLE
#586 bitmap loader init perf fixes

### DIFF
--- a/src/Splat.Drawing/Platforms/Android/Bitmaps/PlatformBitmapLoader.cs
+++ b/src/Splat.Drawing/Platforms/Android/Bitmaps/PlatformBitmapLoader.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading.Tasks;
 using Android.App;
 using Android.Graphics;
@@ -129,32 +130,42 @@ namespace Splat
         {
             // VS2019 onward
             var drawableTypes = assemblies
+                .AsParallel()
                 .SelectMany(a => GetTypesFromAssembly(a, log))
-                .Where(x => x.Name == "Resource" && x.GetNestedType("Drawable") != null)
+                .Where(x => x.Name.Equals("Resource", StringComparison.Ordinal) && x.GetNestedType("Drawable") != null)
                 .Select(x => x.GetNestedType("Drawable"))
                 .ToArray();
 
-            if (log != null)
+            if (log?.IsDebugEnabled == true)
             {
-                log.Debug(() => "DrawableList. Got " + drawableTypes.Length + " types.");
+                var output = new StringBuilder();
+                output.Append("DrawableList. Got ").Append(drawableTypes.Length).AppendLine(" types.");
+
                 foreach (var drawableType in drawableTypes)
                 {
-                    log.Debug(() => "DrawableList Type: " + drawableType.Name);
+                    output.Append("DrawableList Type: ").AppendLine(drawableType.Name);
                 }
+
+                log.Debug(output.ToString());
             }
 
             var result = drawableTypes
+                .AsParallel()
                 .SelectMany(x => x.GetFields())
                 .Where(x => x.FieldType == typeof(int) && x.IsLiteral)
                 .ToDictionary(k => k.Name, v => (int)v.GetRawConstantValue());
 
-            if (log != null)
+            if (log?.IsDebugEnabled == true)
             {
-                log.Debug(() => "DrawableList. Got " + result.Count + " items.");
+                var output = new StringBuilder();
+                output.Append("DrawableList. Got ").Append(result.Count).AppendLine(" items.");
+
                 foreach (var keyValuePair in result)
                 {
-                    log.Debug(() => "DrawableList Item: " + keyValuePair.Key);
+                    output.Append("DrawableList Item: ").AppendLine(keyValuePair.Key);
                 }
+
+                log.Debug(output.ToString());
             }
 
             return result;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bug fix of poor perf in platform bitmap loader init during debug

closes #586
closes #421



**What is the current behavior?**
mass debug lines on xamarin debugger means initialisation is slow and gives poor experience



**What is the new behavior?**
uses stringbuilder and parallel assembly searching.



**What might this PR break?**
stringbuilder might get big, debug output is now single large burst


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

