### PR TITLE
feature resolvers changed to allow registration of null with a value type

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -49,8 +49,8 @@ csharp_style_var_elsewhere = true:suggestion
 
 # Types: use keywords instead of BCL types, and permit var only when the type is clear
 csharp_style_var_for_built_in_types = false:suggestion
-csharp_style_var_when_type_is_apparent = false:none
-csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_when_type_is_apparent =true:none
+csharp_style_var_elsewhere =true:suggestion
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
 

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -16,6 +16,7 @@
     <PackageReleaseNotes>https://github.com/reactiveui/splat/releases</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/reactiveui/splat</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+	<WarningsAsErrors>nullable</WarningsAsErrors>
 
     <!-- disable sourcelink on mono, to workaround https://github.com/dotnet/sourcelink/issues/155 -->
     <EnableSourceLink Condition=" '$(OS)' != 'Windows_NT' AND '$(MSBuildRuntimeType)' != 'Core' ">false</EnableSourceLink>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -62,7 +62,7 @@
   </ItemGroup>
    
   <ItemGroup>	
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.216" PrivateAssets="all" />	
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.220" PrivateAssets="all" />	
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Splat.Autofac.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Autofac.Tests/DependencyResolverTests.cs
@@ -20,6 +20,30 @@ namespace Splat.Autofac.Tests
     public class DependencyResolverTests : BaseDependencyResolverTests<AutofacDependencyResolver>
     {
         /// <summary>
+        /// Shoulds the resolve nulls.
+        /// </summary>
+        [Fact]
+        public void Can_Register_And_Resolve_Null_Types()
+        {
+            var builder = new ContainerBuilder();
+            var autofacResolver = builder.UseAutofacDependencyResolver();
+
+            var foo = 5;
+            Locator.CurrentMutable.Register(() => foo, null);
+
+            var bar = 4;
+            var contract = "foo";
+            Locator.CurrentMutable.Register(() => bar, null, contract);
+            autofacResolver.SetLifetimeScope(builder.Build());
+
+            var value = Locator.Current.GetService(null);
+            Assert.Equal(foo, value);
+
+            value = Locator.Current.GetService(null, contract);
+            Assert.Equal(bar, value);
+        }
+
+        /// <summary>
         /// Shoulds the resolve views.
         /// </summary>
         [Fact]

--- a/src/Splat.Autofac.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Autofac.Tests/DependencyResolverTests.cs
@@ -4,6 +4,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
 using Autofac;
 
 using FluentAssertions;
@@ -36,11 +37,25 @@ namespace Splat.Autofac.Tests
             Locator.CurrentMutable.Register(() => bar, null, contract);
             autofacResolver.SetLifetimeScope(builder.Build());
 
+            Assert.True(Locator.CurrentMutable.HasRegistration(null));
             var value = Locator.Current.GetService(null);
             Assert.Equal(foo, value);
 
+            Assert.True(Locator.CurrentMutable.HasRegistration(null, contract));
             value = Locator.Current.GetService(null, contract);
             Assert.Equal(bar, value);
+
+            var values = Locator.Current.GetServices(null);
+            Assert.Equal(foo, (int)values.First());
+            Assert.Equal(1, values.Count());
+
+            Assert.Throws<NotImplementedException>(() => Locator.CurrentMutable.UnregisterCurrent(null));
+            var valuesNC = Locator.Current.GetServices(null);
+            Assert.Equal(1, valuesNC.Count());
+            Assert.Equal(foo, (int)valuesNC.First());
+            var valuesC = Locator.Current.GetServices(null, contract);
+            Assert.Equal(1, valuesC.Count());
+            Assert.Equal(bar, (int)valuesC.First());
         }
 
         /// <summary>

--- a/src/Splat.Autofac.Tests/Splat.Autofac.Tests.csproj
+++ b/src/Splat.Autofac.Tests/Splat.Autofac.Tests.csproj
@@ -6,6 +6,7 @@
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -50,8 +50,13 @@ namespace Splat.Autofac
         }
 
         /// <inheritdoc />
-        public virtual object? GetService(Type serviceType, string? contract = null)
+        public virtual object? GetService(Type? serviceType, string? contract = null)
         {
+            if (serviceType is null)
+            {
+                serviceType = typeof(NullServiceType);
+            }
+
             lock (_lockObject)
             {
                 return Resolve(serviceType, contract);
@@ -87,7 +92,7 @@ namespace Splat.Autofac
         {
             if (serviceType is null)
             {
-                throw new ArgumentNullException(nameof(serviceType));
+                serviceType = typeof(NullServiceType);
             }
 
             lock (_lockObject)
@@ -112,8 +117,13 @@ namespace Splat.Autofac
         }
 
         /// <inheritdoc />
-        public bool HasRegistration(Type serviceType, string? contract = null)
+        public bool HasRegistration(Type? serviceType, string? contract = null)
         {
+            if (serviceType is null)
+            {
+                serviceType = typeof(NullServiceType);
+            }
+
             lock (_lockObject)
             {
                 var lifeTimeScope = _lifetimeScope ?? _internalLifetimeScope;
@@ -138,8 +148,13 @@ namespace Splat.Autofac
         /// <param name="serviceType">The type which is used for the registration.</param>
         /// <param name="contract">A optional contract value which will indicates to only generate the value if this contract is specified.</param>
         [Obsolete("Because Autofac 5+ containers are immutable, this method should not be used by the end-user.")]
-        public virtual void Register(Func<object?> factory, Type serviceType, string? contract = null)
+        public virtual void Register(Func<object?> factory, Type? serviceType, string? contract = null)
         {
+            if (serviceType is null)
+            {
+                serviceType = typeof(NullServiceType);
+            }
+
             lock (_lockObject)
             {
                 if (_lifetimeScopeSet)
@@ -184,7 +199,7 @@ namespace Splat.Autofac
         /// <inheritdoc />
         [Obsolete("Because Autofac 5+ containers are immutable, UnregisterCurrent method is not available anymore. " +
                   "Instead, simply register your service after InitializeReactiveUI to override it https://autofaccn.readthedocs.io/en/latest/register/registration.html#default-registrations.")]
-        public virtual void UnregisterCurrent(Type serviceType, string? contract = null) =>
+        public virtual void UnregisterCurrent(Type? serviceType, string? contract = null) =>
             throw new NotImplementedException("Because Autofac 5+ containers are immutable, UnregisterCurrent method is not available anymore. " +
                                               "Instead, simply register your service after InitializeReactiveUI to override it https://autofaccn.readthedocs.io/en/latest/register/registration.html#default-registrations.");
 
@@ -199,7 +214,7 @@ namespace Splat.Autofac
         /// <inheritdoc />
         [Obsolete("Because Autofac 5+ containers are immutable, UnregisterAll method is not available anymore. " +
                   "Instead, simply register your service after InitializeReactiveUI to override it https://autofaccn.readthedocs.io/en/latest/register/registration.html#default-registrations.")]
-        public virtual void UnregisterAll(Type serviceType, string? contract = null) =>
+        public virtual void UnregisterAll(Type? serviceType, string? contract = null) =>
             throw new NotImplementedException("Because Autofac 5+ containers are immutable, UnregisterAll method is not available anymore. " +
                                               "Instead, simply register your service after InitializeReactiveUI to override it https://autofaccn.readthedocs.io/en/latest/register/registration.html#default-registrations.");
 
@@ -230,7 +245,7 @@ namespace Splat.Autofac
             }
         }
 
-        private object? Resolve(Type serviceType, string? contract)
+        private object? Resolve(Type? serviceType, string? contract)
         {
             object serviceInstance;
 
@@ -238,11 +253,11 @@ namespace Splat.Autofac
 
             if (contract is null || string.IsNullOrWhiteSpace(contract))
             {
-                lifeTimeScope.TryResolve(serviceType, out serviceInstance!);
+                lifeTimeScope.TryResolve(serviceType!, out serviceInstance!);
             }
             else
             {
-                lifeTimeScope.TryResolveNamed(contract, serviceType, out serviceInstance!);
+                lifeTimeScope.TryResolveNamed(contract, serviceType!, out serviceInstance!);
             }
 
             return serviceInstance;

--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -126,7 +126,7 @@ namespace Splat.Autofac
         ///     Register a function with the resolver which will generate a object
         ///     for the specified service type.
         ///     Optionally a contract can be registered which will indicate
-        ///     that that registration will only work with that contract.
+        ///     that registration will only work with that contract.
         ///     Most implementations will use a stack based approach to allow for multiple items to be registered.
         /// </summary>
         /// <param name="factory">The factory function which generates our object.</param>

--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -50,7 +50,7 @@ namespace Splat.Autofac
         }
 
         /// <inheritdoc />
-        public virtual object? GetService(Type serviceType, string? contract = null)
+        public virtual object GetService(Type serviceType, string? contract = null)
         {
             lock (_lockObject)
             {
@@ -133,7 +133,7 @@ namespace Splat.Autofac
         /// <param name="serviceType">The type which is used for the registration.</param>
         /// <param name="contract">A optional contract value which will indicates to only generate the value if this contract is specified.</param>
         [Obsolete("Because Autofac 5+ containers are immutable, this method should not be used by the end-user.")]
-        public virtual void Register(Func<object> factory, Type serviceType, string? contract = null)
+        public virtual void Register(Func<object?> factory, Type serviceType, string? contract = null)
         {
             lock (_lockObject)
             {
@@ -147,21 +147,21 @@ namespace Splat.Autofac
                 // Second to child lifetimes in a temporary container, that is used only to satisfy ReactiveUI dependencies.
                 if (contract is null || string.IsNullOrWhiteSpace(contract))
                 {
-                    _builder.Register(_ => factory())
+                    _builder.Register(_ => factory()!)
                         .As(serviceType)
                         .AsImplementedInterfaces();
                     _internalLifetimeScope = _internalLifetimeScope.BeginLifetimeScope(internalBuilder =>
-                        internalBuilder.Register(_ => factory())
+                        internalBuilder.Register(_ => factory()!)
                             .As(serviceType)
                             .AsImplementedInterfaces());
                 }
                 else
                 {
-                    _builder.Register(_ => factory())
+                    _builder.Register(_ => factory()!)
                         .Named(contract, serviceType)
                         .AsImplementedInterfaces();
                     _internalLifetimeScope = _internalLifetimeScope.BeginLifetimeScope(internalBuilder =>
-                        internalBuilder.Register(_ => factory())
+                        internalBuilder.Register(_ => factory()!)
                             .Named(contract, serviceType)
                             .AsImplementedInterfaces());
                 }
@@ -225,19 +225,19 @@ namespace Splat.Autofac
             }
         }
 
-        private object? Resolve(Type serviceType, string? contract)
+        private object Resolve(Type serviceType, string? contract)
         {
-            object? serviceInstance;
+            object serviceInstance;
 
             var lifeTimeScope = _lifetimeScope ?? _internalLifetimeScope;
 
             if (contract is null || string.IsNullOrWhiteSpace(contract))
             {
-                lifeTimeScope.TryResolve(serviceType, out serviceInstance);
+                lifeTimeScope.TryResolve(serviceType, out serviceInstance!);
             }
             else
             {
-                lifeTimeScope.TryResolveNamed(contract, serviceType, out serviceInstance);
+                lifeTimeScope.TryResolveNamed(contract, serviceType, out serviceInstance!);
             }
 
             return serviceInstance;

--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -83,8 +83,13 @@ namespace Splat.Autofac
         }
 
         /// <inheritdoc />
-        public virtual IEnumerable<object?> GetServices(Type serviceType, string? contract = null)
+        public virtual IEnumerable<object> GetServices(Type? serviceType, string? contract = null)
         {
+            if (serviceType is null)
+            {
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+
             lock (_lockObject)
             {
                 try
@@ -92,17 +97,17 @@ namespace Splat.Autofac
                     var enumerableType = typeof(IEnumerable<>).MakeGenericType(serviceType);
                     var instance = Resolve(enumerableType, contract);
 
-                    if (instance is null)
+                    if (instance is not null)
                     {
-                        return Array.Empty<object?>();
+                        return new object[] { instance };
                     }
-
-                    return ((IEnumerable)instance).Cast<object?>();
                 }
                 catch (DependencyResolutionException)
                 {
-                    return Array.Empty<object?>();
+                    // no op
                 }
+
+                return Enumerable.Empty<object>();
             }
         }
 
@@ -225,7 +230,7 @@ namespace Splat.Autofac
             }
         }
 
-        private object Resolve(Type serviceType, string? contract)
+        private object? Resolve(Type serviceType, string? contract)
         {
             object serviceInstance;
 

--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -50,7 +50,7 @@ namespace Splat.Autofac
         }
 
         /// <inheritdoc />
-        public virtual object GetService(Type serviceType, string? contract = null)
+        public virtual object? GetService(Type serviceType, string? contract = null)
         {
             lock (_lockObject)
             {
@@ -83,7 +83,7 @@ namespace Splat.Autofac
         }
 
         /// <inheritdoc />
-        public virtual IEnumerable<object> GetServices(Type serviceType, string? contract = null)
+        public virtual IEnumerable<object?> GetServices(Type serviceType, string? contract = null)
         {
             lock (_lockObject)
             {
@@ -94,14 +94,14 @@ namespace Splat.Autofac
 
                     if (instance is null)
                     {
-                        return Array.Empty<object>();
+                        return Array.Empty<object?>();
                     }
 
-                    return ((IEnumerable)instance).Cast<object>();
+                    return ((IEnumerable)instance).Cast<object?>();
                 }
                 catch (DependencyResolutionException)
                 {
-                    return Array.Empty<object>();
+                    return Array.Empty<object?>();
                 }
             }
         }

--- a/src/Splat.Common.Test/DummyObjectClass1.cs
+++ b/src/Splat.Common.Test/DummyObjectClass1.cs
@@ -3,11 +3,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Splat.Tests.Mocks
 {
     /// <summary>
     /// A dummy class used during Locator testing.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class DummyObjectClass1 : IDummyInterface
     {
     }

--- a/src/Splat.Common.Test/DummyObjectClass1.cs
+++ b/src/Splat.Common.Test/DummyObjectClass1.cs
@@ -8,7 +8,7 @@ namespace Splat.Tests.Mocks
     /// <summary>
     /// A dummy class used during Locator testing.
     /// </summary>
-    internal class DummyObjectClass3 : IDummyInterface
+    public class DummyObjectClass1 : IDummyInterface
     {
     }
 }

--- a/src/Splat.Common.Test/DummyObjectClass2.cs
+++ b/src/Splat.Common.Test/DummyObjectClass2.cs
@@ -3,11 +3,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Splat.Tests.Mocks
 {
     /// <summary>
     /// A dummy class used during Locator testing.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class DummyObjectClass2 : IDummyInterface
     {
     }

--- a/src/Splat.Common.Test/DummyObjectClass2.cs
+++ b/src/Splat.Common.Test/DummyObjectClass2.cs
@@ -8,7 +8,7 @@ namespace Splat.Tests.Mocks
     /// <summary>
     /// A dummy class used during Locator testing.
     /// </summary>
-    internal class DummyObjectClass2 : IDummyInterface
+    public class DummyObjectClass2 : IDummyInterface
     {
     }
 }

--- a/src/Splat.Common.Test/DummyObjectClass3.cs
+++ b/src/Splat.Common.Test/DummyObjectClass3.cs
@@ -6,9 +6,9 @@
 namespace Splat.Tests.Mocks
 {
     /// <summary>
-    /// A dummy interface used during Locator testing.
+    /// A dummy class used during Locator testing.
     /// </summary>
-    internal interface IDummyInterface
+    public class DummyObjectClass3 : IDummyInterface
     {
     }
 }

--- a/src/Splat.Common.Test/DummyObjectClass3.cs
+++ b/src/Splat.Common.Test/DummyObjectClass3.cs
@@ -3,11 +3,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Splat.Tests.Mocks
 {
     /// <summary>
     /// A dummy class used during Locator testing.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class DummyObjectClass3 : IDummyInterface
     {
     }

--- a/src/Splat.Common.Test/IDummyInterface.cs
+++ b/src/Splat.Common.Test/IDummyInterface.cs
@@ -6,9 +6,9 @@
 namespace Splat.Tests.Mocks
 {
     /// <summary>
-    /// A dummy class used during Locator testing.
+    /// A dummy interface used during Locator testing.
     /// </summary>
-    internal class DummyObjectClass1 : IDummyInterface
+    public interface IDummyInterface
     {
     }
 }

--- a/src/Splat.Common.Test/IDummyInterface.cs
+++ b/src/Splat.Common.Test/IDummyInterface.cs
@@ -8,7 +8,9 @@ namespace Splat.Tests.Mocks
     /// <summary>
     /// A dummy interface used during Locator testing.
     /// </summary>
+#pragma warning disable CA1040 // Avoid empty interfaces
     public interface IDummyInterface
+#pragma warning restore CA1040 // Avoid empty interfaces
     {
     }
 }

--- a/src/Splat.Common.Test/IViewFor.cs
+++ b/src/Splat.Common.Test/IViewFor.cs
@@ -6,17 +6,19 @@
 namespace Splat.Common.Test
 {
 #pragma warning disable SA1402 // File may only contain a single type
+
     /// <summary>
     /// Represents a view bound to a view model.
     /// </summary>
     /// <typeparam name="T">The view model type.</typeparam>
     /// <seealso cref="Splat.Common.Test.IViewFor" />
     public interface IViewFor<T> : IViewFor
+        where T : class
     {
         /// <summary>
         /// Gets or sets the view model.
         /// </summary>
-        new T ViewModel { get; set; }
+        new T? ViewModel { get; set; }
     }
 
     /// <summary>
@@ -28,7 +30,8 @@ namespace Splat.Common.Test
         /// <summary>
         /// Gets or sets the view model.
         /// </summary>
-        object ViewModel { get; set; }
+        object? ViewModel { get; set; }
     }
+
 #pragma warning restore SA1402 // File may only contain a single type
 }

--- a/src/Splat.Common.Test/IViewModelOne.cs
+++ b/src/Splat.Common.Test/IViewModelOne.cs
@@ -8,7 +8,9 @@ namespace Splat.Common.Test
     /// <summary>
     /// Interface for ViewModelOne.
     /// </summary>
+#pragma warning disable CA1040 // Avoid empty interfaces
     public interface IViewModelOne
+#pragma warning restore CA1040 // Avoid empty interfaces
     {
     }
 }

--- a/src/Splat.Common.Test/MockScreen.cs
+++ b/src/Splat.Common.Test/MockScreen.cs
@@ -3,12 +3,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Splat.Common.Test
 {
     /// <summary>
     /// An <see cref="IScreen"/> implementation.
     /// </summary>
     /// <seealso cref="IScreen" />
+    [ExcludeFromCodeCoverage]
     public class MockScreen : IScreen
     {
     }

--- a/src/Splat.Common.Test/Splat.Common.Test.csproj
+++ b/src/Splat.Common.Test/Splat.Common.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA2000</NoWarn>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
 </Project>

--- a/src/Splat.Common.Test/ViewModelOne.cs
+++ b/src/Splat.Common.Test/ViewModelOne.cs
@@ -3,11 +3,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Splat.Common.Test
 {
     /// <summary>
     /// View Model One.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class ViewModelOne : IViewModelOne
     {
         /// <summary>

--- a/src/Splat.Common.Test/ViewModelTwo.cs
+++ b/src/Splat.Common.Test/ViewModelTwo.cs
@@ -3,11 +3,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Splat.Common.Test
 {
     /// <summary>
     /// View Model Two.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class ViewModelTwo
     {
     }

--- a/src/Splat.Common.Test/ViewOne.cs
+++ b/src/Splat.Common.Test/ViewOne.cs
@@ -12,13 +12,13 @@ namespace Splat.Common.Test
     public class ViewOne : IViewFor<ViewModelOne>
     {
         /// <inheritdoc />
-        object IViewFor.ViewModel
+        object? IViewFor.ViewModel
         {
             get => ViewModel;
-            set => ViewModel = (ViewModelOne)value;
+            set => ViewModel = (ViewModelOne?)value;
         }
 
         /// <inheritdoc />
-        public ViewModelOne ViewModel { get; set; }
+        public ViewModelOne? ViewModel { get; set; }
     }
 }

--- a/src/Splat.Common.Test/ViewOne.cs
+++ b/src/Splat.Common.Test/ViewOne.cs
@@ -3,12 +3,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Splat.Common.Test
 {
     /// <summary>
     /// View One.
     /// </summary>
     /// <seealso cref="ViewModelOne" />
+    [ExcludeFromCodeCoverage]
     public class ViewOne : IViewFor<ViewModelOne>
     {
         /// <inheritdoc />

--- a/src/Splat.Common.Test/ViewTwo.cs
+++ b/src/Splat.Common.Test/ViewTwo.cs
@@ -12,13 +12,13 @@ namespace Splat.Common.Test
     public class ViewTwo : IViewFor<ViewModelTwo>
     {
         /// <inheritdoc />
-        object IViewFor.ViewModel
+        object? IViewFor.ViewModel
         {
             get => ViewModel;
-            set => ViewModel = (ViewModelTwo)value;
+            set => ViewModel = (ViewModelTwo?)value;
         }
 
         /// <inheritdoc />
-        public ViewModelTwo ViewModel { get; set; }
+        public ViewModelTwo? ViewModel { get; set; }
     }
 }

--- a/src/Splat.Common.Test/ViewTwo.cs
+++ b/src/Splat.Common.Test/ViewTwo.cs
@@ -3,12 +3,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Splat.Common.Test
 {
     /// <summary>
     /// View Two.
     /// </summary>
     /// <seealso cref="ViewModelTwo" />
+    [ExcludeFromCodeCoverage]
     public class ViewTwo : IViewFor<ViewModelTwo>
     {
         /// <inheritdoc />

--- a/src/Splat.Drawing.Tests/BitmapLoaderTests.cs
+++ b/src/Splat.Drawing.Tests/BitmapLoaderTests.cs
@@ -11,6 +11,7 @@ using System.Text;
 using Xunit;
 
 #if !NETSTANDARD2_0
+
 namespace Splat.Tests
 {
     /// <summary>
@@ -100,9 +101,10 @@ namespace Splat.Tests
             return Android.App.Application.Context.Assets.Open(imageName);
 #else
             var assembly = Assembly.GetExecutingAssembly();
-            return assembly.GetManifestResourceStream(imageName);
+            return assembly.GetManifestResourceStream(imageName)!;
 #endif
         }
     }
 }
+
 #endif

--- a/src/Splat.Drawing.Tests/Colors/SplatColorTests.cs
+++ b/src/Splat.Drawing.Tests/Colors/SplatColorTests.cs
@@ -55,7 +55,7 @@ namespace Splat.Tests.Colors
             var results = new List<object[]>(values.Length);
             foreach (var value in values)
             {
-                results.Add(new[] { value });
+                results.Add(new[] { value! });
             }
 
             return results;

--- a/src/Splat.Drawing.Tests/Splat.Drawing.Tests.csproj
+++ b/src/Splat.Drawing.Tests/Splat.Drawing.Tests.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000;CA1034</NoWarn>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT' ">

--- a/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
+++ b/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
@@ -21,6 +21,29 @@ namespace Splat.DryIoc.Tests
     public class DependencyResolverTests
     {
         /// <summary>
+        /// Shoulds the resolve nulls.
+        /// </summary>
+        [Fact]
+        public void Can_Register_And_Resolve_Null_Types()
+        {
+            var builder = new Container();
+            builder.UseDryIocDependencyResolver();
+
+            var foo = 5;
+            Locator.CurrentMutable.Register(() => foo, null);
+
+            var bar = 4;
+            var contract = "foo";
+            Locator.CurrentMutable.Register(() => bar, null, contract);
+
+            var value = Locator.Current.GetService(null);
+            Assert.Equal(foo, value);
+
+            value = Locator.Current.GetService(null, contract);
+            Assert.Equal(bar, value);
+        }
+
+        /// <summary>
         /// Should resolve the views.
         /// </summary>
         [Fact]

--- a/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
+++ b/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
@@ -53,6 +53,14 @@ namespace Splat.DryIoc.Tests
             Assert.Equal(0, valuesNC.Count());
             var valuesC = Locator.Current.GetServices(null, contract);
             Assert.Equal(1, valuesC.Count());
+
+            Locator.CurrentMutable.UnregisterAll(null);
+            valuesNC = Locator.Current.GetServices(null);
+            Assert.Equal(0, valuesNC.Count());
+
+            Locator.CurrentMutable.UnregisterAll(null, contract);
+            valuesC = Locator.Current.GetServices(null, contract);
+            Assert.Equal(0, valuesC.Count());
         }
 
         /// <summary>

--- a/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
+++ b/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
@@ -36,11 +36,23 @@ namespace Splat.DryIoc.Tests
             var contract = "foo";
             Locator.CurrentMutable.Register(() => bar, null, contract);
 
+            Assert.True(Locator.CurrentMutable.HasRegistration(null));
             var value = Locator.Current.GetService(null);
             Assert.Equal(foo, value);
 
+            Assert.True(Locator.CurrentMutable.HasRegistration(null, contract));
             value = Locator.Current.GetService(null, contract);
             Assert.Equal(bar, value);
+
+            var values = Locator.Current.GetServices(null);
+            Assert.Equal(foo, (int)values.First());
+            Assert.Equal(1, values.Count());
+
+            Locator.CurrentMutable.UnregisterCurrent(null);
+            var valuesNC = Locator.Current.GetServices(null);
+            Assert.Equal(0, valuesNC.Count());
+            var valuesC = Locator.Current.GetServices(null, contract);
+            Assert.Equal(1, valuesC.Count());
         }
 
         /// <summary>

--- a/src/Splat.DryIoc.Tests/Splat.DryIoc.Tests.csproj
+++ b/src/Splat.DryIoc.Tests/Splat.DryIoc.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.DryIoc/DryIocDependencyResolver.cs
+++ b/src/Splat.DryIoc/DryIocDependencyResolver.cs
@@ -126,6 +126,7 @@ namespace Splat.DryIoc
                 serviceType = typeof(NullServiceType);
             }
 
+            var key = (serviceType, contract ?? string.Empty);
             var hadvalue = _container.GetServiceRegistrations().Any(x =>
             {
                 if (x.ServiceType != serviceType)
@@ -133,7 +134,6 @@ namespace Splat.DryIoc
                     return false;
                 }
 
-                var key = (serviceType, contract ?? string.Empty);
                 if (key.Equals(x.OptionalServiceKey))
                 {
                     _container.Unregister(serviceType, key);
@@ -166,10 +166,31 @@ namespace Splat.DryIoc
             }
 
             var key = (serviceType, contract ?? string.Empty);
+            foreach (var x in _container.GetServiceRegistrations())
+            {
+                if (x.ServiceType != serviceType)
+                {
+                    continue;
+                }
 
-            _container.Unregister(serviceType, key);
-            _container.Unregister(serviceType, contract);
-            _container.Unregister(serviceType);
+                if (key.Equals(x.OptionalServiceKey))
+                {
+                    _container.Unregister(serviceType, key);
+                    continue;
+                }
+
+                if (contract is null && x.OptionalServiceKey is null)
+                {
+                    _container.Unregister(serviceType);
+                    continue;
+                }
+
+                if (x.OptionalServiceKey is string serviceKeyAsString
+                       && contract is not null && contract.Equals(serviceKeyAsString, StringComparison.Ordinal))
+                {
+                    _container.Unregister(serviceType, contract);
+                }
+            }
         }
 
         /// <inheritdoc />

--- a/src/Splat.DryIoc/DryIocDependencyResolver.cs
+++ b/src/Splat.DryIoc/DryIocDependencyResolver.cs
@@ -69,13 +69,7 @@ namespace Splat.DryIoc
                 return registeredinSplat;
             }
 
-            var registeredWithContract = _container.ResolveMany(serviceType, serviceKey: contract).Select(x => isNull ? ((NullServiceType)x).Factory()! : x);
-            if (registeredWithContract.Any())
-            {
-                return registeredWithContract;
-            }
-
-            return _container.ResolveMany(serviceType).Select(x => isNull ? ((NullServiceType)x).Factory()! : x);
+            return Array.Empty<object>();
         }
 
         /// <inheritdoc />

--- a/src/Splat.DryIoc/DryIocDependencyResolver.cs
+++ b/src/Splat.DryIoc/DryIocDependencyResolver.cs
@@ -29,10 +29,10 @@ namespace Splat.DryIoc
         }
 
         /// <inheritdoc />
-        public virtual object? GetService(Type serviceType, string? contract = null) =>
+        public virtual object GetService(Type serviceType, string? contract = null) =>
             string.IsNullOrEmpty(contract)
-                ? _container.ResolveMany(serviceType).LastOrDefault()
-                : _container.ResolveMany(serviceType, serviceKey: contract).LastOrDefault();
+                ? _container.ResolveMany(serviceType).LastOrDefault()!
+                : _container.ResolveMany(serviceType, serviceKey: contract).LastOrDefault()!;
 
         /// <inheritdoc />
         public virtual IEnumerable<object> GetServices(Type serviceType, string? contract = null) =>
@@ -61,7 +61,7 @@ namespace Splat.DryIoc
         }
 
         /// <inheritdoc />
