### PR TITLE
Housekeeping: exclude other test assemblies from coverage

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -58,7 +58,7 @@ jobs:
       with:
         project-files: '**/*Tests*.csproj'
         no-build: true
-        exclude-filter: '[${{env.productNamespacePrefix}}.*.Tests.*]*'
+        exclude-filter: '[${{env.productNamespacePrefix}}.*.Tests.*]*,[${{env.productNamespacePrefix}}.Tests]*,[${{env.productNamespacePrefix}}.TestRunner.*]*'
         include-filter: '[${{env.productNamespacePrefix}}*]*'
         output-format: cobertura
         output: '../../artifacts/'


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Tweaks CI build to exclude more test assemblies from the coverage results

`[${{env.productNamespacePrefix}}.Tests]*,[${{env.productNamespacePrefix}}.TestRunner.*]*`


**What is the current behavior?**
largest miss on code coverage result is Splat.Test



**What is the new behavior?**
should move coverage result up



**What might this PR break?**
n/a


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

