### PR TITLE
WIP: Housekeeping: Update Prism to V8

### DIFF
--- a/src/Splat.Prism.Forms/Splat.Prism.Forms.csproj
+++ b/src/Splat.Prism.Forms/Splat.Prism.Forms.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Prism.Forms" Version="7.2.0.1422" />
+    <PackageReference Include="Prism.Forms" Version="8.0.0.1909" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Splat.Prism.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Prism.Tests/DependencyResolverTests.cs
@@ -25,7 +25,7 @@ namespace Splat.Prism.Tests
         public void CreateScope_Throws_NotImplementedException()
         {
             using var container = new SplatContainerExtension();
-            Assert.Throws<NotImplementedException>(() => container.CreateScope());
+            Assert.Throws<NotSupportedException>(() => container.CreateScope());
         }
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace Splat.Prism.Tests
         public void RegisterScoped_Throws_NotImplementedException()
         {
             using var container = new SplatContainerExtension();
-            Assert.Throws<NotImplementedException>(() => container.RegisterScoped(
+            Assert.Throws<NotSupportedException>(() => container.RegisterScoped(
                 typeof(IViewFor<ViewModelOne>),
                 () => new ViewOne()));
         }
@@ -47,7 +47,7 @@ namespace Splat.Prism.Tests
         public void RegisterManySingleton_Throws_NotImplementedException()
         {
             using var container = new SplatContainerExtension();
-            Assert.Throws<NotImplementedException>(() => container.RegisterManySingleton(
+            Assert.Throws<NotSupportedException>(() => container.RegisterManySingleton(
                 typeof(IViewFor<ViewModelOne>),
                 typeof(ViewOne)));
         }

--- a/src/Splat.Prism.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Prism.Tests/DependencyResolverTests.cs
@@ -19,6 +19,108 @@ namespace Splat.Prism.Tests
     public class DependencyResolverTests
     {
         /// <summary>
+        /// Tracks CreateScope not being implemented in case it's changed in future.
+        /// </summary>
+        [Fact]
+        public void CreateScope_Throws_NotImplementedException()
+        {
+            using var container = new SplatContainerExtension();
+            Assert.Throws<NotImplementedException>(() => container.CreateScope());
+        }
+
+        /// <summary>
+        /// Tracks RegisterScoped not being implemented in case it's changed in future.
+        /// </summary>
+        [Fact]
+        public void RegisterScoped_Throws_NotImplementedException()
+        {
+            using var container = new SplatContainerExtension();
+            Assert.Throws<NotImplementedException>(() => container.RegisterScoped(
+                typeof(IViewFor<ViewModelOne>),
+                () => new ViewOne()));
+        }
+
+        /// <summary>
+        /// Tracks RegisterManySingleton not being implemented in case it's changed in future.
+        /// </summary>
+        [Fact]
+        public void RegisterManySingleton_Throws_NotImplementedException()
+        {
+            using var container = new SplatContainerExtension();
+            Assert.Throws<NotImplementedException>(() => container.RegisterManySingleton(
+                typeof(IViewFor<ViewModelOne>),
+                typeof(ViewOne)));
+        }
+
+        /// <summary>
+        /// Test to ensure register many succeeds.
+        /// </summary>
+        [Fact]
+        public void RegisterMany_Succeeds()
+        {
+            using var container = new SplatContainerExtension();
+            container.RegisterMany(
+                typeof(IViewFor<ViewModelOne>),
+                typeof(ViewOne));
+        }
+
+        /// <summary>
+        /// Test to ensure a simple resolve succeeds.
+        /// </summary>
+        [Fact]
+        public void Resolve_Succeeds()
+        {
+            using var container = new SplatContainerExtension();
+            container.Register(typeof(IViewFor<ViewModelOne>), typeof(ViewOne));
+
+            var instance = container.Resolve(typeof(IViewFor<ViewModelOne>));
+
+            Assert.NotNull(instance);
+        }
+
+        /// <summary>
+        /// Test to ensure a resolve with name succeeds.
+        /// </summary>
+        [Fact]
+        public void Resolve_With_Name_Succeeds()
+        {
+            using var container = new SplatContainerExtension();
+            container.Register(typeof(IViewFor<ViewModelOne>), typeof(ViewOne), "name");
+
+            var instance = container.Resolve(typeof(IViewFor<ViewModelOne>), "name");
+
+            Assert.NotNull(instance);
+        }
+
+        /// <summary>
+        /// Test to ensure a simple is registered check succeeds.
+        /// </summary>
+        [Fact]
+        public void IsRegistered_Returns_True()
+        {
+            using var container = new SplatContainerExtension();
+            container.Register(typeof(IViewFor<ViewModelOne>), typeof(ViewOne));
+
+            var instance = container.IsRegistered(typeof(IViewFor<ViewModelOne>));
+
+            Assert.True(instance);
+        }
+
+        /// <summary>
+        /// Test to ensure a simple is registered check succeeds.
+        /// </summary>
+        [Fact]
+        public void IsRegistered_With_Name_Returns_True()
+        {
+            using var container = new SplatContainerExtension();
+            container.Register(typeof(IViewFor<ViewModelOne>), typeof(ViewOne), "name");
+
+            var instance = container.IsRegistered(typeof(IViewFor<ViewModelOne>), "name");
+
+            Assert.True(instance);
+        }
+
+        /// <summary>
         /// Should resolve the views.
         /// </summary>
         [Fact]

--- a/src/Splat.Prism/Splat.Prism.csproj
+++ b/src/Splat.Prism/Splat.Prism.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Prism.Core" Version="7.2.0.1422" />
+    <PackageReference Include="Prism.Core" Version="8.0.0.1909" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Splat.Prism/SplatContainerExtension.cs
+++ b/src/Splat.Prism/SplatContainerExtension.cs
@@ -43,7 +43,7 @@ namespace Splat.Prism
         /// <inheritdoc/>
         public IScopedProvider CreateScope()
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         /// <inheritdoc/>
@@ -61,7 +61,7 @@ namespace Splat.Prism
         /// <inheritdoc/>
         public IContainerRegistry RegisterScoped(Type type, Func<IContainerProvider, object> factoryMethod)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         /// <inheritdoc/>
@@ -79,7 +79,7 @@ namespace Splat.Prism
         /// <inheritdoc/>
         public IContainerRegistry RegisterManySingleton(Type type, params Type[] serviceTypes)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         /// <inheritdoc/>
@@ -140,13 +140,13 @@ namespace Splat.Prism
         /// <inheritdoc/>
         public IContainerRegistry RegisterScoped(Type @from, Type to)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         /// <inheritdoc/>
         public IContainerRegistry RegisterScoped(Type type, Func<object> factoryMethod)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         /// <summary>
@@ -226,13 +226,13 @@ namespace Splat.Prism
         /// <inheritdoc/>
         public IContainerRegistry RegisterSingleton(Type type, Func<object> factoryMethod)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         /// <inheritdoc/>
         public IContainerRegistry RegisterSingleton(Type type, Func<IContainerProvider, object> factoryMethod)
         {
-            throw new NotImplementedException();
+            throw new NotSupportedException();
         }
 
         /// <inheritdoc/>

--- a/src/Splat.Prism/SplatContainerExtension.cs
+++ b/src/Splat.Prism/SplatContainerExtension.cs
@@ -36,6 +36,17 @@ namespace Splat.Prism
         public IDependencyResolver Instance { get; } = new ModernDependencyResolver();
 
         /// <inheritdoc/>
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
+        public IScopedProvider CurrentScope => throw new NotImplementedException();
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
+
+        /// <inheritdoc/>
+        public IScopedProvider CreateScope()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
         public void Dispose()
         {
             Dispose(true);
@@ -48,6 +59,12 @@ namespace Splat.Prism
         }
 
         /// <inheritdoc/>
+        public IContainerRegistry RegisterScoped(Type type, Func<IContainerProvider, object> factoryMethod)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
         public bool IsRegistered(Type type)
         {
             return Instance.HasRegistration(type);
@@ -57,6 +74,12 @@ namespace Splat.Prism
         public bool IsRegistered(Type type, string name)
         {
             return Instance.HasRegistration(type, name);
+        }
+
+        /// <inheritdoc/>
+        public IContainerRegistry RegisterManySingleton(Type type, params Type[] serviceTypes)
+        {
+            throw new NotImplementedException();
         }
 
         /// <inheritdoc/>
@@ -87,6 +110,43 @@ namespace Splat.Prism
             _types[(from, name)] = to;
             Instance.Register(() => Activator.CreateInstance(to), from, name);
             return this;
+        }
+
+        /// <inheritdoc/>
+        public IContainerRegistry Register(Type type, Func<object> factoryMethod)
+        {
+            Instance.Register(factoryMethod, type);
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public IContainerRegistry Register(Type type, Func<IContainerProvider, object> factoryMethod)
+        {
+            Instance.Register(() => factoryMethod(this), type);
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public IContainerRegistry RegisterMany(Type type, params Type[] serviceTypes)
+        {
+            foreach (Type serviceType in serviceTypes)
+            {
+                Instance.Register(() => Activator.CreateInstance(type), serviceType);
+            }
+
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public IContainerRegistry RegisterScoped(Type @from, Type to)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public IContainerRegistry RegisterScoped(Type type, Func<object> factoryMethod)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -161,6 +221,18 @@ namespace Splat.Prism
             _types[(from, null)] = to;
             Instance.RegisterLazySingleton(() => Activator.CreateInstance(to), from, name);
             return this;
+        }
+
+        /// <inheritdoc/>
+        public IContainerRegistry RegisterSingleton(Type type, Func<object> factoryMethod)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public IContainerRegistry RegisterSingleton(Type type, Func<IContainerProvider, object> factoryMethod)
+        {
+            throw new NotImplementedException();
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Package update

**What is the current behavior?**
Blocks people wanting to use V8 with Splat

**What is the new behavior?**
Updates the Splat Prism integration for the new interfaces. Still not supporting scoped objects

**What might this PR break?**
anyone downstream dependent on v7 but in terms of splat not much, interface was extended not broken


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