-        public virtual void Register(Func<object> factory, Type serviceType, string? contract = null)
+        public virtual void Register(Func<object?> factory, Type serviceType, string? contract = null)
         {
             if (factory is null)
             {

--- a/src/Splat.DryIoc/DryIocDependencyResolver.cs
+++ b/src/Splat.DryIoc/DryIocDependencyResolver.cs
@@ -29,13 +29,13 @@ namespace Splat.DryIoc
         }
 
         /// <inheritdoc />
-        public virtual object GetService(Type serviceType, string? contract = null) =>
+        public virtual object? GetService(Type serviceType, string? contract = null) =>
             string.IsNullOrEmpty(contract)
-                ? _container.ResolveMany(serviceType).LastOrDefault()!
-                : _container.ResolveMany(serviceType, serviceKey: contract).LastOrDefault()!;
+                ? _container.ResolveMany(serviceType).LastOrDefault()
+                : _container.ResolveMany(serviceType, serviceKey: contract).LastOrDefault();
 
         /// <inheritdoc />
-        public virtual IEnumerable<object> GetServices(Type serviceType, string? contract = null) =>
+        public virtual IEnumerable<object?> GetServices(Type serviceType, string? contract = null) =>
             string.IsNullOrEmpty(contract)
                 ? _container.ResolveMany(serviceType)
                 : _container.ResolveMany(serviceType, serviceKey: contract);

--- a/src/Splat.DryIoc/DryIocDependencyResolver.cs
+++ b/src/Splat.DryIoc/DryIocDependencyResolver.cs
@@ -35,7 +35,7 @@ namespace Splat.DryIoc
                 : _container.ResolveMany(serviceType, serviceKey: contract).LastOrDefault();
 
         /// <inheritdoc />
-        public virtual IEnumerable<object?> GetServices(Type serviceType, string? contract = null) =>
+        public virtual IEnumerable<object> GetServices(Type? serviceType, string? contract = null) =>
             string.IsNullOrEmpty(contract)
                 ? _container.ResolveMany(serviceType)
                 : _container.ResolveMany(serviceType, serviceKey: contract);

--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/ContainerWrapper.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/ContainerWrapper.cs
@@ -9,7 +9,10 @@ namespace Splat.Microsoft.Extensions.DependencyInjection.Tests
     {
         private IServiceProvider _serviceProvider;
 
+#pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+
         public ContainerWrapper()
+#pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
         {
             ServiceCollection.UseMicrosoftDependencyResolver();
         }

--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/ContainerWrapper.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/ContainerWrapper.cs
@@ -19,18 +19,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection.Tests
 
         public IServiceCollection ServiceCollection { get; } = new ServiceCollection();
 
-        public IServiceProvider ServiceProvider
-        {
-            get
-            {
-                if (_serviceProvider is null)
-                {
-                    _serviceProvider = ServiceCollection.BuildServiceProvider();
-                }
-
-                return _serviceProvider;
-            }
-        }
+        public IServiceProvider ServiceProvider => _serviceProvider ??= ServiceCollection.BuildServiceProvider();
 
         public void BuildAndUse() => ServiceProvider.UseMicrosoftDependencyResolver();
     }

--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/DependencyResolverTests.cs
@@ -10,7 +10,7 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 
 using Splat.Common.Test;
-
+using Splat.NLog;
 using Xunit;
 
 namespace Splat.Microsoft.Extensions.DependencyInjection.Tests
@@ -146,6 +146,29 @@ namespace Splat.Microsoft.Extensions.DependencyInjection.Tests
             var result = Record.Exception(() => Locator.CurrentMutable.Register(() => new ViewOne()));
 
             result.Should().BeOfType<InvalidOperationException>();
+        }
+
+        /// <summary>
+        /// Tests to ensure NLog registers correctly with different service locators.
+        /// Based on issue reported in #553.
+        /// </summary>
+        [Fact]
+        public void ILogManager_Resolvable()
+        {
+            var wrapper = new ContainerWrapper();
+            var services = wrapper.ServiceCollection;
+
+            // Setup NLog for Logging (doesn't matter if I actually configure NLog or not)
+            var funcLogManager = new FuncLogManager(type => new NLogLogger(LogResolver.Resolve(type)));
+            services.AddSingleton<ILogManager>(funcLogManager);
+
+            wrapper.BuildAndUse();
+
+            // Get the ILogManager instance.
+            ILogManager lm = Locator.Current.GetService<ILogManager>();
+
+            var mgr = lm.GetLogger<NLogLogger>();
+            Assert.NotNull(mgr);
         }
     }
 }

--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/DependencyResolverTests.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/DependencyResolverTests.cs
@@ -165,9 +165,12 @@ namespace Splat.Microsoft.Extensions.DependencyInjection.Tests
             wrapper.BuildAndUse();
 
             // Get the ILogManager instance.
-            ILogManager lm = Locator.Current.GetService<ILogManager>();
+            ILogManager? lm = Locator.Current.GetService<ILogManager>();
+            Assert.NotNull(lm);
 
+#pragma warning disable CS8604 // Possible null reference argument.
             var mgr = lm.GetLogger<NLogLogger>();
+#pragma warning restore CS8604 // Possible null reference argument.
             Assert.NotNull(mgr);
         }
     }

--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/MicrosoftDependencyResolverTests.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/MicrosoftDependencyResolverTests.cs
@@ -21,16 +21,16 @@ namespace Splat.Tests.ServiceLocation
         {
             var resolver = GetDependencyResolver();
             var foo = 5;
-            resolver.Register(() => foo, null);
+            resolver.Register(() => foo, null!);
 
-            var value = resolver.GetService(null);
+            var value = resolver.GetService(null!);
             Assert.Equal(foo, value);
 
             var bar = 4;
             var contract = "foo";
-            resolver.Register(() => bar, null, contract);
+            resolver.Register(() => bar, null!, contract);
 
-            value = resolver.GetService(null, contract);
+            value = resolver.GetService(null!, contract);
             Assert.Equal(bar, value);
         }
 

--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/MicrosoftDependencyResolverTests.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/MicrosoftDependencyResolverTests.cs
@@ -41,8 +41,18 @@ namespace Splat.Tests.ServiceLocation
             Assert.Equal(1, values.Count());
 
             resolver.UnregisterCurrent(null);
-            values = resolver.GetServices(null);
-            Assert.Equal(0, values.Count());
+            var valuesNC = resolver.GetServices(null);
+            Assert.Equal(0, valuesNC.Count());
+            var valuesC = resolver.GetServices(null, contract);
+            Assert.Equal(1, valuesC.Count());
+
+            resolver.UnregisterAll(null);
+            valuesNC = resolver.GetServices(null);
+            Assert.Equal(0, valuesNC.Count());
+
+            resolver.UnregisterAll(null, contract);
+            valuesC = resolver.GetServices(null, contract);
+            Assert.Equal(0, valuesC.Count());
         }
 
         /// <inheritdoc />

--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/MicrosoftDependencyResolverTests.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/MicrosoftDependencyResolverTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Splat.Microsoft.Extensions.DependencyInjection;
@@ -24,15 +25,24 @@ namespace Splat.Tests.ServiceLocation
             var foo = 5;
             resolver.Register(() => foo, null!);
 
-            var value = resolver.GetService(null!);
-            Assert.Equal(foo, value);
-
             var bar = 4;
             var contract = "foo";
             resolver.Register(() => bar, null!, contract);
 
+            Assert.True(resolver.HasRegistration(null));
+            var value = resolver.GetService(null!);
+            Assert.Equal(foo, value);
+
+            Assert.True(resolver.HasRegistration(null, contract));
             value = resolver.GetService(null!, contract);
             Assert.Equal(bar, value);
+
+            var values = resolver.GetServices(null);
+            Assert.Equal(1, values.Count());
+
+            resolver.UnregisterCurrent(null);
+            values = resolver.GetServices(null);
+            Assert.Equal(0, values.Count());
         }
 
         /// <inheritdoc />

--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/MicrosoftDependencyResolverTests.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/MicrosoftDependencyResolverTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Microsoft.Extensions.DependencyInjection;
 using Splat.Microsoft.Extensions.DependencyInjection;
 using Xunit;
 

--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/Splat.Microsoft.Extensions.DependencyInjection.Tests.csproj
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/Splat.Microsoft.Extensions.DependencyInjection.Tests.csproj
@@ -5,6 +5,7 @@
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/Splat.Microsoft.Extensions.DependencyInjection.Tests.csproj
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/Splat.Microsoft.Extensions.DependencyInjection.Tests.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Splat.NLog\LogResolver.cs" Link="LogResolver.cs" />
     <Compile Include="..\Splat.Tests\ServiceLocation\BaseDependencyResolverTests.cs" Link="BaseDependencyResolverTests.cs" />
   </ItemGroup>
 

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
@@ -85,8 +85,8 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
         }
 
         /// <inheritdoc />
-        public virtual object? GetService(Type serviceType, string? contract = null) =>
-            GetServices(serviceType, contract).LastOrDefault();
+        public virtual object GetService(Type serviceType, string? contract = null) =>
+            GetServices(serviceType, contract).LastOrDefault()!;
 
         /// <inheritdoc />
         public virtual IEnumerable<object> GetServices(Type serviceType, string? contract = null)
@@ -106,7 +106,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
                 {
                     services = services
                         .Cast<NullServiceType>()
-                        .Select(nst => nst.Factory());
+                        .Select(nst => nst.Factory()!);
                 }
             }
             else
@@ -122,7 +122,10 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
         }
 
         /// <inheritdoc />
+#pragma warning disable CS8614 // Nullability of reference types in type of parameter doesn't match implicitly implemented member.
+
         public virtual void Register(Func<object> factory, Type serviceType, string? contract = null)
+#pragma warning restore CS8614 // Nullability of reference types in type of parameter doesn't match implicitly implemented member.
         {
             if (_isImmutable)
             {
@@ -143,7 +146,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
                     _serviceCollection?.AddTransient(serviceType, _ =>
                     isNull
                     ? new NullServiceType(factory)
-                    : factory());
+                    : factory()!);
                 }
                 else
                 {

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
@@ -4,14 +4,11 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Splat.Microsoft.Extensions.DependencyInjection
@@ -85,8 +82,8 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
         }
 
         /// <inheritdoc />
-        public virtual object? GetService(Type serviceType, string? contract = null) =>
-            GetServices(serviceType, contract).LastOrDefault()!;
+        public virtual object? GetService(Type? serviceType, string? contract = null) =>
+            GetServices(serviceType, contract).LastOrDefault();
 
         /// <inheritdoc />
         public virtual IEnumerable<object> GetServices(Type? serviceType, string? contract = null)
@@ -118,7 +115,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
                 var dic = GetContractDictionary(serviceType, false);
                 services = dic?
                     .GetFactories(contract)
-                    .Select(f => f())
+                    .Select(f => f()!)
                     ?? Array.Empty<object>();
             }
 
@@ -126,10 +123,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
         }
 
         /// <inheritdoc />
-#pragma warning disable CS8614 // Nullability of reference types in type of parameter doesn't match implicitly implemented member.
-
-        public virtual void Register(Func<object> factory, Type? serviceType, string? contract = null)
-#pragma warning restore CS8614 // Nullability of reference types in type of parameter doesn't match implicitly implemented member.
+        public virtual void Register(Func<object?> factory, Type? serviceType, string? contract = null)
         {
             if (_isImmutable)
             {
@@ -165,7 +159,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
         }
 
         /// <inheritdoc/>
-        public virtual void UnregisterCurrent(Type serviceType, string? contract = null)
+        public virtual void UnregisterCurrent(Type? serviceType, string? contract = null)
         {
             if (_isImmutable)
             {
@@ -212,7 +206,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <param name="serviceType">The service type to unregister.</param>
         /// <param name="contract">This parameter is ignored. Service will be removed from all contracts.</param>
-        public virtual void UnregisterAll(Type serviceType, string? contract = null)
+        public virtual void UnregisterAll(Type? serviceType, string? contract = null)
         {
             if (_isImmutable)
             {
@@ -263,7 +257,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
         }
 
         /// <inheritdoc/>
-        public virtual bool HasRegistration(Type serviceType, string? contract = null)
+        public virtual bool HasRegistration(Type? serviceType, string? contract = null)
         {
             if (serviceType is null)
             {
@@ -363,31 +357,31 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
 
         private class ContractDictionary
         {
-            private readonly ConcurrentDictionary<string, List<Func<object>>> _dictionary = new();
+            private readonly ConcurrentDictionary<string, List<Func<object?>>> _dictionary = new();
 
             public bool IsEmpty => _dictionary.IsEmpty;
 
             public bool TryRemoveContract(string contract) =>
                 _dictionary.TryRemove(contract, out var _);
 
-            public Func<object>? GetFactory(string contract) =>
+            public Func<object?>? GetFactory(string contract) =>
                 GetFactories(contract)
                     .LastOrDefault();
 
-            public IEnumerable<Func<object>> GetFactories(string contract) =>
+            public IEnumerable<Func<object?>> GetFactories(string contract) =>
                 _dictionary.TryGetValue(contract, out var collection)
-                ? collection ?? Enumerable.Empty<Func<object>>()
-                : Array.Empty<Func<object>>();
+                ? collection ?? Enumerable.Empty<Func<object?>>()
+                : Array.Empty<Func<object?>>();
 
-            public void AddFactory(string contract, Func<object> factory) =>
-                _dictionary.AddOrUpdate(contract, _ => new List<Func<object>> { factory }, (_, list) =>
+            public void AddFactory(string contract, Func<object?> factory) =>
+                _dictionary.AddOrUpdate(contract, _ => new List<Func<object?>> { factory }, (_, list) =>
                 {
-                    (list ??= new List<Func<object>>()).Add(factory);
+                    (list ??= new List<Func<object?>>()).Add(factory);
                     return list;
                 });
 
             public void RemoveLastFactory(string contract) =>
-                _dictionary.AddOrUpdate(contract, new List<Func<object>>(), (_, list) =>
+                _dictionary.AddOrUpdate(contract, new List<Func<object?>>(), (_, list) =>
                 {
                     var lastIndex = list.Count - 1;
                     if (lastIndex > 0)
@@ -405,16 +399,6 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
         [SuppressMessage("Design", "CA1812: Unused class.", Justification = "Used in reflection.")]
         private class ContractDictionary<T> : ContractDictionary
         {
-        }
-
-        private class NullServiceType
-        {
-            public NullServiceType(Func<object> factory)
-            {
-                Factory = factory;
-            }
-
-            public Func<object> Factory { get; }
         }
     }
 }

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
@@ -85,11 +85,11 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
         }
 
         /// <inheritdoc />
-        public virtual object GetService(Type serviceType, string? contract = null) =>
+        public virtual object? GetService(Type serviceType, string? contract = null) =>
             GetServices(serviceType, contract).LastOrDefault()!;
 
         /// <inheritdoc />
-        public virtual IEnumerable<object> GetServices(Type serviceType, string? contract = null)
+        public virtual IEnumerable<object?> GetServices(Type serviceType, string? contract = null)
         {
             var isNull = serviceType is null;
             if (serviceType is null)
@@ -97,11 +97,11 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
                 serviceType = typeof(NullServiceType);
             }
 
-            IEnumerable<object> services;
+            IEnumerable<object?> services;
 
             if (contract is null || string.IsNullOrWhiteSpace(contract))
             {
-                services = ServiceProvider.GetServices(serviceType).Where(x => x is not null).Select(x => x!);
+                services = ServiceProvider.GetServices(serviceType);
                 if (isNull)
                 {
                     services = services
@@ -115,7 +115,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
                 services = dic?
                     .GetFactories(contract)
                     .Select(f => f())
-                    ?? Enumerable.Empty<object>();
+                    ?? Enumerable.Empty<object?>();
             }
 
             return services;
@@ -240,7 +240,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
                 else
                 {
                     var dic = GetContractDictionary(serviceType, false);
-                    if (dic is not null && dic.TryRemoveContract(contract) && dic.IsEmpty)
+                    if (dic?.TryRemoveContract(contract) == true && dic.IsEmpty)
                     {
                         RemoveContractService(serviceType);
                     }
@@ -378,12 +378,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
             public void AddFactory(string contract, Func<object> factory) =>
                 _dictionary.AddOrUpdate(contract, _ => new List<Func<object>> { factory }, (_, list) =>
                 {
-                    if (list is null)
-                    {
-                        list = new List<Func<object>>();
-                    }
-
-                    list.Add(factory);
+                    (list ??= new List<Func<object>>()).Add(factory);
                     return list;
                 });
 

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
@@ -89,7 +89,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
             GetServices(serviceType, contract).LastOrDefault()!;
 
         /// <inheritdoc />
-        public virtual IEnumerable<object?> GetServices(Type serviceType, string? contract = null)
+        public virtual IEnumerable<object> GetServices(Type? serviceType, string? contract = null)
         {
             var isNull = serviceType is null;
             if (serviceType is null)
@@ -97,11 +97,15 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
                 serviceType = typeof(NullServiceType);
             }
 
-            IEnumerable<object?> services;
+            IEnumerable<object> services;
 
             if (contract is null || string.IsNullOrWhiteSpace(contract))
             {
-                services = ServiceProvider.GetServices(serviceType);
+                // this is to deal with CS8613 that GetServices returns IEnumerable<object?>?
+                services = ServiceProvider.GetServices(serviceType)
+                    .Where(a => a is not null)
+                    .Select(a => a!);
+
                 if (isNull)
                 {
                     services = services
@@ -115,7 +119,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
                 services = dic?
                     .GetFactories(contract)
                     .Select(f => f())
-                    ?? Enumerable.Empty<object?>();
+                    ?? Enumerable.Empty<object>();
             }
 
             return services;
@@ -124,7 +128,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
         /// <inheritdoc />
 #pragma warning disable CS8614 // Nullability of reference types in type of parameter doesn't match implicitly implemented member.
 
-        public virtual void Register(Func<object> factory, Type serviceType, string? contract = null)
+        public virtual void Register(Func<object> factory, Type? serviceType, string? contract = null)
 #pragma warning restore CS8614 // Nullability of reference types in type of parameter doesn't match implicitly implemented member.
         {
             if (_isImmutable)

--- a/src/Splat.Ninject.Tests/NInjectDependencyResolverTests.cs
+++ b/src/Splat.Ninject.Tests/NInjectDependencyResolverTests.cs
@@ -22,16 +22,16 @@ namespace Splat.Ninject.Tests
         {
             var resolver = GetDependencyResolver();
             var foo = 5;
-            resolver.Register(() => foo, null);
+            resolver.Register(() => foo, null!);
 
-            var value = resolver.GetService(null);
+            var value = resolver.GetService(null!);
             Assert.Equal(foo, value);
 
             var bar = 4;
             var contract = "foo";
-            resolver.Register(() => bar, null, contract);
+            resolver.Register(() => bar, null!, contract);
 
-            value = resolver.GetService(null, contract);
+            value = resolver.GetService(null!, contract);
             Assert.Equal(bar, value);
         }
 

--- a/src/Splat.Ninject.Tests/NInjectDependencyResolverTests.cs
+++ b/src/Splat.Ninject.Tests/NInjectDependencyResolverTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Ninject;
 using Splat.Tests.ServiceLocation;
@@ -22,17 +23,26 @@ namespace Splat.Ninject.Tests
         {
             var resolver = GetDependencyResolver();
             var foo = 5;
-            resolver.Register(() => foo, null!);
-
-            var value = resolver.GetService(null!);
-            Assert.Equal(foo, value);
+            resolver.Register(() => foo, null);
 
             var bar = 4;
             var contract = "foo";
-            resolver.Register(() => bar, null!, contract);
+            resolver.Register(() => bar, null, contract);
 
-            value = resolver.GetService(null!, contract);
+            Assert.True(resolver.HasRegistration(null));
+            var value = resolver.GetService(null);
+            Assert.Equal(foo, value);
+
+            Assert.True(resolver.HasRegistration(null, contract));
+            value = resolver.GetService(null, contract);
             Assert.Equal(bar, value);
+
+            var values = resolver.GetServices(null);
+            Assert.Equal(1, values.Count());
+
+            resolver.UnregisterCurrent(null);
+            values = resolver.GetServices(null);
+            Assert.Equal(0, values.Count());
         }
 
         /// <inheritdoc />

--- a/src/Splat.Ninject.Tests/NInjectDependencyResolverTests.cs
+++ b/src/Splat.Ninject.Tests/NInjectDependencyResolverTests.cs
@@ -41,8 +41,18 @@ namespace Splat.Ninject.Tests
             Assert.Equal(1, values.Count());
 
             resolver.UnregisterCurrent(null);
-            values = resolver.GetServices(null);
-            Assert.Equal(0, values.Count());
+            var valuesNC = resolver.GetServices(null);
+            Assert.Equal(0, valuesNC.Count());
+            var valuesC = resolver.GetServices(null, contract);
+            Assert.Equal(1, valuesC.Count());
+
+            resolver.UnregisterAll(null);
+            valuesNC = resolver.GetServices(null);
+            Assert.Equal(0, valuesNC.Count());
+
+            resolver.UnregisterAll(null, contract);
+            valuesC = resolver.GetServices(null, contract);
+            Assert.Equal(0, valuesC.Count());
         }
 
         /// <inheritdoc />

--- a/src/Splat.Ninject.Tests/Splat.Ninject.Tests.csproj
+++ b/src/Splat.Ninject.Tests/Splat.Ninject.Tests.csproj
@@ -5,6 +5,7 @@
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Ninject/NinjectDependencyResolver.cs
+++ b/src/Splat.Ninject/NinjectDependencyResolver.cs
@@ -34,10 +34,10 @@ namespace Splat.Ninject
             GetServices(serviceType, contract).LastOrDefault()!;
 
         /// <inheritdoc />
-        public virtual IEnumerable<object?> GetServices(Type serviceType, string? contract = null)
+        public virtual IEnumerable<object> GetServices(Type? serviceType, string? contract = null)
         {
             var isNull = serviceType is null;
-            if (isNull)
+            if (serviceType is null)
             {
                 serviceType = typeof(NullServiceType);
             }
@@ -61,7 +61,7 @@ namespace Splat.Ninject
         }
 
         /// <inheritdoc />
-        public virtual void Register(Func<object?> factory, Type serviceType, string? contract = null)
+        public virtual void Register(Func<object?> factory, Type? serviceType, string? contract = null)
         {
             var isNull = serviceType is null;
 
@@ -80,7 +80,7 @@ namespace Splat.Ninject
         }
 
         /// <inheritdoc />
-        public virtual void UnregisterCurrent(Type serviceType, string? contract = null)
+        public virtual void UnregisterCurrent(Type? serviceType, string? contract = null)
         {
             var isNull = serviceType is null;
 
@@ -107,7 +107,7 @@ namespace Splat.Ninject
         }
 
         /// <inheritdoc />
-        public virtual void UnregisterAll(Type serviceType, string? contract = null)
+        public virtual void UnregisterAll(Type? serviceType, string? contract = null)
         {
             var isNull = serviceType is null;
 

--- a/src/Splat.Ninject/NinjectDependencyResolver.cs
+++ b/src/Splat.Ninject/NinjectDependencyResolver.cs
@@ -30,11 +30,11 @@ namespace Splat.Ninject
         }
 
         /// <inheritdoc />
-        public virtual object GetService(Type serviceType, string? contract = null) =>
+        public virtual object? GetService(Type serviceType, string? contract = null) =>
             GetServices(serviceType, contract).LastOrDefault()!;
 
         /// <inheritdoc />
-        public virtual IEnumerable<object> GetServices(Type serviceType, string? contract = null)
+        public virtual IEnumerable<object?> GetServices(Type serviceType, string? contract = null)
         {
             var isNull = serviceType is null;
             if (isNull)

--- a/src/Splat.Ninject/NinjectDependencyResolver.cs
+++ b/src/Splat.Ninject/NinjectDependencyResolver.cs
@@ -30,7 +30,7 @@ namespace Splat.Ninject
         }
 
         /// <inheritdoc />
-        public virtual object? GetService(Type serviceType, string? contract = null) =>
+        public virtual object? GetService(Type? serviceType, string? contract = null) =>
             GetServices(serviceType, contract).LastOrDefault()!;
 
         /// <inheritdoc />
@@ -55,8 +55,13 @@ namespace Splat.Ninject
         }
 
         /// <inheritdoc />
-        public bool HasRegistration(Type serviceType, string? contract = null)
+        public bool HasRegistration(Type? serviceType, string? contract = null)
         {
+            if (serviceType is null)
+            {
+                serviceType = typeof(NullServiceType);
+            }
+
             return _kernel.CanResolve(serviceType, metadata => IsCorrectMetadata(metadata, contract));
         }
 
@@ -165,17 +170,6 @@ namespace Splat.Ninject
         {
             return (metadata?.Name is null && string.IsNullOrWhiteSpace(contract))
                    || (metadata?.Name is not null && metadata.Name.Equals(contract, StringComparison.OrdinalIgnoreCase));
-        }
-
-        [SuppressMessage("Design", "CA1812: Uninitialized class.", Justification = "Used in reflection.")]
-        private class NullServiceType
-        {
-            public NullServiceType(Func<object?> factory)
-            {
-                Factory = factory;
-            }
-
-            public Func<object?> Factory { get; }
         }
     }
 }

--- a/src/Splat.Ninject/NinjectDependencyResolver.cs
+++ b/src/Splat.Ninject/NinjectDependencyResolver.cs
@@ -44,14 +44,17 @@ namespace Splat.Ninject
 
             if (isNull)
             {
-                return _kernel.GetAll(
-                    typeof(NullServiceType),
-                    contract);
+                try
+                {
+                    return _kernel.GetAll(typeof(NullServiceType), contract).ToArray();
+                }
+                catch
+                {
+                    return Array.Empty<object>();
+                }
             }
 
-            return _kernel.GetAll(
-                serviceType,
-                contract);
+            return _kernel.GetAll(serviceType, contract);
         }
 
         /// <inheritdoc />

--- a/src/Splat.Ninject/NinjectDependencyResolver.cs
+++ b/src/Splat.Ninject/NinjectDependencyResolver.cs
@@ -30,8 +30,8 @@ namespace Splat.Ninject
         }
 
         /// <inheritdoc />
-        public virtual object? GetService(Type serviceType, string? contract = null) =>
-            GetServices(serviceType, contract)?.LastOrDefault();
+        public virtual object GetService(Type serviceType, string? contract = null) =>
+            GetServices(serviceType, contract).LastOrDefault()!;
 
         /// <inheritdoc />
         public virtual IEnumerable<object> GetServices(Type serviceType, string? contract = null)
@@ -61,7 +61,7 @@ namespace Splat.Ninject
         }
 
         /// <inheritdoc />
-        public virtual void Register(Func<object> factory, Type serviceType, string? contract = null)
+        public virtual void Register(Func<object?> factory, Type serviceType, string? contract = null)
         {
             var isNull = serviceType is null;
 
@@ -170,12 +170,12 @@ namespace Splat.Ninject
         [SuppressMessage("Design", "CA1812: Uninitialized class.", Justification = "Used in reflection.")]
         private class NullServiceType
         {
-            public NullServiceType(Func<object> factory)
+            public NullServiceType(Func<object?> factory)
             {
                 Factory = factory;
             }
 
-            public Func<object> Factory { get; }
+            public Func<object?> Factory { get; }
         }
     }
 }

--- a/src/Splat.Prism.Tests/Splat.Prism.Tests.csproj
+++ b/src/Splat.Prism.Tests/Splat.Prism.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1707;CS1574</NoWarn>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Prism/SplatContainerExtension.cs
+++ b/src/Splat.Prism/SplatContainerExtension.cs
@@ -240,42 +240,42 @@ namespace Splat.Prism
         }
 
         /// <inheritdoc/>
-        public object? Resolve(Type type)
+        public object Resolve(Type type)
         {
             return Instance.GetService(type);
         }
 
         /// <inheritdoc/>
-        public object? Resolve(Type type, params (Type Type, object Instance)[] parameters)
+        public object Resolve(Type type, params (Type Type, object Instance)[] parameters)
         {
             if (_types.TryGetValue((type, null), out var resolvedType))
             {
                 return Activator.CreateInstance(resolvedType, parameters.Select(x => x.Instance)) ?? throw new InvalidOperationException("Could not create type");
             }
 
-            return null;
+            return null!;
         }
 
         /// <inheritdoc/>
-        public object? Resolve(Type type, string name)
+        public object Resolve(Type type, string name)
         {
             return Instance.GetService(type, name);
         }
 
         /// <inheritdoc/>
-        public object? Resolve(Type type, string name, params (Type Type, object Instance)[] parameters)
+        public object Resolve(Type type, string name, params (Type Type, object Instance)[] parameters)
         {
             if (!_types.TryGetValue((type, name), out var resolvedType))
             {
                 if (resolvedType is null)
                 {
-                    return null;
+                    return null!;
                 }
 
-                return Activator.CreateInstance(resolvedType, parameters.Select(x => x.Instance));
+                return Activator.CreateInstance(resolvedType, parameters.Select(x => x.Instance))!;
             }
 
-            return null;
+            return null!;
         }
 
         /// <summary>

--- a/src/Splat.Prism/SplatContainerExtension.cs
+++ b/src/Splat.Prism/SplatContainerExtension.cs
@@ -15,7 +15,6 @@ namespace Splat.Prism
     /// <summary>
     /// A container for the Prism application.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1316:Tuple element names should use correct casing", Justification = "Match Prism naming scheme.")]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Analyzers", "CA1065: Don't throw exceptions from properties", Justification = "Deliberate usage")]
     public class SplatContainerExtension : IContainerExtension<IDependencyResolver>, IDisposable
     {
@@ -240,42 +239,42 @@ namespace Splat.Prism
         }
 
         /// <inheritdoc/>
-        public object Resolve(Type type)
+        public object? Resolve(Type type)
         {
             return Instance.GetService(type);
         }
 
         /// <inheritdoc/>
-        public object Resolve(Type type, params (Type Type, object Instance)[] parameters)
+        public object? Resolve(Type type, params (Type Type, object Instance)[] parameters)
         {
             if (_types.TryGetValue((type, null), out var resolvedType))
             {
                 return Activator.CreateInstance(resolvedType, parameters.Select(x => x.Instance)) ?? throw new InvalidOperationException("Could not create type");
             }
 
-            return null!;
+            return default;
         }
 
         /// <inheritdoc/>
-        public object Resolve(Type type, string name)
+        public object? Resolve(Type type, string name)
         {
             return Instance.GetService(type, name);
         }
 
         /// <inheritdoc/>
-        public object Resolve(Type type, string name, params (Type Type, object Instance)[] parameters)
+        public object? Resolve(Type type, string name, params (Type Type, object Instance)[] parameters)
         {
             if (!_types.TryGetValue((type, name), out var resolvedType))
             {
                 if (resolvedType is null)
                 {
-                    return null!;
+                    return default;
                 }
 
                 return Activator.CreateInstance(resolvedType, parameters.Select(x => x.Instance))!;
             }
 
-            return null!;
+            return default;
         }
 
         /// <summary>

--- a/src/Splat.SimpleInjector.Tests/DependencyResolverTests.cs
+++ b/src/Splat.SimpleInjector.Tests/DependencyResolverTests.cs
@@ -36,6 +36,21 @@ namespace Splat.Simplnjector
         }
 
         /// <summary>
+        /// Simples the injector dependency resolver should resolve a view model.
+        /// </summary>
+        [Fact]
+        public void SimpleInjectorDependencyResolver_Should_Resolve_View_Model_Directly()
+        {
+            var container = new SimpleInjectorInitializer();
+            container.Register(() => new ViewModelOne());
+
+            var viewModel = container.GetService<ViewModelOne>();
+
+            viewModel.Should().NotBeNull();
+            viewModel.Should().BeOfType<ViewModelOne>();
+        }
+
+        /// <summary>
         /// Simples the injector dependency resolver should resolve a view.
         /// </summary>
         [Fact]

--- a/src/Splat.SimpleInjector.Tests/DependencyResolverTests.cs
+++ b/src/Splat.SimpleInjector.Tests/DependencyResolverTests.cs
@@ -94,7 +94,7 @@ namespace Splat.Simplnjector
             Locator.CurrentMutable.InitializeSplat();
             container.UseSimpleInjectorDependencyResolver(initializer);
 
-            ILogger dependency = Locator.Current.GetService(typeof(ILogger)) as ILogger;
+            var dependency = Locator.Current.GetService(typeof(ILogger)) as ILogger;
             Assert.NotNull(dependency);
         }
 

--- a/src/Splat.SimpleInjector.Tests/Splat.SimpleInjector.Tests.csproj
+++ b/src/Splat.SimpleInjector.Tests/Splat.SimpleInjector.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
+++ b/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
@@ -32,8 +32,13 @@ namespace Splat.SimpleInjector
         }
 
         /// <inheritdoc />
-        public object? GetService(Type serviceType, string? contract = null)
+        public object? GetService(Type? serviceType, string? contract = null)
         {
+            if (serviceType is null)
+            {
+                serviceType = typeof(NullServiceType);
+            }
+
             try
             {
                 InstanceProducer? registration = _container.GetRegistration(serviceType);
@@ -56,7 +61,7 @@ namespace Splat.SimpleInjector
         {
             if (serviceType is null)
             {
-                throw new ArgumentNullException(nameof(serviceType));
+                serviceType = typeof(NullServiceType);
             }
 
             try
@@ -76,26 +81,31 @@ namespace Splat.SimpleInjector
         }
 
         /// <inheritdoc />
-        public bool HasRegistration(Type serviceType, string? contract = null)
+        public bool HasRegistration(Type? serviceType, string? contract = null)
         {
+            if (serviceType is null)
+            {
+                serviceType = typeof(NullServiceType);
+            }
+
             return _container.GetCurrentRegistrations().Any(x => x.ServiceType == serviceType);
         }
 
         /// <inheritdoc />
-        public void Register(Func<object?> factory, Type serviceType, string? contract = null)
+        public void Register(Func<object?> factory, Type? serviceType, string? contract = null)
         {
             // The function does nothing because there should be no registration called on this object.
             // Anyway, Locator.SetLocator performs some unnecessary registrations.
         }
 
         /// <inheritdoc />
-        public void UnregisterCurrent(Type serviceType, string? contract = null)
+        public void UnregisterCurrent(Type? serviceType, string? contract = null)
         {
             throw new NotImplementedException();
         }
 
         /// <inheritdoc />
-        public void UnregisterAll(Type serviceType, string? contract = null)
+        public void UnregisterAll(Type? serviceType, string? contract = null)
         {
             throw new NotImplementedException();
         }

--- a/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
+++ b/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
@@ -32,7 +32,7 @@ namespace Splat.SimpleInjector
         }
 
         /// <inheritdoc />
-        public object? GetService(Type serviceType, string? contract = null)
+        public object GetService(Type serviceType, string? contract = null)
         {
             try
             {
@@ -43,11 +43,11 @@ namespace Splat.SimpleInjector
                 }
 
                 IEnumerable<object> registers = _container.GetAllInstances(serviceType);
-                return registers.LastOrDefault();
+                return registers.LastOrDefault()!;
             }
             catch
             {
-                return null;
+                return null!;
             }
         }
 
@@ -77,7 +77,7 @@ namespace Splat.SimpleInjector
         }
 
         /// <inheritdoc />
-        public void Register(Func<object> factory, Type serviceType, string? contract = null)
+        public void Register(Func<object?> factory, Type serviceType, string? contract = null)
         {
             // The function does nothing because there should be no registration called on this object.
             // Anyway, Locator.SetLocator performs some unnecessary registrations.
@@ -122,7 +122,7 @@ namespace Splat.SimpleInjector
 
         private void RegisterFactories(SimpleInjectorInitializer initializer)
         {
-            foreach (KeyValuePair<Type, List<Func<object>>> typeFactories in initializer.RegisteredFactories)
+            foreach (KeyValuePair<Type, List<Func<object?>>> typeFactories in initializer.RegisteredFactories)
             {
                 _container.Collection.Register(
                     typeFactories.Key,

--- a/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
+++ b/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
@@ -52,8 +52,13 @@ namespace Splat.SimpleInjector
         }
 
         /// <inheritdoc />
-        public IEnumerable<object?> GetServices(Type serviceType, string? contract = null)
+        public IEnumerable<object> GetServices(Type? serviceType, string? contract = null)
         {
+            if (serviceType is null)
+            {
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+
             try
             {
                 return _container.GetAllInstances(serviceType);
@@ -66,7 +71,7 @@ namespace Splat.SimpleInjector
                     return new[] { registration.GetInstance() };
                 }
 
-                return Enumerable.Empty<object?>();
+                return Enumerable.Empty<object>();
             }
         }
 

--- a/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
+++ b/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
@@ -32,7 +32,7 @@ namespace Splat.SimpleInjector
         }
 
         /// <inheritdoc />
-        public object GetService(Type serviceType, string? contract = null)
+        public object? GetService(Type serviceType, string? contract = null)
         {
             try
             {
@@ -47,12 +47,12 @@ namespace Splat.SimpleInjector
             }
             catch
             {
-                return null!;
+                return default;
             }
         }
 
         /// <inheritdoc />
-        public IEnumerable<object> GetServices(Type serviceType, string? contract = null)
+        public IEnumerable<object?> GetServices(Type serviceType, string? contract = null)
         {
             try
             {
@@ -66,7 +66,7 @@ namespace Splat.SimpleInjector
                     return new[] { registration.GetInstance() };
                 }
 
-                return Enumerable.Empty<object>();
+                return Enumerable.Empty<object?>();
             }
         }
 

--- a/src/Splat.SimpleInjector/SimpleInjectorInitializer.cs
+++ b/src/Splat.SimpleInjector/SimpleInjectorInitializer.cs
@@ -24,8 +24,13 @@ namespace Splat.SimpleInjector
             = new();
 
         /// <inheritdoc />
-        public object? GetService(Type serviceType, string? contract = null)
+        public object? GetService(Type? serviceType, string? contract = null)
         {
+            if (serviceType is null)
+            {
+                serviceType = typeof(NullServiceType);
+            }
+
             lock (_lockObject)
             {
                 Func<object?>? fact = RegisteredFactories[serviceType].LastOrDefault();
@@ -38,7 +43,7 @@ namespace Splat.SimpleInjector
         {
             if (serviceType is null)
             {
-                throw new ArgumentNullException(nameof(serviceType));
+                serviceType = typeof(NullServiceType);
             }
 
             lock (_lockObject)
@@ -49,8 +54,13 @@ namespace Splat.SimpleInjector
         }
 
         /// <inheritdoc />
-        public bool HasRegistration(Type serviceType, string? contract = null)
+        public bool HasRegistration(Type? serviceType, string? contract = null)
         {
+            if (serviceType is null)
+            {
+                serviceType = typeof(NullServiceType);
+            }
+
             lock (_lockObject)
             {
                 return RegisteredFactories.TryGetValue(serviceType, out var values)
@@ -59,8 +69,14 @@ namespace Splat.SimpleInjector
         }
 
         /// <inheritdoc />
-        public void Register(Func<object?> factory, Type serviceType, string? contract = null)
+        public void Register(Func<object?> factory, Type? serviceType, string? contract = null)
         {
+            var isNull = serviceType is null;
+            if (serviceType is null)
+            {
+                serviceType = typeof(NullServiceType);
+            }
+
             lock (_lockObject)
             {
                 if (!RegisteredFactories.ContainsKey(serviceType))
@@ -68,19 +84,27 @@ namespace Splat.SimpleInjector
                     RegisteredFactories.Add(serviceType, new List<Func<object?>>());
                 }
 
-                RegisteredFactories[serviceType].Add(factory);
+                RegisteredFactories[serviceType].Add(() =>
+                    isNull
+                        ? new NullServiceType(factory)
+                        : factory());
             }
         }
 
         /// <inheritdoc />
-        public void UnregisterCurrent(Type serviceType, string? contract = null)
+        public void UnregisterCurrent(Type? serviceType, string? contract = null)
         {
             throw new NotImplementedException();
         }
 
         /// <inheritdoc />
-        public void UnregisterAll(Type serviceType, string? contract = null)
+        public void UnregisterAll(Type? serviceType, string? contract = null)
         {
+            if (serviceType is null)
+            {
+                serviceType = typeof(NullServiceType);
+            }
+
             lock (_lockObject)
             {
                 if (RegisteredFactories.ContainsKey(serviceType))

--- a/src/Splat.SimpleInjector/SimpleInjectorInitializer.cs
+++ b/src/Splat.SimpleInjector/SimpleInjectorInitializer.cs
@@ -24,7 +24,7 @@ namespace Splat.SimpleInjector
             = new();
 
         /// <inheritdoc />
-        public object GetService(Type serviceType, string? contract = null)
+        public object? GetService(Type serviceType, string? contract = null)
         {
             lock (_lockObject)
             {
@@ -34,7 +34,7 @@ namespace Splat.SimpleInjector
         }
 
         /// <inheritdoc/>
-        public IEnumerable<object> GetServices(Type serviceType, string? contract = null)
+        public IEnumerable<object?> GetServices(Type serviceType, string? contract = null)
         {
             lock (_lockObject)
             {

--- a/src/Splat.SimpleInjector/SimpleInjectorInitializer.cs
+++ b/src/Splat.SimpleInjector/SimpleInjectorInitializer.cs
@@ -34,8 +34,13 @@ namespace Splat.SimpleInjector
         }
 
         /// <inheritdoc/>
-        public IEnumerable<object?> GetServices(Type serviceType, string? contract = null)
+        public IEnumerable<object> GetServices(Type? serviceType, string? contract = null)
         {
+            if (serviceType is null)
+            {
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+
             lock (_lockObject)
             {
                 return RegisteredFactories[serviceType]

--- a/src/Splat.SimpleInjector/SimpleInjectorInitializer.cs
+++ b/src/Splat.SimpleInjector/SimpleInjectorInitializer.cs
@@ -20,16 +20,16 @@ namespace Splat.SimpleInjector
         /// <summary>
         /// Gets dictionary of registered factories.
         /// </summary>
-        public Dictionary<Type, List<Func<object>>> RegisteredFactories { get; }
+        public Dictionary<Type, List<Func<object?>>> RegisteredFactories { get; }
             = new();
 
         /// <inheritdoc />
-        public object? GetService(Type serviceType, string? contract = null)
+        public object GetService(Type serviceType, string? contract = null)
         {
             lock (_lockObject)
             {
-                Func<object>? fact = RegisteredFactories[serviceType].LastOrDefault();
-                return fact?.Invoke();
+                Func<object?>? fact = RegisteredFactories[serviceType].LastOrDefault();
+                return fact?.Invoke()!;
             }
         }
 
@@ -39,7 +39,7 @@ namespace Splat.SimpleInjector
             lock (_lockObject)
             {
                 return RegisteredFactories[serviceType]
-                    .Select(n => n());
+                    .Select(n => n()!);
             }
         }
 
@@ -54,13 +54,13 @@ namespace Splat.SimpleInjector
         }
 
         /// <inheritdoc />
-        public void Register(Func<object> factory, Type serviceType, string? contract = null)
+        public void Register(Func<object?> factory, Type serviceType, string? contract = null)
         {
             lock (_lockObject)
             {
                 if (!RegisteredFactories.ContainsKey(serviceType))
                 {
-                    RegisteredFactories.Add(serviceType, new List<Func<object>>());
+                    RegisteredFactories.Add(serviceType, new List<Func<object?>>());
                 }
 
                 RegisteredFactories[serviceType].Add(factory);
@@ -92,12 +92,10 @@ namespace Splat.SimpleInjector
         }
 
         /// <inheritdoc />
-#pragma warning disable CA1063 // Implement IDisposable Correctly
         public void Dispose()
-#pragma warning restore CA1063 // Implement IDisposable Correctly
         {
-            GC.SuppressFinalize(this);
             Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         /// <summary>

--- a/src/Splat.SimpleInjector/TransientSimpleInjectorRegistration.cs
+++ b/src/Splat.SimpleInjector/TransientSimpleInjectorRegistration.cs
@@ -11,8 +11,8 @@ namespace Splat.SimpleInjector
 {
     internal class TransientSimpleInjectorRegistration : Registration
     {
-        public TransientSimpleInjectorRegistration(Container container, Type implementationType, Func<object>? instanceCreator = null)
-            : base(Lifestyle.Transient, container, implementationType, instanceCreator)
+        public TransientSimpleInjectorRegistration(Container container, Type implementationType, Func<object?>? instanceCreator = null)
+            : base(Lifestyle.Transient, container, implementationType, instanceCreator!)
         {
         }
 

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net5.0.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net5.0.approved.txt
@@ -161,14 +161,11 @@ namespace Splat
     {
         public static T GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
         public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
-        public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> factory, string? contract = null)
-            where T :  notnull { }
+        public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> factory, string? contract = null) { }
         public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object? value, System.Type serviceType, string? contract = null) { }
-        public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T value, string? contract = null)
-            where T :  notnull { }
+        public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T? value, string? contract = null) { }
         public static void RegisterLazySingleton(this Splat.IMutableDependencyResolver resolver, System.Func<object?> valueFactory, System.Type serviceType, string? contract = null) { }
-        public static void RegisterLazySingleton<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> valueFactory, string? contract = null)
-            where T :  notnull { }
+        public static void RegisterLazySingleton<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> valueFactory, string? contract = null) { }
         public static System.IDisposable ServiceRegistrationCallback(this Splat.IMutableDependencyResolver resolver, System.Type serviceType, System.Action<System.IDisposable> callback) { }
         public static void UnregisterAll<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null) { }
         public static void UnregisterCurrent<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net5.0.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net5.0.approved.txt
@@ -159,8 +159,8 @@ namespace Splat
     }
     public static class DependencyResolverMixins
     {
-        public static T GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
-        public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
+        public static T? GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
+        public static System.Collections.Generic.IEnumerable<T?> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
         public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> factory, string? contract = null) { }
         public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object? value, System.Type serviceType, string? contract = null) { }
         public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T? value, string? contract = null) { }
@@ -191,11 +191,11 @@ namespace Splat
     }
     public class FuncDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
-        public FuncDependencyResolver(System.Func<System.Type, string?, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object?>, System.Type, string?>? register = null, System.Action<System.Type, string?>? unregisterCurrent = null, System.Action<System.Type, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
+        public FuncDependencyResolver(System.Func<System.Type, string?, System.Collections.Generic.IEnumerable<object?>> getAllServices, System.Action<System.Func<object?>, System.Type, string?>? register = null, System.Action<System.Type, string?>? unregisterCurrent = null, System.Action<System.Type, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
-        public object GetService(System.Type serviceType, string? contract = null) { }
-        public System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string? contract = null) { }
+        public object? GetService(System.Type serviceType, string? contract = null) { }
+        public System.Collections.Generic.IEnumerable<object?> GetServices(System.Type serviceType, string? contract = null) { }
         public bool HasRegistration(System.Type serviceType, string? contract = null) { }
         public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
@@ -415,8 +415,8 @@ namespace Splat
     }
     public interface IReadonlyDependencyResolver
     {
-        object GetService(System.Type serviceType, string? contract = null);
-        System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string? contract = null);
+        object? GetService(System.Type serviceType, string? contract = null);
+        System.Collections.Generic.IEnumerable<object?> GetServices(System.Type serviceType, string? contract = null);
     }
     public interface IStaticFullLogger
     {
@@ -516,12 +516,12 @@ namespace Splat
         public ModernDependencyResolver() { }
         protected ModernDependencyResolver([System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "serviceType",
-                "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object?>>>? registry) { }
+                "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string?>, System.Collections.Generic.List<System.Func<object?>>>? registry) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
         public Splat.ModernDependencyResolver Duplicate() { }
-        public object GetService(System.Type serviceType, string? contract = null) { }
-        public System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string? contract = null) { }
+        public object? GetService(System.Type serviceType, string? contract = null) { }
+        public System.Collections.Generic.IEnumerable<object?> GetServices(System.Type serviceType, string? contract = null) { }
         public bool HasRegistration(System.Type serviceType, string? contract = null) { }
         public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net5.0.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net5.0.approved.txt
@@ -161,16 +161,13 @@ namespace Splat
     {
         public static T? GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
         public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
-        public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> factory, string? contract = null)
-            where T :  notnull { }
+        public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> factory, string? contract = null) { }
         public static void Register<TAs, T>(this Splat.IMutableDependencyResolver resolver, string? contract = null)
             where T : new() { }
-        public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object value, System.Type serviceType, string? contract = null) { }
-        public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T value, string? contract = null)
-            where T :  notnull { }
-        public static void RegisterLazySingleton(this Splat.IMutableDependencyResolver resolver, System.Func<object> valueFactory, System.Type serviceType, string? contract = null) { }
-        public static void RegisterLazySingleton<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> valueFactory, string? contract = null)
-            where T :  notnull { }
+        public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object? value, System.Type? serviceType, string? contract = null) { }
+        public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T? value, string? contract = null) { }
+        public static void RegisterLazySingleton(this Splat.IMutableDependencyResolver resolver, System.Func<object?> valueFactory, System.Type? serviceType, string? contract = null) { }
+        public static void RegisterLazySingleton<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> valueFactory, string? contract = null) { }
         public static System.IDisposable ServiceRegistrationCallback(this Splat.IMutableDependencyResolver resolver, System.Type serviceType, System.Action<System.IDisposable> callback) { }
         public static void UnregisterAll<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null) { }
         public static void UnregisterCurrent<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null) { }
@@ -196,16 +193,16 @@ namespace Splat
     }
     public class FuncDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
-        public FuncDependencyResolver(System.Func<System.Type, string?, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object?>, System.Type, string?>? register = null, System.Action<System.Type, string?>? unregisterCurrent = null, System.Action<System.Type, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
+        public FuncDependencyResolver(System.Func<System.Type?, string?, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object?>, System.Type?, string?>? register = null, System.Action<System.Type?, string?>? unregisterCurrent = null, System.Action<System.Type?, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
-        public object? GetService(System.Type serviceType, string? contract = null) { }
+        public object? GetService(System.Type? serviceType, string? contract = null) { }
         public System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null) { }
-        public bool HasRegistration(System.Type serviceType, string? contract = null) { }
-        public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
+        public bool HasRegistration(System.Type? serviceType, string? contract = null) { }
+        public void Register(System.Func<object?> factory, System.Type? serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
-        public void UnregisterAll(System.Type serviceType, string? contract = null) { }
-        public void UnregisterCurrent(System.Type serviceType, string? contract = null) { }
+        public void UnregisterAll(System.Type? serviceType, string? contract = null) { }
+        public void UnregisterCurrent(System.Type? serviceType, string? contract = null) { }
     }
     public class FuncLogManager : Splat.ILogManager
     {
@@ -412,15 +409,15 @@ namespace Splat
     }
     public interface IMutableDependencyResolver
     {
-        bool HasRegistration(System.Type serviceType, string? contract = null);
-        void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null);
+        bool HasRegistration(System.Type? serviceType, string? contract = null);
+        void Register(System.Func<object?> factory, System.Type? serviceType, string? contract = null);
         System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback);
-        void UnregisterAll(System.Type serviceType, string? contract = null);
-        void UnregisterCurrent(System.Type serviceType, string? contract = null);
+        void UnregisterAll(System.Type? serviceType, string? contract = null);
+        void UnregisterCurrent(System.Type? serviceType, string? contract = null);
     }
     public interface IReadonlyDependencyResolver
     {
-        object? GetService(System.Type serviceType, string? contract = null);
+        object? GetService(System.Type? serviceType, string? contract = null);
         System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null);
     }
     public interface IStaticFullLogger
@@ -519,19 +516,19 @@ namespace Splat
     public class ModernDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
         public ModernDependencyResolver() { }
-        protected ModernDependencyResolver([System.Runtime.CompilerServices.TupleElementNames(new string[] {
+        protected ModernDependencyResolver([System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "serviceType",
                 "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string?>, System.Collections.Generic.List<System.Func<object?>>>? registry) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
         public Splat.ModernDependencyResolver Duplicate() { }
-        public object? GetService(System.Type serviceType, string? contract = null) { }
+        public object? GetService(System.Type? serviceType, string? contract = null) { }
         public System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null) { }
-        public bool HasRegistration(System.Type serviceType, string? contract = null) { }
-        public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
+        public bool HasRegistration(System.Type? serviceType, string? contract = null) { }
+        public void Register(System.Func<object?> factory, System.Type? serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
-        public void UnregisterAll(System.Type serviceType, string? contract = null) { }
-        public void UnregisterCurrent(System.Type serviceType, string? contract = null) { }
+        public void UnregisterAll(System.Type? serviceType, string? contract = null) { }
+        public void UnregisterCurrent(System.Type? serviceType, string? contract = null) { }
     }
     public class NullLogger : Splat.ILogger
     {
@@ -541,6 +538,11 @@ namespace Splat
         public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
         public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
         public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public class NullServiceType
+    {
+        public NullServiceType(System.Func<object?> factory) { }
+        public System.Func<object?> Factory { get; }
     }
     public static class PointMathExtensions
     {

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net5.0.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net5.0.approved.txt
@@ -191,11 +191,11 @@ namespace Splat
     }
     public class FuncDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
-        public FuncDependencyResolver(System.Func<System.Type, string?, System.Collections.Generic.IEnumerable<object?>> getAllServices, System.Action<System.Func<object?>, System.Type, string?>? register = null, System.Action<System.Type, string?>? unregisterCurrent = null, System.Action<System.Type, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
+        public FuncDependencyResolver(System.Func<System.Type, string?, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object?>, System.Type, string?>? register = null, System.Action<System.Type, string?>? unregisterCurrent = null, System.Action<System.Type, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
         public object? GetService(System.Type serviceType, string? contract = null) { }
-        public System.Collections.Generic.IEnumerable<object?> GetServices(System.Type serviceType, string? contract = null) { }
+        public System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null) { }
         public bool HasRegistration(System.Type serviceType, string? contract = null) { }
         public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
@@ -416,7 +416,7 @@ namespace Splat
     public interface IReadonlyDependencyResolver
     {
         object? GetService(System.Type serviceType, string? contract = null);
-        System.Collections.Generic.IEnumerable<object?> GetServices(System.Type serviceType, string? contract = null);
+        System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null);
     }
     public interface IStaticFullLogger
     {
@@ -521,7 +521,7 @@ namespace Splat
         protected virtual void Dispose(bool isDisposing) { }
         public Splat.ModernDependencyResolver Duplicate() { }
         public object? GetService(System.Type serviceType, string? contract = null) { }
-        public System.Collections.Generic.IEnumerable<object?> GetServices(System.Type serviceType, string? contract = null) { }
+        public System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null) { }
         public bool HasRegistration(System.Type serviceType, string? contract = null) { }
         public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net5.0.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net5.0.approved.txt
@@ -159,15 +159,15 @@ namespace Splat
     }
     public static class DependencyResolverMixins
     {
-        public static T? GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
+        public static T GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
         public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
-        public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> factory, string? contract = null)
+        public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> factory, string? contract = null)
             where T :  notnull { }
-        public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object value, System.Type serviceType, string? contract = null) { }
+        public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object? value, System.Type serviceType, string? contract = null) { }
         public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T value, string? contract = null)
             where T :  notnull { }
-        public static void RegisterLazySingleton(this Splat.IMutableDependencyResolver resolver, System.Func<object> valueFactory, System.Type serviceType, string? contract = null) { }
-        public static void RegisterLazySingleton<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> valueFactory, string? contract = null)
+        public static void RegisterLazySingleton(this Splat.IMutableDependencyResolver resolver, System.Func<object?> valueFactory, System.Type serviceType, string? contract = null) { }
+        public static void RegisterLazySingleton<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> valueFactory, string? contract = null)
             where T :  notnull { }
         public static System.IDisposable ServiceRegistrationCallback(this Splat.IMutableDependencyResolver resolver, System.Type serviceType, System.Action<System.IDisposable> callback) { }
         public static void UnregisterAll<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null) { }
@@ -194,13 +194,13 @@ namespace Splat
     }
     public class FuncDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
-        public FuncDependencyResolver(System.Func<System.Type, string?, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object>, System.Type, string?>? register = null, System.Action<System.Type, string?>? unregisterCurrent = null, System.Action<System.Type, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
+        public FuncDependencyResolver(System.Func<System.Type, string?, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object?>, System.Type, string?>? register = null, System.Action<System.Type, string?>? unregisterCurrent = null, System.Action<System.Type, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
-        public object? GetService(System.Type serviceType, string? contract = null) { }
+        public object GetService(System.Type serviceType, string? contract = null) { }
         public System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string? contract = null) { }
         public bool HasRegistration(System.Type serviceType, string? contract = null) { }
-        public void Register(System.Func<object> factory, System.Type serviceType, string? contract = null) { }
+        public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
         public void UnregisterAll(System.Type serviceType, string? contract = null) { }
         public void UnregisterCurrent(System.Type serviceType, string? contract = null) { }
@@ -411,14 +411,14 @@ namespace Splat
     public interface IMutableDependencyResolver
     {
         bool HasRegistration(System.Type serviceType, string? contract = null);
-        void Register(System.Func<object> factory, System.Type serviceType, string? contract = null);
+        void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null);
         System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback);
         void UnregisterAll(System.Type serviceType, string? contract = null);
         void UnregisterCurrent(System.Type serviceType, string? contract = null);
     }
     public interface IReadonlyDependencyResolver
     {
-        object? GetService(System.Type serviceType, string? contract = null);
+        object GetService(System.Type serviceType, string? contract = null);
         System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string? contract = null);
     }
     public interface IStaticFullLogger
@@ -519,14 +519,14 @@ namespace Splat
         public ModernDependencyResolver() { }
         protected ModernDependencyResolver([System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "serviceType",
-                "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>>? registry) { }
+                "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object?>>>? registry) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
         public Splat.ModernDependencyResolver Duplicate() { }
-        public object? GetService(System.Type serviceType, string? contract = null) { }
+        public object GetService(System.Type serviceType, string? contract = null) { }
         public System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string? contract = null) { }
         public bool HasRegistration(System.Type serviceType, string? contract = null) { }
-        public void Register(System.Func<object> factory, System.Type serviceType, string? contract = null) { }
+        public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
         public void UnregisterAll(System.Type serviceType, string? contract = null) { }
         public void UnregisterCurrent(System.Type serviceType, string? contract = null) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.1.approved.txt
@@ -161,14 +161,11 @@ namespace Splat
     {
         public static T GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
         public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
-        public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> factory, string? contract = null)
-            where T :  notnull { }
+        public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> factory, string? contract = null) { }
         public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object? value, System.Type serviceType, string? contract = null) { }
-        public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T value, string? contract = null)
-            where T :  notnull { }
+        public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T? value, string? contract = null) { }
         public static void RegisterLazySingleton(this Splat.IMutableDependencyResolver resolver, System.Func<object?> valueFactory, System.Type serviceType, string? contract = null) { }
-        public static void RegisterLazySingleton<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> valueFactory, string? contract = null)
-            where T :  notnull { }
+        public static void RegisterLazySingleton<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> valueFactory, string? contract = null) { }
         public static System.IDisposable ServiceRegistrationCallback(this Splat.IMutableDependencyResolver resolver, System.Type serviceType, System.Action<System.IDisposable> callback) { }
         public static void UnregisterAll<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null) { }
         public static void UnregisterCurrent<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.1.approved.txt
@@ -159,8 +159,8 @@ namespace Splat
     }
     public static class DependencyResolverMixins
     {
-        public static T GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
-        public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
+        public static T? GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
+        public static System.Collections.Generic.IEnumerable<T?> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
         public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> factory, string? contract = null) { }
         public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object? value, System.Type serviceType, string? contract = null) { }
         public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T? value, string? contract = null) { }
@@ -191,11 +191,11 @@ namespace Splat
     }
     public class FuncDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
-        public FuncDependencyResolver(System.Func<System.Type, string?, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object?>, System.Type, string?>? register = null, System.Action<System.Type, string?>? unregisterCurrent = null, System.Action<System.Type, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
+        public FuncDependencyResolver(System.Func<System.Type, string?, System.Collections.Generic.IEnumerable<object?>> getAllServices, System.Action<System.Func<object?>, System.Type, string?>? register = null, System.Action<System.Type, string?>? unregisterCurrent = null, System.Action<System.Type, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
-        public object GetService(System.Type serviceType, string? contract = null) { }
-        public System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string? contract = null) { }
+        public object? GetService(System.Type serviceType, string? contract = null) { }
+        public System.Collections.Generic.IEnumerable<object?> GetServices(System.Type serviceType, string? contract = null) { }
         public bool HasRegistration(System.Type serviceType, string? contract = null) { }
         public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
@@ -415,8 +415,8 @@ namespace Splat
     }
     public interface IReadonlyDependencyResolver
     {
-        object GetService(System.Type serviceType, string? contract = null);
-        System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string? contract = null);
+        object? GetService(System.Type serviceType, string? contract = null);
+        System.Collections.Generic.IEnumerable<object?> GetServices(System.Type serviceType, string? contract = null);
     }
     public interface IStaticFullLogger
     {
@@ -516,12 +516,12 @@ namespace Splat
         public ModernDependencyResolver() { }
         protected ModernDependencyResolver([System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "serviceType",
-                "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object?>>>? registry) { }
+                "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string?>, System.Collections.Generic.List<System.Func<object?>>>? registry) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
         public Splat.ModernDependencyResolver Duplicate() { }
-        public object GetService(System.Type serviceType, string? contract = null) { }
-        public System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string? contract = null) { }
+        public object? GetService(System.Type serviceType, string? contract = null) { }
+        public System.Collections.Generic.IEnumerable<object?> GetServices(System.Type serviceType, string? contract = null) { }
         public bool HasRegistration(System.Type serviceType, string? contract = null) { }
         public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.1.approved.txt
@@ -161,16 +161,13 @@ namespace Splat
     {
         public static T? GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
         public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
-        public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> factory, string? contract = null)
-            where T :  notnull { }
+        public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> factory, string? contract = null) { }
         public static void Register<TAs, T>(this Splat.IMutableDependencyResolver resolver, string? contract = null)
             where T : new() { }
-        public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object value, System.Type serviceType, string? contract = null) { }
-        public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T value, string? contract = null)
-            where T :  notnull { }
-        public static void RegisterLazySingleton(this Splat.IMutableDependencyResolver resolver, System.Func<object> valueFactory, System.Type serviceType, string? contract = null) { }
-        public static void RegisterLazySingleton<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> valueFactory, string? contract = null)
-            where T :  notnull { }
+        public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object? value, System.Type? serviceType, string? contract = null) { }
+        public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T? value, string? contract = null) { }
+        public static void RegisterLazySingleton(this Splat.IMutableDependencyResolver resolver, System.Func<object?> valueFactory, System.Type? serviceType, string? contract = null) { }
+        public static void RegisterLazySingleton<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> valueFactory, string? contract = null) { }
         public static System.IDisposable ServiceRegistrationCallback(this Splat.IMutableDependencyResolver resolver, System.Type serviceType, System.Action<System.IDisposable> callback) { }
         public static void UnregisterAll<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null) { }
         public static void UnregisterCurrent<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null) { }
@@ -196,16 +193,16 @@ namespace Splat
     }
     public class FuncDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
-        public FuncDependencyResolver(System.Func<System.Type, string?, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object?>, System.Type, string?>? register = null, System.Action<System.Type, string?>? unregisterCurrent = null, System.Action<System.Type, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
+        public FuncDependencyResolver(System.Func<System.Type?, string?, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object?>, System.Type?, string?>? register = null, System.Action<System.Type?, string?>? unregisterCurrent = null, System.Action<System.Type?, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
-        public object? GetService(System.Type serviceType, string? contract = null) { }
+        public object? GetService(System.Type? serviceType, string? contract = null) { }
         public System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null) { }
-        public bool HasRegistration(System.Type serviceType, string? contract = null) { }
-        public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
+        public bool HasRegistration(System.Type? serviceType, string? contract = null) { }
+        public void Register(System.Func<object?> factory, System.Type? serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
-        public void UnregisterAll(System.Type serviceType, string? contract = null) { }
-        public void UnregisterCurrent(System.Type serviceType, string? contract = null) { }
+        public void UnregisterAll(System.Type? serviceType, string? contract = null) { }
+        public void UnregisterCurrent(System.Type? serviceType, string? contract = null) { }
     }
     public class FuncLogManager : Splat.ILogManager
     {
@@ -412,15 +409,15 @@ namespace Splat
     }
     public interface IMutableDependencyResolver
     {
-        bool HasRegistration(System.Type serviceType, string? contract = null);
-        void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null);
+        bool HasRegistration(System.Type? serviceType, string? contract = null);
+        void Register(System.Func<object?> factory, System.Type? serviceType, string? contract = null);
         System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback);
-        void UnregisterAll(System.Type serviceType, string? contract = null);
-        void UnregisterCurrent(System.Type serviceType, string? contract = null);
+        void UnregisterAll(System.Type? serviceType, string? contract = null);
+        void UnregisterCurrent(System.Type? serviceType, string? contract = null);
     }
     public interface IReadonlyDependencyResolver
     {
-        object? GetService(System.Type serviceType, string? contract = null);
+        object? GetService(System.Type? serviceType, string? contract = null);
         System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null);
     }
     public interface IStaticFullLogger
@@ -519,19 +516,19 @@ namespace Splat
     public class ModernDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
         public ModernDependencyResolver() { }
-        protected ModernDependencyResolver([System.Runtime.CompilerServices.TupleElementNames(new string[] {
+        protected ModernDependencyResolver([System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
                 "serviceType",
                 "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string?>, System.Collections.Generic.List<System.Func<object?>>>? registry) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
         public Splat.ModernDependencyResolver Duplicate() { }
-        public object? GetService(System.Type serviceType, string? contract = null) { }
+        public object? GetService(System.Type? serviceType, string? contract = null) { }
         public System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null) { }
-        public bool HasRegistration(System.Type serviceType, string? contract = null) { }
-        public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
+        public bool HasRegistration(System.Type? serviceType, string? contract = null) { }
+        public void Register(System.Func<object?> factory, System.Type? serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
-        public void UnregisterAll(System.Type serviceType, string? contract = null) { }
-        public void UnregisterCurrent(System.Type serviceType, string? contract = null) { }
+        public void UnregisterAll(System.Type? serviceType, string? contract = null) { }
+        public void UnregisterCurrent(System.Type? serviceType, string? contract = null) { }
     }
     public class NullLogger : Splat.ILogger
     {
@@ -541,6 +538,11 @@ namespace Splat
         public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
         public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
         public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public class NullServiceType
+    {
+        public NullServiceType(System.Func<object?> factory) { }
+        public System.Func<object?> Factory { get; }
     }
     public static class PointMathExtensions
     {

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.1.approved.txt
@@ -191,11 +191,11 @@ namespace Splat
     }
     public class FuncDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
-        public FuncDependencyResolver(System.Func<System.Type, string?, System.Collections.Generic.IEnumerable<object?>> getAllServices, System.Action<System.Func<object?>, System.Type, string?>? register = null, System.Action<System.Type, string?>? unregisterCurrent = null, System.Action<System.Type, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
+        public FuncDependencyResolver(System.Func<System.Type, string?, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object?>, System.Type, string?>? register = null, System.Action<System.Type, string?>? unregisterCurrent = null, System.Action<System.Type, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
         public object? GetService(System.Type serviceType, string? contract = null) { }
-        public System.Collections.Generic.IEnumerable<object?> GetServices(System.Type serviceType, string? contract = null) { }
+        public System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null) { }
         public bool HasRegistration(System.Type serviceType, string? contract = null) { }
         public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
@@ -416,7 +416,7 @@ namespace Splat
     public interface IReadonlyDependencyResolver
     {
         object? GetService(System.Type serviceType, string? contract = null);
-        System.Collections.Generic.IEnumerable<object?> GetServices(System.Type serviceType, string? contract = null);
+        System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null);
     }
     public interface IStaticFullLogger
     {
@@ -521,7 +521,7 @@ namespace Splat
         protected virtual void Dispose(bool isDisposing) { }
         public Splat.ModernDependencyResolver Duplicate() { }
         public object? GetService(System.Type serviceType, string? contract = null) { }
-        public System.Collections.Generic.IEnumerable<object?> GetServices(System.Type serviceType, string? contract = null) { }
+        public System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null) { }
         public bool HasRegistration(System.Type serviceType, string? contract = null) { }
         public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.1.approved.txt
@@ -159,15 +159,15 @@ namespace Splat
     }
     public static class DependencyResolverMixins
     {
-        public static T? GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
+        public static T GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
         public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
-        public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> factory, string? contract = null)
+        public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> factory, string? contract = null)
             where T :  notnull { }
-        public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object value, System.Type serviceType, string? contract = null) { }
+        public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object? value, System.Type serviceType, string? contract = null) { }
         public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T value, string? contract = null)
             where T :  notnull { }
-        public static void RegisterLazySingleton(this Splat.IMutableDependencyResolver resolver, System.Func<object> valueFactory, System.Type serviceType, string? contract = null) { }
-        public static void RegisterLazySingleton<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> valueFactory, string? contract = null)
+        public static void RegisterLazySingleton(this Splat.IMutableDependencyResolver resolver, System.Func<object?> valueFactory, System.Type serviceType, string? contract = null) { }
+        public static void RegisterLazySingleton<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> valueFactory, string? contract = null)
             where T :  notnull { }
         public static System.IDisposable ServiceRegistrationCallback(this Splat.IMutableDependencyResolver resolver, System.Type serviceType, System.Action<System.IDisposable> callback) { }
         public static void UnregisterAll<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null) { }
@@ -194,13 +194,13 @@ namespace Splat
     }
     public class FuncDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
     {
-        public FuncDependencyResolver(System.Func<System.Type, string?, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object>, System.Type, string?>? register = null, System.Action<System.Type, string?>? unregisterCurrent = null, System.Action<System.Type, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
+        public FuncDependencyResolver(System.Func<System.Type, string?, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object?>, System.Type, string?>? register = null, System.Action<System.Type, string?>? unregisterCurrent = null, System.Action<System.Type, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
-        public object? GetService(System.Type serviceType, string? contract = null) { }
+        public object GetService(System.Type serviceType, string? contract = null) { }
         public System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string? contract = null) { }
         public bool HasRegistration(System.Type serviceType, string? contract = null) { }
-        public void Register(System.Func<object> factory, System.Type serviceType, string? contract = null) { }
+        public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
         public void UnregisterAll(System.Type serviceType, string? contract = null) { }
         public void UnregisterCurrent(System.Type serviceType, string? contract = null) { }
@@ -411,14 +411,14 @@ namespace Splat
     public interface IMutableDependencyResolver
     {
         bool HasRegistration(System.Type serviceType, string? contract = null);
-        void Register(System.Func<object> factory, System.Type serviceType, string? contract = null);
+        void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null);
         System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback);
         void UnregisterAll(System.Type serviceType, string? contract = null);
         void UnregisterCurrent(System.Type serviceType, string? contract = null);
     }
     public interface IReadonlyDependencyResolver
     {
-        object? GetService(System.Type serviceType, string? contract = null);
+        object GetService(System.Type serviceType, string? contract = null);
         System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string? contract = null);
     }
     public interface IStaticFullLogger
@@ -519,14 +519,14 @@ namespace Splat
         public ModernDependencyResolver() { }
         protected ModernDependencyResolver([System.Runtime.CompilerServices.TupleElementNames(new string[] {
                 "serviceType",
-                "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object>>>? registry) { }
+                "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string>, System.Collections.Generic.List<System.Func<object?>>>? registry) { }
         public void Dispose() { }
         protected virtual void Dispose(bool isDisposing) { }
         public Splat.ModernDependencyResolver Duplicate() { }
-        public object? GetService(System.Type serviceType, string? contract = null) { }
+        public object GetService(System.Type serviceType, string? contract = null) { }
         public System.Collections.Generic.IEnumerable<object> GetServices(System.Type serviceType, string? contract = null) { }
         public bool HasRegistration(System.Type serviceType, string? contract = null) { }
-        public void Register(System.Func<object> factory, System.Type serviceType, string? contract = null) { }
+        public void Register(System.Func<object?> factory, System.Type serviceType, string? contract = null) { }
         public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
         public void UnregisterAll(System.Type serviceType, string? contract = null) { }
         public void UnregisterCurrent(System.Type serviceType, string? contract = null) { }

--- a/src/Splat.Tests/ApiExtensions.cs
+++ b/src/Splat.Tests/ApiExtensions.cs
@@ -34,14 +34,14 @@ namespace Splat.Tests
         /// <param name="assembly">The assembly that is being checked.</param>
         /// <param name="memberName">The caller member.</param>
         /// <param name="filePath">The caller file path.</param>
-        public static void CheckApproval(this Assembly assembly, [CallerMemberName] string memberName = null, [CallerFilePath] string filePath = null)
+        public static void CheckApproval(this Assembly assembly, [CallerMemberName] string? memberName = null, [CallerFilePath] string? filePath = null)
         {
             var targetFrameworkName = Assembly.GetExecutingAssembly().GetTargetFrameworkName();
 
             var sourceDirectory = Path.GetDirectoryName(filePath);
 
-            var approvedFileName = Path.Combine(sourceDirectory, $"ApiApprovalTests.{memberName}.{targetFrameworkName}.approved.txt");
-            var receivedFileName = Path.Combine(sourceDirectory, $"ApiApprovalTests.{memberName}.{targetFrameworkName}.received.txt");
+            var approvedFileName = Path.Combine(sourceDirectory!, $"ApiApprovalTests.{memberName}.{targetFrameworkName}.approved.txt");
+            var receivedFileName = Path.Combine(sourceDirectory!, $"ApiApprovalTests.{memberName}.{targetFrameworkName}.received.txt");
 
             string approvedPublicApi = string.Empty;
 

--- a/src/Splat.Tests/ApplicationPerformanceMonitoring/BaseFeatureUsageTrackingTests.cs
+++ b/src/Splat.Tests/ApplicationPerformanceMonitoring/BaseFeatureUsageTrackingTests.cs
@@ -71,9 +71,9 @@ namespace Splat.Tests.ApplicationPerformanceMonitoring
 
                 var genericSubfeature = subfeature as IFeatureUsageTrackingSession<Guid>;
                 Assert.NotNull(genericSubfeature);
-                Assert.Equal(subfeatureName, genericSubfeature.FeatureName);
-                Assert.NotEqual(Guid.Empty, genericSubfeature.FeatureReference);
-                Assert.Equal(instance.FeatureReference, genericSubfeature.ParentReference);
+                Assert.Equal(subfeatureName, genericSubfeature?.FeatureName);
+                Assert.NotEqual(Guid.Empty, genericSubfeature?.FeatureReference);
+                Assert.Equal(instance.FeatureReference, genericSubfeature?.ParentReference);
             }
 
             /// <summary>

--- a/src/Splat.Tests/LocatorSerialRegisterTests.cs
+++ b/src/Splat.Tests/LocatorSerialRegisterTests.cs
@@ -311,8 +311,8 @@ namespace Splat.Tests
         public void FuncDependencyResolver_UnregisterAll()
         {
             bool unregisterAllCalled = false;
-            Type type = null;
-            string contract = null;
+            Type? type = null;
+            string? contract = null;
 
             var currentMutable = new FuncDependencyResolver(
                 (funcType, funcContract) => Array.Empty<object>(),
@@ -343,8 +343,8 @@ namespace Splat.Tests
         public void FuncDependencyResolver_UnregisterCurrent()
         {
             bool unregisterAllCalled = false;
-            Type type = null;
-            string contract = null;
+            Type? type = null;
+            string? contract = null;
 
             var currentMutable = new FuncDependencyResolver(
                 (funcType, funcContract) => Array.Empty<object>(),

--- a/src/Splat.Tests/LocatorTests.cs
+++ b/src/Splat.Tests/LocatorTests.cs
@@ -4,7 +4,7 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-
+using System.Linq;
 using FluentAssertions;
 
 using Splat.Tests.Mocks;
@@ -32,11 +32,20 @@ namespace Splat.Tests
             var contract = "foo";
             container.CurrentMutable.Register(() => bar, null!, contract);
 
+            Assert.True(container.CurrentMutable.HasRegistration(null));
             var value = container.Current.GetService(null!);
             Assert.Equal(foo, value);
 
+            Assert.True(container.CurrentMutable.HasRegistration(null, contract));
             value = container.Current.GetService(null!, contract);
             Assert.Equal(bar, value);
+
+            var values = container.Current.GetServices(null);
+            Assert.Equal(1, values.Count());
+
+            container.CurrentMutable.UnregisterCurrent(null);
+            values = container.Current.GetServices(null);
+            Assert.Equal(0, values.Count());
         }
 
         /// <summary>

--- a/src/Splat.Tests/LocatorTests.cs
+++ b/src/Splat.Tests/LocatorTests.cs
@@ -50,6 +50,20 @@ namespace Splat.Tests
         }
 
         /// <summary>
+        /// Tests that if we use a contract it returns null entries for that type.
+        /// </summary>
+        [Fact]
+        public void InitializeSplat_ContractRegistrationsExtensionMethodsNullNoRegistration()
+        {
+            var testLocator = new InternalLocator();
+            var logManager = testLocator.Current.GetService<ILogManager>("test");
+            var logger = testLocator.Current.GetService<ILogger>("test");
+
+            Assert.Null(logManager);
+            Assert.Null(logger);
+        }
+
+        /// <summary>
         /// Tests using the extension methods that the retrieving of the default InitializeSplat() still work.
         /// </summary>
         [Fact]
@@ -195,6 +209,64 @@ namespace Splat.Tests
 
                 items.Should().BeEmpty();
             }
+        }
+
+        /// <summary>
+        /// Nullables the type.
+        /// </summary>
+        [Fact]
+        public void RegisterAndResolveANullableTypeWithValue()
+        {
+            Locator.CurrentMutable.Register<DummyObjectClass1?>(() => new());
+            var doc = Locator.Current.GetService<DummyObjectClass1?>();
+            doc.Should().BeOfType<DummyObjectClass1>();
+        }
+
+        /// <summary>
+        /// Nullables the type.
+        /// </summary>
+        [Fact]
+        public void RegisterAndResolveANullableTypeWithNull()
+        {
+            Locator.CurrentMutable.Register<DummyObjectClass1?>(() => null);
+            var doc = Locator.Current.GetService<DummyObjectClass1?>();
+            doc.Should().BeNull();
+        }
+
+        /// <summary>
+        /// Nullables the type.
+        /// </summary>
+        [Fact]
+        public void RegisterAndResolveANullableTypeWithValueLocatorDisposed()
+        {
+            var currentMutable = new ModernDependencyResolver();
+            currentMutable.Register<DummyObjectClass1?>(() => new());
+            currentMutable.Dispose();
+            var doc = currentMutable.GetService<DummyObjectClass1?>();
+            doc.Should().BeNull();
+        }
+
+        /// <summary>
+        /// Nullables the type.
+        /// </summary>
+        [Fact]
+        public void RegisterAndResolveANullableTypeWithDefault()
+        {
+            Locator.CurrentMutable.Register<DummyObjectClass1?>(() => default);
+            var doc = Locator.Current.GetService<DummyObjectClass1?>();
+            doc.Should().BeNull();
+        }
+
+        /// <summary>
+        /// Nullables the type.
+        /// </summary>
+        [Fact]
+        public void RegisterAndResolveANullableTypeWithNulledInstance()
+        {
+            DummyObjectClass1? dummy = null;
+            Locator.CurrentMutable.Register<DummyObjectClass1?>(() => dummy);
+            var doc = Locator.Current.GetService<DummyObjectClass1?>();
+            doc.Should().BeNull();
         }
 
         /// <summary>

--- a/src/Splat.Tests/LocatorTests.cs
+++ b/src/Splat.Tests/LocatorTests.cs
@@ -280,15 +280,15 @@ namespace Splat.Tests
         public void FuncDependencyResolver_UnregisterAll()
         {
             bool unregisterAllCalled = false;
-            Type type = null;
-            string contract = null;
+            Type? type = null;
+            string? contract = null;
 
             var currentMutable = new FuncDependencyResolver(
                 (funcType, funcContract) => Array.Empty<object>(),
                 unregisterAll: (passedType, passedContract) =>
                 {
                     unregisterAllCalled = true;
-                    contract = passedContract;
+                    contract = passedContract!;
                     type = passedType;
                 });
 
@@ -312,15 +312,15 @@ namespace Splat.Tests
         public void FuncDependencyResolver_UnregisterCurrent()
         {
             bool unregisterAllCalled = false;
-            Type type = null;
-            string contract = null;
+            Type? type = null;
+            string? contract = null;
 
             var currentMutable = new FuncDependencyResolver(
                 (funcType, funcContract) => Array.Empty<object>(),
                 unregisterCurrent: (passedType, passedContract) =>
                 {
                     unregisterAllCalled = true;
-                    contract = passedContract;
+                    contract = passedContract!;
                     type = passedType;
                 });
 

--- a/src/Splat.Tests/LocatorTests.cs
+++ b/src/Splat.Tests/LocatorTests.cs
@@ -18,6 +18,28 @@ namespace Splat.Tests
     public class LocatorTests
     {
         /// <summary>
+        /// Shoulds the resolve nulls.
+        /// </summary>
+        [Fact]
+        public void Can_Register_And_Resolve_Null_Types()
+        {
+            var container = new InternalLocator();
+
+            var foo = 5;
+            container.CurrentMutable.Register(() => foo, null!);
+
+            var bar = 4;
+            var contract = "foo";
+            container.CurrentMutable.Register(() => bar, null!, contract);
+
+            var value = container.Current.GetService(null!);
+            Assert.Equal(foo, value);
+
+            value = container.Current.GetService(null!, contract);
+            Assert.Equal(bar, value);
+        }
+
+        /// <summary>
         /// Tests if the registrations are not empty on no external registrations.
         /// </summary>
         [Fact]

--- a/src/Splat.Tests/LocatorTests.cs
+++ b/src/Splat.Tests/LocatorTests.cs
@@ -44,8 +44,18 @@ namespace Splat.Tests
             Assert.Equal(1, values.Count());
 
             container.CurrentMutable.UnregisterCurrent(null);
-            values = container.Current.GetServices(null);
-            Assert.Equal(0, values.Count());
+            var valuesNC = container.Current.GetServices(null);
+            Assert.Equal(0, valuesNC.Count());
+            var valuesC = container.Current.GetServices(null, contract);
+            Assert.Equal(1, valuesC.Count());
+
+            container.CurrentMutable.UnregisterAll(null);
+            valuesNC = container.Current.GetServices(null);
+            Assert.Equal(0, valuesNC.Count());
+
+            container.CurrentMutable.UnregisterAll(null, contract);
+            valuesC = container.Current.GetServices(null, contract);
+            Assert.Equal(0, valuesC.Count());
         }
 
         /// <summary>

--- a/src/Splat.Tests/Logging/ActionLoggerTests.cs
+++ b/src/Splat.Tests/Logging/ActionLoggerTests.cs
@@ -20,7 +20,7 @@ namespace Splat.Tests.Logging
         [Fact]
         public void Write_Should_Emit_Message()
         {
-            string passedMessage = null;
+            string? passedMessage = null;
             LogLevel? passedLevel = null;
 
             var logger = new ActionLogger(
@@ -29,9 +29,9 @@ namespace Splat.Tests.Logging
                     passedMessage = message;
                     passedLevel = level;
                 },
-                null,
-                null,
-                null);
+                null!,
+                null!,
+                null!);
 
             var fullLogger = new WrappingFullLogger(logger);
 
@@ -47,20 +47,20 @@ namespace Splat.Tests.Logging
         [Fact]
         public void Debug_With_Generic_Type_Should_Emit_Message_And_Type()
         {
-            string passedMessage = null;
+            string? passedMessage = null;
             LogLevel? passedLevel = null;
-            Type passedType = null;
+            Type? passedType = null;
 
             var logger = new ActionLogger(
-                null,
+                null!,
                 (message, type, level) =>
                 {
                     passedMessage = message;
                     passedType = type;
                     passedLevel = level;
                 },
-                null,
-                null);
+                null!,
+                null!);
 
             var fullLogger = new WrappingFullLogger(logger);
 
@@ -77,20 +77,20 @@ namespace Splat.Tests.Logging
         [Fact]
         public void Debug_With_Generic_Type_Should_Emit_Message_And_Type_Provided()
         {
-            string passedMessage = null;
+            string? passedMessage = null;
             LogLevel? passedLevel = null;
-            Type passedType = null;
+            Type? passedType = null;
 
             var logger = new ActionLogger(
-                null,
+                null!,
                 (message, type, level) =>
                 {
                     passedMessage = message;
                     passedType = type;
                     passedLevel = level;
                 },
-                null,
-                null);
+                null!,
+                null!);
 
             var fullLogger = new WrappingFullLogger(logger);
 
@@ -107,20 +107,20 @@ namespace Splat.Tests.Logging
         [Fact]
         public void Info_With_Generic_Type_Should_Emit_Message_And_Type()
         {
-            string passedMessage = null;
+            string? passedMessage = null;
             LogLevel? passedLevel = null;
-            Type passedType = null;
+            Type? passedType = null;
 
             var logger = new ActionLogger(
-                null,
+                null!,
                 (message, type, level) =>
                 {
                     passedMessage = message;
                     passedType = type;
                     passedLevel = level;
                 },
-                null,
-                null);
+                null!,
+                null!);
 
             var fullLogger = new WrappingFullLogger(logger);
 
@@ -137,20 +137,20 @@ namespace Splat.Tests.Logging
         [Fact]
         public void Info_With_Generic_Type_Should_Emit_Message_And_Type_Provided()
         {
-            string passedMessage = null;
+            string? passedMessage = null;
             LogLevel? passedLevel = null;
-            Type passedType = null;
+            Type? passedType = null;
 
             var logger = new ActionLogger(
-                null,
+                null!,
                 (message, type, level) =>
                 {
                     passedMessage = message;
                     passedType = type;
                     passedLevel = level;
                 },
-                null,
-                null);
+                null!,
+                null!);
 
             var fullLogger = new WrappingFullLogger(logger);
 
@@ -167,20 +167,20 @@ namespace Splat.Tests.Logging
         [Fact]
         public void Warn_With_Generic_Type_Should_Emit_Message_And_Type()
         {
-            string passedMessage = null;
+            string? passedMessage = null;
             LogLevel? passedLevel = null;
-            Type passedType = null;
+            Type? passedType = null;
 
             var logger = new ActionLogger(
-                null,
+                null!,
                 (message, type, level) =>
                 {
                     passedMessage = message;
                     passedType = type;
                     passedLevel = level;
                 },
-                null,
-                null);
+                null!,
+                null!);
 
             var fullLogger = new WrappingFullLogger(logger);
 
@@ -197,20 +197,20 @@ namespace Splat.Tests.Logging
         [Fact]
         public void Warn_With_Generic_Type_Should_Emit_Message_And_Type_Provided()
         {
-            string passedMessage = null;
+            string? passedMessage = null;
             LogLevel? passedLevel = null;
-            Type passedType = null;
+            Type? passedType = null;
 
             var logger = new ActionLogger(
-                null,
+                null!,
                 (message, type, level) =>
                 {
                     passedMessage = message;
                     passedType = type;
                     passedLevel = level;
                 },
-                null,
-                null);
+                null!,
+                null!);
 
             var fullLogger = new WrappingFullLogger(logger);
 
@@ -227,20 +227,20 @@ namespace Splat.Tests.Logging
         [Fact]
         public void Error_With_Generic_Type_Should_Emit_Message_And_Type()
         {
-            string passedMessage = null;
+            string? passedMessage = null;
             LogLevel? passedLevel = null;
-            Type passedType = null;
+            Type? passedType = null;
 
             var logger = new ActionLogger(
-                null,
+                null!,
                 (message, type, level) =>
                 {
                     passedMessage = message;
                     passedType = type;
                     passedLevel = level;
                 },
-                null,
-                null);
+                null!,
+                null!);
 
             var fullLogger = new WrappingFullLogger(logger);
 
@@ -257,20 +257,20 @@ namespace Splat.Tests.Logging
         [Fact]
         public void Error_With_Generic_Type_Should_Emit_Message_And_Type_Provided()
         {
-            string passedMessage = null;
+            string? passedMessage = null;
             LogLevel? passedLevel = null;
-            Type passedType = null;
+            Type? passedType = null;
 
             var logger = new ActionLogger(
-                null,
+                null!,
                 (message, type, level) =>
                 {
                     passedMessage = message;
                     passedType = type;
                     passedLevel = level;
                 },
-                null,
-                null);
+                null!,
+                null!);
 
             var fullLogger = new WrappingFullLogger(logger);
 
@@ -287,20 +287,20 @@ namespace Splat.Tests.Logging
         [Fact]
         public void Fatal_With_Generic_Type_Should_Emit_Message_And_Type()
         {
-            string passedMessage = null;
+            string? passedMessage = null;
             LogLevel? passedLevel = null;
-            Type passedType = null;
+            Type? passedType = null;
 
             var logger = new ActionLogger(
-                null,
+                null!,
                 (message, type, level) =>
                 {
                     passedMessage = message;
                     passedType = type;
                     passedLevel = level;
                 },
-                null,
-                null);
+                null!,
+                null!);
 
             var fullLogger = new WrappingFullLogger(logger);
 
@@ -317,20 +317,20 @@ namespace Splat.Tests.Logging
         [Fact]
         public void Fatal_With_Generic_Type_Should_Emit_Message_And_Type_Provided()
         {
-            string passedMessage = null;
+            string? passedMessage = null;
             LogLevel? passedLevel = null;
-            Type passedType = null;
+            Type? passedType = null;
 
             var logger = new ActionLogger(
-                null,
+                null!,
                 (message, type, level) =>
                 {
                     passedMessage = message;
                     passedType = type;
                     passedLevel = level;
                 },
-                null,
-                null);
+                null!,
+                null!);
 
             var fullLogger = new WrappingFullLogger(logger);
 

--- a/src/Splat.Tests/Logging/FullLoggers/SerilogLoggerTests.cs
+++ b/src/Splat.Tests/Logging/FullLoggers/SerilogLoggerTests.cs
@@ -30,25 +30,25 @@ namespace Splat.Tests.Logging
         /// Gets a list of mappings of Serilog levels and equivalent Splat log levels.
         /// </summary>
         private static readonly Dictionary<LogLevel, LogEventLevel> _mappingsToSerilog = new()
-            {
-                { LogLevel.Debug, LogEventLevel.Debug },
-                { LogLevel.Info, LogEventLevel.Information },
-                { LogLevel.Warn, LogEventLevel.Warning },
-                { LogLevel.Error, LogEventLevel.Error },
-                { LogLevel.Fatal, LogEventLevel.Fatal }
-            };
+        {
+            { LogLevel.Debug, LogEventLevel.Debug },
+            { LogLevel.Info, LogEventLevel.Information },
+            { LogLevel.Warn, LogEventLevel.Warning },
+            { LogLevel.Error, LogEventLevel.Error },
+            { LogLevel.Fatal, LogEventLevel.Fatal }
+        };
 
         /// <summary>
         /// Gets a list of mappings of Serilog levels and equivalent Splat log levels.
         /// </summary>
         private static readonly Dictionary<LogEventLevel, LogLevel> _mappingsToSplat = new()
-            {
-                { LogEventLevel.Debug, LogLevel.Debug },
-                { LogEventLevel.Information, LogLevel.Info },
-                { LogEventLevel.Warning, LogLevel.Warn },
-                { LogEventLevel.Error, LogLevel.Error },
-                { LogEventLevel.Fatal, LogLevel.Fatal }
-            };
+        {
+            { LogEventLevel.Debug, LogLevel.Debug },
+            { LogEventLevel.Information, LogLevel.Info },
+            { LogEventLevel.Warning, LogLevel.Warn },
+            { LogEventLevel.Error, LogLevel.Error },
+            { LogEventLevel.Fatal, LogLevel.Fatal }
+        };
 
         /// <summary>
         /// Test to make sure the calling `UseSerilogWithWrappingFullLogger` logs.
@@ -67,11 +67,11 @@ namespace Splat.Tests.Logging
 
                 Assert.Equal(0, target.Logs.Count);
 
-                IEnableLogger logger = null;
+                IEnableLogger logger = null!;
                 logger.Log().Debug<DummyObjectClass2>("This is a test.");
 
                 Assert.Equal(1, target.Logs.Count);
-                Assert.Equal("This is a test.", target.Logs.Last().message.Trim(NewLine).Trim());
+                Assert.Equal("This is a test.", target.Logs.Last().message!.Trim(NewLine).Trim());
             }
             finally
             {
@@ -94,12 +94,12 @@ namespace Splat.Tests.Logging
 
                 Assert.Equal(0, target.Logs.Count);
 
-                IEnableLogger logger = null;
+                IEnableLogger logger = null!;
 
                 logger.Log().Debug<DummyObjectClass2>("This is a test.");
 
                 Assert.Equal(1, target.Logs.Count);
-                Assert.Equal("This is a test.", target.Logs.Last().message.Trim(NewLine).Trim());
+                Assert.Equal("This is a test.", target.Logs.Last().message!.Trim(NewLine).Trim());
             }
             finally
             {

--- a/src/Splat.Tests/Logging/WrappingFullLoggers/ConsoleLoggerTests.cs
+++ b/src/Splat.Tests/Logging/WrappingFullLoggers/ConsoleLoggerTests.cs
@@ -35,9 +35,9 @@ namespace Splat.Tests.Logging
 
             public ICollection<(LogLevel logLevel, string message)> Logs => _logs;
 
-            public override void WriteLine(string value)
+            public override void WriteLine(string? value)
             {
-                var colonIndex = value.IndexOf(":", StringComparison.InvariantCulture);
+                var colonIndex = value!.IndexOf(":", StringComparison.InvariantCulture);
                 var level = (LogLevel)Enum.Parse(typeof(LogLevel), value.Substring(0, colonIndex));
                 var message = value.Substring(colonIndex + 1).Trim();
                 _logs.Add((level, message));

--- a/src/Splat.Tests/Logging/WrappingFullLoggers/ExceptionlessLoggerTests.cs
+++ b/src/Splat.Tests/Logging/WrappingFullLoggers/ExceptionlessLoggerTests.cs
@@ -25,19 +25,19 @@ namespace Splat.Tests.Logging.WrappingFullLoggers
         private static readonly Dictionary<global::Exceptionless.Logging.LogLevel, LogLevel> _exceptionless2Splat = new()
         {
             { global::Exceptionless.Logging.LogLevel.Debug, LogLevel.Debug },
-            { global::Exceptionless.Logging.LogLevel.Info,  LogLevel.Info },
-            { global::Exceptionless.Logging.LogLevel.Warn,  LogLevel.Warn },
+            { global::Exceptionless.Logging.LogLevel.Info, LogLevel.Info },
+            { global::Exceptionless.Logging.LogLevel.Warn, LogLevel.Warn },
             { global::Exceptionless.Logging.LogLevel.Error, LogLevel.Error },
             { global::Exceptionless.Logging.LogLevel.Fatal, LogLevel.Fatal },
         };
 
         private static readonly Dictionary<LogLevel, global::Exceptionless.Logging.LogLevel> _splat2Exceptionless = new()
         {
-            { LogLevel.Debug,  global::Exceptionless.Logging.LogLevel.Debug },
-            { LogLevel.Info,   global::Exceptionless.Logging.LogLevel.Info },
-            { LogLevel.Warn,   global::Exceptionless.Logging.LogLevel.Warn },
-            { LogLevel.Error,  global::Exceptionless.Logging.LogLevel.Error },
-            { LogLevel.Fatal,  global::Exceptionless.Logging.LogLevel.Fatal },
+            { LogLevel.Debug, global::Exceptionless.Logging.LogLevel.Debug },
+            { LogLevel.Info, global::Exceptionless.Logging.LogLevel.Info },
+            { LogLevel.Warn, global::Exceptionless.Logging.LogLevel.Warn },
+            { LogLevel.Error, global::Exceptionless.Logging.LogLevel.Error },
+            { LogLevel.Fatal, global::Exceptionless.Logging.LogLevel.Fatal },
         };
 
         /// <inheritdoc/>
@@ -71,7 +71,7 @@ namespace Splat.Tests.Logging.WrappingFullLoggers
 
             var level = obj.Event.Data.GetValueOrDefault(Event.KnownDataKeys.Level) as string;
 
-            var logLevel = global::Exceptionless.Logging.LogLevel.FromString(level);
+            var logLevel = global::Exceptionless.Logging.LogLevel.FromString(level!);
 
             var splatLogLevel = GetSplatLogLevel(logLevel);
             var exception = obj.ContextData.HasException() ? obj.ContextData.GetException() : null;

--- a/src/Splat.Tests/Logging/WrappingFullLoggers/Log4NetLoggerTests.cs
+++ b/src/Splat.Tests/Logging/WrappingFullLoggers/Log4NetLoggerTests.cs
@@ -27,19 +27,19 @@ namespace Splat.Tests.Logging
         private static readonly Dictionary<Level, LogLevel> _log4Net2Splat = new()
         {
             { Level.Debug, LogLevel.Debug },
-            { Level.Info,  LogLevel.Info },
-            { Level.Warn,  LogLevel.Warn },
+            { Level.Info, LogLevel.Info },
+            { Level.Warn, LogLevel.Warn },
             { Level.Error, LogLevel.Error },
             { Level.Fatal, LogLevel.Fatal },
         };
 
         private static readonly Dictionary<LogLevel, Level> _splat2log4net = new()
         {
-            { LogLevel.Debug,  Level.Debug },
-            { LogLevel.Info,   Level.Info },
-            { LogLevel.Warn,   Level.Warn },
-            { LogLevel.Error,  Level.Error },
-            { LogLevel.Fatal,  Level.Fatal },
+            { LogLevel.Debug, Level.Debug },
+            { LogLevel.Info, Level.Info },
+            { LogLevel.Warn, Level.Warn },
+            { LogLevel.Error, Level.Error },
+            { LogLevel.Fatal, Level.Fatal },
         };
 
         /// <inheritdoc/>
@@ -106,7 +106,7 @@ namespace Splat.Tests.Logging
                             return (currentLevel, $"{x.MessageObject} {x.ExceptionObject}");
                         }
 
-                        return (currentLevel, x.MessageObject.ToString());
+                        return (currentLevel, x.MessageObject.ToString()!);
                     }).ToList();
                 }
             }

--- a/src/Splat.Tests/MemoizingMRUCacheTests.cs
+++ b/src/Splat.Tests/MemoizingMRUCacheTests.cs
@@ -22,7 +22,7 @@ namespace Splat.Tests
         public void ThrowsArgumentNullException()
         {
             var instance = GetTestInstance();
-            Assert.Throws<ArgumentNullException>(() => instance.Get(null));
+            Assert.Throws<ArgumentNullException>(() => instance.Get(null!));
         }
 
         /// <summary>

--- a/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
+++ b/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
@@ -161,9 +161,12 @@ namespace Splat.Tests.ServiceLocation
 
                 // Get the ILogManager instance
                 var lm = Locator.Current.GetService<ILogManager>();
+                Assert.NotNull(lm);
 
                 // now suceeds for AutoFac, Ninject and Splat
+#pragma warning disable CS8604 // Possible null reference argument.
                 var mgr = lm.GetLogger<NLogLogger>();
+#pragma warning restore CS8604 // Possible null reference argument.
                 Assert.NotNull(mgr);
             }
         }

--- a/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
+++ b/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
@@ -151,12 +151,21 @@ namespace Splat.Tests.ServiceLocation
         {
             var resolver = GetDependencyResolver();
 
-            // Setup NLog for Logging (doesn't matter if I actually configure NLog or not)
-            resolver.UseNLogWithWrappingFullLogger();
+            // NOTE:MicrosoftDependencyResolver test for this funtionality is in DependencyResolverTests
+            if (resolver.GetType().Name != "MicrosoftDependencyResolver")
+            {
+                // Setup NLog for Logging (doesn't matter if I actually configure NLog or not)
+                resolver.UseNLogWithWrappingFullLogger();
+                Locator.SetLocator(resolver);
+                Locator.CurrentMutable.InitializeSplat();
 
-            // Get the ILogManager instance (this should succeed, but fails in current code)
-            ILogManager lm = Locator.Current.GetService<ILogManager>();
-            Assert.NotNull(lm);
+                // Get the ILogManager instance
+                var lm = Locator.Current.GetService<ILogManager>();
+
+                // now suceeds for AutoFac, Ninject and Splat
+                var mgr = lm.GetLogger<NLogLogger>();
+                Assert.NotNull(mgr);
+            }
         }
 
         /// <summary>

--- a/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
+++ b/src/Splat.Tests/ServiceLocation/BaseDependencyResolverTests.cs
@@ -178,9 +178,10 @@ namespace Splat.Tests.ServiceLocation
         [Fact]
         public void NullResolverTests()
         {
-            IReadonlyDependencyResolver resolver = default;
-            IMutableDependencyResolver resolver1 = default;
-            IDependencyResolver resolver2 = default;
+            IReadonlyDependencyResolver? resolver = default;
+            IMutableDependencyResolver? resolver1 = default;
+            IDependencyResolver? resolver2 = default;
+#pragma warning disable CS8604 // Possible null reference argument.
             Assert.Throws<ArgumentNullException>(() => resolver.GetService<ILogManager>());
             Assert.Throws<ArgumentNullException>(() => resolver.GetServices<ILogManager>());
             Assert.Throws<ArgumentNullException>(() => resolver1.ServiceRegistrationCallback(typeof(ILogManager), (IDisposable d) => { d.Dispose(); }));
@@ -201,6 +202,7 @@ namespace Splat.Tests.ServiceLocation
             Assert.Throws<ArgumentNullException>(() => resolver1.RegisterConstantAnd(new ViewModelOne()));
             Assert.Throws<ArgumentNullException>(() => resolver1.RegisterConstantAnd(new ViewModelOne(), typeof(ViewModelOne)));
             Assert.Throws<ArgumentNullException>(() => resolver1.RegisterConstantAnd<ViewModelOne>());
+#pragma warning restore CS8604 // Possible null reference argument.
         }
 
         /// <summary>
@@ -210,7 +212,7 @@ namespace Splat.Tests.ServiceLocation
         public void RegisterAndTests()
         {
             var resolver = GetDependencyResolver();
-            Assert.Throws<ArgumentNullException>(() => resolver.RegisterAnd<IViewModelOne>(null));
+            Assert.Throws<ArgumentNullException>(() => resolver.RegisterAnd<IViewModelOne>(default!));
             resolver.RegisterAnd<ViewModelOne>("one")
                     .RegisterAnd<IViewModelOne, ViewModelOne>("two")
                     .RegisterAnd(() => new DefaultLogManager(), "three")

--- a/src/Splat.Tests/Splat.Tests.csproj
+++ b/src/Splat.Tests/Splat.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000;CA1034</NoWarn>
     <LangVersion>latest</LangVersion>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Tests/Splat.Tests.csproj
+++ b/src/Splat.Tests/Splat.Tests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Splat.ApplicationInsights\Splat.ApplicationInsights.csproj" />
+    <ProjectReference Include="..\Splat.Common.Test\Splat.Common.Test.csproj" />
     <ProjectReference Include="..\Splat.Exceptionless\Splat.Exceptionless.csproj" />
     <ProjectReference Include="..\Splat.AppCenter\Splat.AppCenter.csproj" />
     <ProjectReference Include="..\Splat.Log4Net\Splat.Log4Net.csproj" />

--- a/src/Splat.Tests/XUnitHelpers.cs
+++ b/src/Splat.Tests/XUnitHelpers.cs
@@ -25,7 +25,7 @@ namespace Splat.Tests
             var results = new List<object[]>(values.Length);
             foreach (var value in values)
             {
-                results.Add(new[] { value });
+                results.Add(new[] { value! });
             }
 
             return results;

--- a/src/Splat/ServiceLocation/DependencyResolverMixins.cs
+++ b/src/Splat/ServiceLocation/DependencyResolverMixins.cs
@@ -100,7 +100,6 @@ namespace Splat
         /// <param name="factory">A factory method for generating a object of the specified type.</param>
         /// <param name="contract">A optional contract value which will indicates to only generate the value if this contract is specified.</param>
         public static void Register<T>(this IMutableDependencyResolver resolver, Func<T?> factory, string? contract = null)
-            where T : notnull
         {
             if (resolver is null)
             {
@@ -139,8 +138,7 @@ namespace Splat
         /// <param name="resolver">The resolver to register the service type with.</param>
         /// <param name="value">The specified instance to always return.</param>
         /// <param name="contract">A optional contract value which will indicates to only return the value if this contract is specified.</param>
-        public static void RegisterConstant<T>(this IMutableDependencyResolver resolver, T value, string? contract = null)
-            where T : notnull
+        public static void RegisterConstant<T>(this IMutableDependencyResolver resolver, T? value, string? contract = null)
         {
             if (resolver is null)
             {
@@ -178,7 +176,6 @@ namespace Splat
         /// <param name="valueFactory">A factory method for generating a object of the specified type.</param>
         /// <param name="contract">A optional contract value which will indicates to only return the value if this contract is specified.</param>
         public static void RegisterLazySingleton<T>(this IMutableDependencyResolver resolver, Func<T?> valueFactory, string? contract = null)
-            where T : notnull
         {
             RegisterLazySingleton(resolver, () => valueFactory(), typeof(T), contract);
         }

--- a/src/Splat/ServiceLocation/DependencyResolverMixins.cs
+++ b/src/Splat/ServiceLocation/DependencyResolverMixins.cs
@@ -24,14 +24,14 @@ namespace Splat
         /// <param name="resolver">The resolver we are getting the service from.</param>
         /// <param name="contract">A optional value which will retrieve only a object registered with the same contract.</param>
         /// <returns>The requested object, if found; <c>null</c> otherwise.</returns>
-        public static T? GetService<T>(this IReadonlyDependencyResolver resolver, string? contract = null)
+        public static T GetService<T>(this IReadonlyDependencyResolver resolver, string? contract = null)
         {
             if (resolver is null)
             {
                 throw new ArgumentNullException(nameof(resolver));
             }
 
-            return (T?)resolver.GetService(typeof(T), contract);
+            return (T)resolver.GetService(typeof(T), contract);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace Splat
         /// <param name="resolver">The resolver to register the service type with.</param>
         /// <param name="factory">A factory method for generating a object of the specified type.</param>
         /// <param name="contract">A optional contract value which will indicates to only generate the value if this contract is specified.</param>
-        public static void Register<T>(this IMutableDependencyResolver resolver, Func<T> factory, string? contract = null)
+        public static void Register<T>(this IMutableDependencyResolver resolver, Func<T?> factory, string? contract = null)
             where T : notnull
         {
             if (resolver is null)
@@ -122,7 +122,7 @@ namespace Splat
         /// <param name="value">The specified instance to always return.</param>
         /// <param name="serviceType">The type of service to register.</param>
         /// <param name="contract">A optional contract value which will indicates to only return the value if this contract is specified.</param>
-        public static void RegisterConstant(this IMutableDependencyResolver resolver, object value, Type serviceType, string? contract = null)
+        public static void RegisterConstant(this IMutableDependencyResolver resolver, object? value, Type serviceType, string? contract = null)
         {
             if (resolver is null)
             {
@@ -158,14 +158,14 @@ namespace Splat
         /// <param name="valueFactory">A factory method for generating a object of the specified type.</param>
         /// <param name="serviceType">The type of service to register.</param>
         /// <param name="contract">A optional contract value which will indicates to only return the value if this contract is specified.</param>
-        public static void RegisterLazySingleton(this IMutableDependencyResolver resolver, Func<object> valueFactory, Type serviceType, string? contract = null)
+        public static void RegisterLazySingleton(this IMutableDependencyResolver resolver, Func<object?> valueFactory, Type serviceType, string? contract = null)
         {
             if (resolver is null)
             {
                 throw new ArgumentNullException(nameof(resolver));
             }
 
-            var val = new Lazy<object>(valueFactory, LazyThreadSafetyMode.ExecutionAndPublication);
+            var val = new Lazy<object?>(valueFactory, LazyThreadSafetyMode.ExecutionAndPublication);
             resolver.Register(() => val.Value, serviceType, contract);
         }
 
@@ -177,7 +177,7 @@ namespace Splat
         /// <param name="resolver">The resolver to register the service type with.</param>
         /// <param name="valueFactory">A factory method for generating a object of the specified type.</param>
         /// <param name="contract">A optional contract value which will indicates to only return the value if this contract is specified.</param>
-        public static void RegisterLazySingleton<T>(this IMutableDependencyResolver resolver, Func<T> valueFactory, string? contract = null)
+        public static void RegisterLazySingleton<T>(this IMutableDependencyResolver resolver, Func<T?> valueFactory, string? contract = null)
             where T : notnull
         {
             RegisterLazySingleton(resolver, () => valueFactory(), typeof(T), contract);

--- a/src/Splat/ServiceLocation/DependencyResolverMixins.cs
+++ b/src/Splat/ServiceLocation/DependencyResolverMixins.cs
@@ -43,14 +43,14 @@ namespace Splat
         /// <param name="contract">A optional value which will retrieve only a object registered with the same contract.</param>
         /// <returns>A sequence of instances of the requested <typeparamref name="T"/>. The sequence
         /// should be empty (not <c>null</c>) if no objects of the given type are available.</returns>
-        public static IEnumerable<T?> GetServices<T>(this IReadonlyDependencyResolver resolver, string? contract = null)
+        public static IEnumerable<T> GetServices<T>(this IReadonlyDependencyResolver resolver, string? contract = null)
         {
             if (resolver is null)
             {
                 throw new ArgumentNullException(nameof(resolver));
             }
 
-            return resolver.GetServices(typeof(T), contract).Cast<T?>();
+            return resolver.GetServices(typeof(T), contract).Cast<T>();
         }
 
         /// <summary>
@@ -139,7 +139,7 @@ namespace Splat
         /// <param name="value">The specified instance to always return.</param>
         /// <param name="serviceType">The type of service to register.</param>
         /// <param name="contract">A optional contract value which will indicates to only return the value if this contract is specified.</param>
-        public static void RegisterConstant(this IMutableDependencyResolver resolver, object? value, Type serviceType, string? contract = null)
+        public static void RegisterConstant(this IMutableDependencyResolver resolver, object? value, Type? serviceType, string? contract = null)
         {
             if (resolver is null)
             {
@@ -174,7 +174,7 @@ namespace Splat
         /// <param name="valueFactory">A factory method for generating a object of the specified type.</param>
         /// <param name="serviceType">The type of service to register.</param>
         /// <param name="contract">A optional contract value which will indicates to only return the value if this contract is specified.</param>
-        public static void RegisterLazySingleton(this IMutableDependencyResolver resolver, Func<object?> valueFactory, Type serviceType, string? contract = null)
+        public static void RegisterLazySingleton(this IMutableDependencyResolver resolver, Func<object?> valueFactory, Type? serviceType, string? contract = null)
         {
             if (resolver is null)
             {

--- a/src/Splat/ServiceLocation/DependencyResolverMixins.cs
+++ b/src/Splat/ServiceLocation/DependencyResolverMixins.cs
@@ -24,14 +24,14 @@ namespace Splat
         /// <param name="resolver">The resolver we are getting the service from.</param>
         /// <param name="contract">A optional value which will retrieve only a object registered with the same contract.</param>
         /// <returns>The requested object, if found; <c>null</c> otherwise.</returns>
-        public static T GetService<T>(this IReadonlyDependencyResolver resolver, string? contract = null)
+        public static T? GetService<T>(this IReadonlyDependencyResolver resolver, string? contract = null)
         {
             if (resolver is null)
             {
                 throw new ArgumentNullException(nameof(resolver));
             }
 
-            return (T)resolver.GetService(typeof(T), contract);
+            return (T?)resolver.GetService(typeof(T), contract);
         }
 
         /// <summary>
@@ -43,14 +43,14 @@ namespace Splat
         /// <param name="contract">A optional value which will retrieve only a object registered with the same contract.</param>
         /// <returns>A sequence of instances of the requested <typeparamref name="T"/>. The sequence
         /// should be empty (not <c>null</c>) if no objects of the given type are available.</returns>
-        public static IEnumerable<T> GetServices<T>(this IReadonlyDependencyResolver resolver, string? contract = null)
+        public static IEnumerable<T?> GetServices<T>(this IReadonlyDependencyResolver resolver, string? contract = null)
         {
             if (resolver is null)
             {
                 throw new ArgumentNullException(nameof(resolver));
             }
 
-            return resolver.GetServices(typeof(T), contract).Cast<T>();
+            return resolver.GetServices(typeof(T), contract).Cast<T?>();
         }
 
         /// <summary>

--- a/src/Splat/ServiceLocation/FuncDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/FuncDependencyResolver.cs
@@ -17,7 +17,7 @@ namespace Splat
     /// </summary>
     public class FuncDependencyResolver : IDependencyResolver
     {
-        private readonly Func<Type, string?, IEnumerable<object?>> _innerGetServices;
+        private readonly Func<Type, string?, IEnumerable<object>> _innerGetServices;
         private readonly Action<Func<object?>, Type, string?>? _innerRegister;
         private readonly Action<Type, string?>? _unregisterCurrent;
         private readonly Action<Type, string?>? _unregisterAll;
@@ -35,7 +35,7 @@ namespace Splat
         /// <param name="unregisterAll">A func which will unregister all the registered elements for a service type and contract.</param>
         /// <param name="toDispose">A optional disposable which is called when this resolver is disposed.</param>
         public FuncDependencyResolver(
-            Func<Type, string?, IEnumerable<object?>> getAllServices,
+            Func<Type, string?, IEnumerable<object>> getAllServices,
             Action<Func<object?>, Type, string?>? register = null,
             Action<Type, string?>? unregisterCurrent = null,
             Action<Type, string?>? unregisterAll = null,
@@ -51,12 +51,17 @@ namespace Splat
         /// <inheritdoc />
         public object? GetService(Type serviceType, string? contract = null)
         {
-            return (GetServices(serviceType, contract) ?? Enumerable.Empty<object?>()).LastOrDefault()!;
+            return GetServices(serviceType, contract)?.LastOrDefault();
         }
 
         /// <inheritdoc />
-        public IEnumerable<object?> GetServices(Type serviceType, string? contract = null)
+        public IEnumerable<object> GetServices(Type? serviceType, string? contract = null)
         {
+            if (serviceType is null)
+            {
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+
             return _innerGetServices(serviceType, contract);
         }
 

--- a/src/Splat/ServiceLocation/FuncDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/FuncDependencyResolver.cs
@@ -17,7 +17,7 @@ namespace Splat
     /// </summary>
     public class FuncDependencyResolver : IDependencyResolver
     {
-        private readonly Func<Type, string?, IEnumerable<object>> _innerGetServices;
+        private readonly Func<Type, string?, IEnumerable<object?>> _innerGetServices;
         private readonly Action<Func<object?>, Type, string?>? _innerRegister;
         private readonly Action<Type, string?>? _unregisterCurrent;
         private readonly Action<Type, string?>? _unregisterAll;
@@ -35,7 +35,7 @@ namespace Splat
         /// <param name="unregisterAll">A func which will unregister all the registered elements for a service type and contract.</param>
         /// <param name="toDispose">A optional disposable which is called when this resolver is disposed.</param>
         public FuncDependencyResolver(
-            Func<Type, string?, IEnumerable<object>> getAllServices,
+            Func<Type, string?, IEnumerable<object?>> getAllServices,
             Action<Func<object?>, Type, string?>? register = null,
             Action<Type, string?>? unregisterCurrent = null,
             Action<Type, string?>? unregisterAll = null,
@@ -49,13 +49,13 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public object GetService(Type serviceType, string? contract = null)
+        public object? GetService(Type serviceType, string? contract = null)
         {
-            return (GetServices(serviceType, contract) ?? Enumerable.Empty<object>()).LastOrDefault()!;
+            return (GetServices(serviceType, contract) ?? Enumerable.Empty<object?>()).LastOrDefault()!;
         }
 
         /// <inheritdoc />
-        public IEnumerable<object> GetServices(Type serviceType, string? contract = null)
+        public IEnumerable<object?> GetServices(Type serviceType, string? contract = null)
         {
             return _innerGetServices(serviceType, contract);
         }
@@ -90,12 +90,7 @@ namespace Splat
 
                     if (disp.IsDisposed)
                     {
-                        if (toRemove is null)
-                        {
-                            toRemove = new List<Action<IDisposable>>();
-                        }
-
-                        toRemove.Add(callback);
+                        (toRemove ??= new List<Action<IDisposable>>()).Add(callback);
                     }
                 }
 

--- a/src/Splat/ServiceLocation/FuncDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/FuncDependencyResolver.cs
@@ -18,7 +18,7 @@ namespace Splat
     public class FuncDependencyResolver : IDependencyResolver
     {
         private readonly Func<Type, string?, IEnumerable<object>> _innerGetServices;
-        private readonly Action<Func<object>, Type, string?>? _innerRegister;
+        private readonly Action<Func<object?>, Type, string?>? _innerRegister;
         private readonly Action<Type, string?>? _unregisterCurrent;
         private readonly Action<Type, string?>? _unregisterAll;
         private readonly Dictionary<(Type type, string callback), List<Action<IDisposable>>> _callbackRegistry = new();
@@ -36,7 +36,7 @@ namespace Splat
         /// <param name="toDispose">A optional disposable which is called when this resolver is disposed.</param>
         public FuncDependencyResolver(
             Func<Type, string?, IEnumerable<object>> getAllServices,
-            Action<Func<object>, Type, string?>? register = null,
+            Action<Func<object?>, Type, string?>? register = null,
             Action<Type, string?>? unregisterCurrent = null,
             Action<Type, string?>? unregisterAll = null,
             IDisposable? toDispose = null)
@@ -49,9 +49,9 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public object? GetService(Type serviceType, string? contract = null)
+        public object GetService(Type serviceType, string? contract = null)
         {
-            return (GetServices(serviceType, contract) ?? Enumerable.Empty<object>()).LastOrDefault();
+            return (GetServices(serviceType, contract) ?? Enumerable.Empty<object>()).LastOrDefault()!;
         }
 
         /// <inheritdoc />
@@ -67,7 +67,7 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public void Register(Func<object> factory, Type serviceType, string? contract = null)
+        public void Register(Func<object?> factory, Type serviceType, string? contract = null)
         {
             if (_innerRegister is null)
             {

--- a/src/Splat/ServiceLocation/FuncDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/FuncDependencyResolver.cs
@@ -17,11 +17,11 @@ namespace Splat
     /// </summary>
     public class FuncDependencyResolver : IDependencyResolver
     {
-        private readonly Func<Type, string?, IEnumerable<object>> _innerGetServices;
-        private readonly Action<Func<object?>, Type, string?>? _innerRegister;
-        private readonly Action<Type, string?>? _unregisterCurrent;
-        private readonly Action<Type, string?>? _unregisterAll;
-        private readonly Dictionary<(Type type, string callback), List<Action<IDisposable>>> _callbackRegistry = new();
+        private readonly Func<Type?, string?, IEnumerable<object>> _innerGetServices;
+        private readonly Action<Func<object?>, Type?, string?>? _innerRegister;
+        private readonly Action<Type?, string?>? _unregisterCurrent;
+        private readonly Action<Type?, string?>? _unregisterAll;
+        private readonly Dictionary<(Type? type, string callback), List<Action<IDisposable>>> _callbackRegistry = new();
 
         private IDisposable _inner;
         private bool _isDisposed;
@@ -35,10 +35,10 @@ namespace Splat
         /// <param name="unregisterAll">A func which will unregister all the registered elements for a service type and contract.</param>
         /// <param name="toDispose">A optional disposable which is called when this resolver is disposed.</param>
         public FuncDependencyResolver(
-            Func<Type, string?, IEnumerable<object>> getAllServices,
-            Action<Func<object?>, Type, string?>? register = null,
-            Action<Type, string?>? unregisterCurrent = null,
-            Action<Type, string?>? unregisterAll = null,
+            Func<Type?, string?, IEnumerable<object>> getAllServices,
+            Action<Func<object?>, Type?, string?>? register = null,
+            Action<Type?, string?>? unregisterCurrent = null,
+            Action<Type?, string?>? unregisterAll = null,
             IDisposable? toDispose = null)
         {
             _innerGetServices = getAllServices;
@@ -49,37 +49,53 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public object? GetService(Type serviceType, string? contract = null)
-        {
-            return (GetServices(serviceType, contract) ?? Array.Empty<object>()).LastOrDefault();
-        }
+        public object? GetService(Type? serviceType, string? contract = null) =>
+            GetServices(serviceType, contract).LastOrDefault();
 
         /// <inheritdoc />
         public IEnumerable<object> GetServices(Type? serviceType, string? contract = null)
         {
             if (serviceType is null)
             {
-                throw new ArgumentNullException(nameof(serviceType));
+                serviceType = typeof(NullServiceType);
             }
 
-            return _innerGetServices(serviceType, contract);
+            return _innerGetServices(serviceType, contract) ?? Array.Empty<object>();
         }
 
         /// <inheritdoc />
-        public bool HasRegistration(Type serviceType, string? contract = null)
+        public bool HasRegistration(Type? serviceType, string? contract = null)
         {
+            if (serviceType is null)
+            {
+                serviceType = typeof(NullServiceType);
+            }
+
             return _innerGetServices(serviceType, contract) is not null;
         }
 
         /// <inheritdoc />
-        public void Register(Func<object?> factory, Type serviceType, string? contract = null)
+        public void Register(Func<object?> factory, Type? serviceType, string? contract = null)
         {
             if (_innerRegister is null)
             {
                 throw new NotImplementedException();
             }
 
-            _innerRegister(factory, serviceType, contract);
+            var isNull = serviceType is null;
+
+            if (serviceType is null)
+            {
+                serviceType = typeof(NullServiceType);
+            }
+
+            _innerRegister(
+                () =>
+                isNull
+                    ? new NullServiceType(factory)
+                    : factory(),
+                serviceType,
+                contract);
 
             var pair = (serviceType, contract ?? string.Empty);
 
@@ -110,22 +126,32 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public void UnregisterCurrent(Type serviceType, string? contract = null)
+        public void UnregisterCurrent(Type? serviceType, string? contract = null)
         {
             if (_unregisterCurrent is null)
             {
                 throw new NotImplementedException();
             }
 
+            if (serviceType is null)
+            {
+                serviceType = typeof(NullServiceType);
+            }
+
             _unregisterCurrent.Invoke(serviceType, contract);
         }
 
         /// <inheritdoc />
-        public void UnregisterAll(Type serviceType, string? contract = null)
+        public void UnregisterAll(Type? serviceType, string? contract = null)
         {
             if (_unregisterAll is null)
             {
                 throw new NotImplementedException();
+            }
+
+            if (serviceType is null)
+            {
+                serviceType = typeof(NullServiceType);
             }
 
             _unregisterAll.Invoke(serviceType, contract);

--- a/src/Splat/ServiceLocation/IMutableDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/IMutableDependencyResolver.cs
@@ -30,7 +30,7 @@ namespace Splat
         /// <param name="factory">The factory function which generates our object.</param>
         /// <param name="serviceType">The type which is used for the registration.</param>
         /// <param name="contract">A optional contract value which will indicates to only generate the value if this contract is specified.</param>
-        void Register(Func<object> factory, Type serviceType, string? contract = null);
+        void Register(Func<object?> factory, Type serviceType, string? contract = null);
 
         /// <summary>
         /// Unregisters the current item based on the specified type and contract.

--- a/src/Splat/ServiceLocation/IMutableDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/IMutableDependencyResolver.cs
@@ -18,7 +18,7 @@ namespace Splat
         /// <param name="serviceType">The type to check for registration.</param>
         /// <returns>Whether there is a registration for the type.</returns>
         /// <param name="contract">A optional contract value which will indicates to only generate the value if this contract is specified.</param>
-        bool HasRegistration(Type serviceType, string? contract = null);
+        bool HasRegistration(Type? serviceType, string? contract = null);
 
         /// <summary>
         /// Register a function with the resolver which will generate a object
@@ -30,21 +30,21 @@ namespace Splat
         /// <param name="factory">The factory function which generates our object.</param>
         /// <param name="serviceType">The type which is used for the registration.</param>
         /// <param name="contract">A optional contract value which will indicates to only generate the value if this contract is specified.</param>
-        void Register(Func<object?> factory, Type serviceType, string? contract = null);
+        void Register(Func<object?> factory, Type? serviceType, string? contract = null);
 
         /// <summary>
         /// Unregisters the current item based on the specified type and contract.
         /// </summary>
         /// <param name="serviceType">The service type to unregister.</param>
         /// <param name="contract">The optional contract value, which will only remove the value associated with the contract.</param>
-        void UnregisterCurrent(Type serviceType, string? contract = null);
+        void UnregisterCurrent(Type? serviceType, string? contract = null);
 
         /// <summary>
         /// Unregisters all the values associated with the specified type and contract.
         /// </summary>
         /// <param name="serviceType">The service type to unregister.</param>
         /// <param name="contract">The optional contract value, which will only remove the value associated with the contract.</param>
-        void UnregisterAll(Type serviceType, string? contract = null);
+        void UnregisterAll(Type? serviceType, string? contract = null);
 
         /// <summary>
         /// Register a callback to be called when a new service matching the type

--- a/src/Splat/ServiceLocation/IReadonlyDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/IReadonlyDependencyResolver.cs
@@ -29,6 +29,6 @@ namespace Splat
         /// <param name="contract">A optional value which will retrieve only objects registered with the same contract.</param>
         /// <returns>A sequence of instances of the requested <paramref name="serviceType"/>. The sequence
         /// should be empty (not <c>null</c>) if no objects of the given type are available.</returns>
-        IEnumerable<object?> GetServices(Type serviceType, string? contract = null);
+        IEnumerable<object> GetServices(Type? serviceType, string? contract = null);
     }
 }

--- a/src/Splat/ServiceLocation/IReadonlyDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/IReadonlyDependencyResolver.cs
@@ -19,7 +19,7 @@ namespace Splat
         /// <param name="serviceType">The object type.</param>
         /// <param name="contract">A optional value which will retrieve only a object registered with the same contract.</param>
         /// <returns>The requested object, if found; <c>null</c> otherwise.</returns>
-        object? GetService(Type serviceType, string? contract = null);
+        object? GetService(Type? serviceType, string? contract = null);
 
         /// <summary>
         /// Gets all instances of the given <paramref name="serviceType"/>. Must return an empty

--- a/src/Splat/ServiceLocation/IReadonlyDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/IReadonlyDependencyResolver.cs
@@ -19,7 +19,7 @@ namespace Splat
         /// <param name="serviceType">The object type.</param>
         /// <param name="contract">A optional value which will retrieve only a object registered with the same contract.</param>
         /// <returns>The requested object, if found; <c>null</c> otherwise.</returns>
-        object? GetService(Type serviceType, string? contract = null);
+        object GetService(Type serviceType, string? contract = null);
 
         /// <summary>
         /// Gets all instances of the given <paramref name="serviceType"/>. Must return an empty

--- a/src/Splat/ServiceLocation/IReadonlyDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/IReadonlyDependencyResolver.cs
@@ -19,7 +19,7 @@ namespace Splat
         /// <param name="serviceType">The object type.</param>
         /// <param name="contract">A optional value which will retrieve only a object registered with the same contract.</param>
         /// <returns>The requested object, if found; <c>null</c> otherwise.</returns>
-        object GetService(Type serviceType, string? contract = null);
+        object? GetService(Type serviceType, string? contract = null);
 
         /// <summary>
         /// Gets all instances of the given <paramref name="serviceType"/>. Must return an empty
@@ -29,6 +29,6 @@ namespace Splat
         /// <param name="contract">A optional value which will retrieve only objects registered with the same contract.</param>
         /// <returns>A sequence of instances of the requested <paramref name="serviceType"/>. The sequence
         /// should be empty (not <c>null</c>) if no objects of the given type are available.</returns>
-        IEnumerable<object> GetServices(Type serviceType, string? contract = null);
+        IEnumerable<object?> GetServices(Type serviceType, string? contract = null);
     }
 }

--- a/src/Splat/ServiceLocation/ModernDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/ModernDependencyResolver.cs
@@ -24,7 +24,7 @@ namespace Splat
     /// </summary>
     public class ModernDependencyResolver : IDependencyResolver
     {
-        private Dictionary<(Type serviceType, string contract), List<Func<object>>>? _registry;
+        private Dictionary<(Type serviceType, string contract), List<Func<object?>>>? _registry;
         private Dictionary<(Type serviceType, string contract), List<Action<IDisposable>>> _callbackRegistry;
 
         private bool _isDisposed;
@@ -41,11 +41,11 @@ namespace Splat
         /// Initializes a new instance of the <see cref="ModernDependencyResolver"/> class.
         /// </summary>
         /// <param name="registry">A registry of services.</param>
-        protected ModernDependencyResolver(Dictionary<(Type serviceType, string contract), List<Func<object>>>? registry)
+        protected ModernDependencyResolver(Dictionary<(Type serviceType, string contract), List<Func<object?>>>? registry)
         {
             _registry = registry is not null ?
                 registry.ToDictionary(k => k.Key, v => v.Value.ToList()) :
-                new Dictionary<(Type serviceType, string contract), List<Func<object>>>();
+                new Dictionary<(Type serviceType, string contract), List<Func<object?>>>();
 
             _callbackRegistry = new Dictionary<(Type serviceType, string contract), List<Action<IDisposable>>>();
         }
@@ -63,7 +63,7 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public void Register(Func<object> factory, Type serviceType, string? contract = null)
+        public void Register(Func<object?> factory, Type serviceType, string? contract = null)
         {
             var pair = GetKey(serviceType, contract);
 
@@ -74,7 +74,7 @@ namespace Splat
 
             if (!_registry.ContainsKey(pair))
             {
-                _registry[pair] = new List<Func<object>>();
+                _registry[pair] = new List<Func<object?>>();
             }
 
             _registry[pair].Add(factory);
@@ -111,21 +111,21 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public object? GetService(Type serviceType, string? contract = null)
+        public object GetService(Type serviceType, string? contract = null)
         {
             if (_registry is null)
             {
-                return default;
+                return null!;
             }
 
             var pair = GetKey(serviceType, contract);
             if (!_registry.ContainsKey(pair))
             {
-                return default;
+                return null!;
             }
 
             var ret = _registry[pair].LastOrDefault();
-            return ret is null ? null : ret();
+            return (ret is null ? null : ret())!;
         }
 
         /// <inheritdoc />
@@ -142,7 +142,7 @@ namespace Splat
                 return Enumerable.Empty<object>();
             }
 
-            return _registry[pair].Select(x => x()).ToList();
+            return _registry[pair].Select(x => x()!).ToList();
         }
 
         /// <inheritdoc />
@@ -179,7 +179,7 @@ namespace Splat
 
             var pair = GetKey(serviceType, contract);
 
-            _registry[pair] = new List<Func<object>>();
+            _registry[pair] = new List<Func<object?>>();
         }
 
         /// <inheritdoc />

--- a/src/Splat/ServiceLocation/ModernDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/ModernDependencyResolver.cs
@@ -126,20 +126,25 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public IEnumerable<object?> GetServices(Type serviceType, string? contract = null)
+        public IEnumerable<object> GetServices(Type? serviceType, string? contract = null)
         {
+            if (serviceType == null)
+            {
+                throw new ArgumentNullException(nameof(serviceType));
+            }
+
             if (_registry is null)
             {
-                return Enumerable.Empty<object?>();
+                return Enumerable.Empty<object>();
             }
 
             var pair = GetKey(serviceType, contract);
             if (!_registry.ContainsKey(pair))
             {
-                return Enumerable.Empty<object?>();
+                return Enumerable.Empty<object>();
             }
 
-            return _registry[pair].ConvertAll(x => x());
+            return _registry[pair].ConvertAll(x => x()!);
         }
 
         /// <inheritdoc />

--- a/src/Splat/ServiceLocation/ModernDependencyResolver.cs
+++ b/src/Splat/ServiceLocation/ModernDependencyResolver.cs
@@ -26,8 +26,8 @@ namespace Splat
     /// </summary>
     public class ModernDependencyResolver : IDependencyResolver
     {
-        private readonly Dictionary<(Type serviceType, string contract), List<Action<IDisposable>>> _callbackRegistry;
-        private Dictionary<(Type serviceType, string contract), List<Func<object?>>>? _registry;
+        private readonly Dictionary<(Type serviceType, string? contract), List<Action<IDisposable>>> _callbackRegistry;
+        private Dictionary<(Type serviceType, string? contract), List<Func<object?>>>? _registry;
 
         private bool _isDisposed;
 
@@ -43,13 +43,13 @@ namespace Splat
         /// Initializes a new instance of the <see cref="ModernDependencyResolver"/> class.
         /// </summary>
         /// <param name="registry">A registry of services.</param>
-        protected ModernDependencyResolver(Dictionary<(Type serviceType, string contract), List<Func<object?>>>? registry)
+        protected ModernDependencyResolver(Dictionary<(Type serviceType, string? contract), List<Func<object?>>>? registry)
         {
             _registry = registry is not null ?
                 registry.ToDictionary(k => k.Key, v => v.Value.ToList()) :
-                new Dictionary<(Type serviceType, string contract), List<Func<object?>>>();
+                new Dictionary<(Type serviceType, string? contract), List<Func<object?>>>();
 
-            _callbackRegistry = new Dictionary<(Type serviceType, string contract), List<Action<IDisposable>>>();
+            _callbackRegistry = new Dictionary<(Type serviceType, string? contract), List<Action<IDisposable>>>();
         }
 
         /// <inheritdoc />
@@ -108,38 +108,38 @@ namespace Splat
         }
 
         /// <inheritdoc />
-        public object GetService(Type serviceType, string? contract = null)
+        public object? GetService(Type serviceType, string? contract = null)
         {
             if (_registry is null)
             {
-                return null!;
+                return default;
             }
 
             var pair = GetKey(serviceType, contract);
             if (!_registry.ContainsKey(pair))
             {
-                return null!;
+                return default;
             }
 
             var ret = _registry[pair].LastOrDefault();
-            return (ret != null ? ret() : null)!;
+            return ret is null ? default : ret();
         }
 
         /// <inheritdoc />
-        public IEnumerable<object> GetServices(Type serviceType, string? contract = null)
+        public IEnumerable<object?> GetServices(Type serviceType, string? contract = null)
         {
             if (_registry is null)
             {
-                return Enumerable.Empty<object>();
+                return Enumerable.Empty<object?>();
             }
 
             var pair = GetKey(serviceType, contract);
             if (!_registry.ContainsKey(pair))
             {
-                return Enumerable.Empty<object>();
+                return Enumerable.Empty<object?>();
             }
 
-            return _registry[pair].ConvertAll(x => x()!);
+            return _registry[pair].ConvertAll(x => x());
         }
 
         /// <inheritdoc />

--- a/src/Splat/ServiceLocation/NullServiceType.cs
+++ b/src/Splat/ServiceLocation/NullServiceType.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Splat
+{
+    /// <summary>
+    /// Null Service Type.
+    /// </summary>
+    public class NullServiceType
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NullServiceType"/> class.
+        /// </summary>
+        /// <param name="factory">The value factory.</param>
+        public NullServiceType(Func<object?> factory) => Factory = factory;
+
+        /// <summary>
+        /// Gets the Factory.
+        /// </summary>
+        public Func<object?> Factory { get; }
+    }
+}

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "11.1",
+  "version": "12.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of master
     "^refs/heads/preview/.*", // we release previews


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix for dryloc resolver
feature for some resolvers to use a null serviceType and a Func of value type to be registered

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

Presently only one resolver can resolve null service types
Dryloc resolver fails to resolve multiple services with the same type and differing contracts

**What is the new behaviour?**
<!-- If this is a feature change -->

increased the number of resolvers that can resolve Func of value type.
Dryloc resolver now resolves multiple services with the same type and differing contracts

**What might this PR break?**

people using dryloc may experience a different item being resolved now compared to previously, but will now return the correct service

**Please check if the PR fulfils these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

Test projects have the Func of value type and null serviceType applied

FuncDependencyResolver and SimpleInjectorDependencyResolver do not currently support Func of value type