### PR TITLE
fix for SplatColor Equal and tests for SplatColor

### DIFF
--- a/src/Splat.Common.Test/IViewModelOne.cs
+++ b/src/Splat.Common.Test/IViewModelOne.cs
@@ -8,7 +8,10 @@ namespace Splat.Common.Test
     /// <summary>
     /// Interface for ViewModelOne.
     /// </summary>
+#pragma warning disable CA1040 // Avoid empty interfaces
+
     public interface IViewModelOne
+#pragma warning restore CA1040 // Avoid empty interfaces
     {
     }
 }

--- a/src/Splat.Common.Test/MockScreen.cs
+++ b/src/Splat.Common.Test/MockScreen.cs
@@ -3,12 +3,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Splat.Common.Test
 {
     /// <summary>
     /// An <see cref="IScreen"/> implementation.
     /// </summary>
     /// <seealso cref="IScreen" />
+    [ExcludeFromCodeCoverage]
     public class MockScreen : IScreen
     {
     }

--- a/src/Splat.Common.Test/ViewModelOne.cs
+++ b/src/Splat.Common.Test/ViewModelOne.cs
@@ -3,11 +3,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Splat.Common.Test
 {
     /// <summary>
     /// View Model One.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class ViewModelOne : IViewModelOne
     {
         /// <summary>

--- a/src/Splat.Common.Test/ViewModelTwo.cs
+++ b/src/Splat.Common.Test/ViewModelTwo.cs
@@ -3,11 +3,14 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Splat.Common.Test
 {
     /// <summary>
     /// View Model Two.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class ViewModelTwo
     {
     }

--- a/src/Splat.Common.Test/ViewOne.cs
+++ b/src/Splat.Common.Test/ViewOne.cs
@@ -3,12 +3,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Splat.Common.Test
 {
     /// <summary>
     /// View One.
     /// </summary>
     /// <seealso cref="ViewModelOne" />
+    [ExcludeFromCodeCoverage]
     public class ViewOne : IViewFor<ViewModelOne>
     {
         /// <inheritdoc />

--- a/src/Splat.Common.Test/ViewTwo.cs
+++ b/src/Splat.Common.Test/ViewTwo.cs
@@ -3,12 +3,15 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Splat.Common.Test
 {
     /// <summary>
     /// View Two.
     /// </summary>
     /// <seealso cref="ViewModelTwo" />
+    [ExcludeFromCodeCoverage]
     public class ViewTwo : IViewFor<ViewModelTwo>
     {
         /// <inheritdoc />

--- a/src/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.net5.0.approved.txt
+++ b/src/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.net5.0.approved.txt
@@ -59,6 +59,7 @@ namespace Splat
     }
     public enum KnownColor
     {
+        Empty = 0,
         ActiveBorder = 1,
         ActiveCaption = 2,
         ActiveCaptionText = 3,
@@ -428,10 +429,10 @@ namespace Splat
         public override int GetHashCode() { }
         public float GetHue() { }
         public float GetSaturation() { }
-        public int ToArgb() { }
+        public uint ToArgb() { }
         public Splat.KnownColor ToKnownColor() { }
         public override string ToString() { }
-        public static Splat.SplatColor FromArgb(int argb) { }
+        public static Splat.SplatColor FromArgb(uint argb) { }
         public static Splat.SplatColor FromArgb(int alpha, Splat.SplatColor baseColor) { }
         public static Splat.SplatColor FromArgb(int red, int green, int blue) { }
         public static Splat.SplatColor FromArgb(int alpha, int red, int green, int blue) { }

--- a/src/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.netcoreapp3.1.approved.txt
+++ b/src/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.netcoreapp3.1.approved.txt
@@ -57,6 +57,7 @@ namespace Splat
     }
     public enum KnownColor
     {
+        Empty = 0,
         ActiveBorder = 1,
         ActiveCaption = 2,
         ActiveCaptionText = 3,
@@ -426,10 +427,10 @@ namespace Splat
         public override int GetHashCode() { }
         public float GetHue() { }
         public float GetSaturation() { }
-        public int ToArgb() { }
+        public uint ToArgb() { }
         public Splat.KnownColor ToKnownColor() { }
         public override string ToString() { }
-        public static Splat.SplatColor FromArgb(int argb) { }
+        public static Splat.SplatColor FromArgb(uint argb) { }
         public static Splat.SplatColor FromArgb(int alpha, Splat.SplatColor baseColor) { }
         public static Splat.SplatColor FromArgb(int red, int green, int blue) { }
         public static Splat.SplatColor FromArgb(int alpha, int red, int green, int blue) { }

--- a/src/Splat.Drawing.Tests/Colors/CoverageColorTests.cs
+++ b/src/Splat.Drawing.Tests/Colors/CoverageColorTests.cs
@@ -1,0 +1,226 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Splat.Drawing.Tests.Colors
+{
+    /// <summary>
+    /// Coverage Color Tests.
+    /// </summary>
+    public class CoverageColorTests
+    {
+        /// <summary>
+        /// Colors the is empty.
+        /// </summary>
+        [Fact]
+        public void ColorIsEmpty()
+        {
+            var fixture = SplatColor.Empty;
+            Assert.True(fixture.IsEmpty);
+            Assert.Equal((byte)0, fixture.A);
+            Assert.Equal((byte)0, fixture.R);
+            Assert.Equal((byte)0, fixture.G);
+            Assert.Equal((byte)0, fixture.B);
+        }
+
+        /// <summary>
+        /// Colors the is equal.
+        /// </summary>
+        [Fact]
+        public void ColorIsEqual()
+        {
+            var fixture1 = SplatColor.FromArgb(255, 0, 0, 139);
+            var fixture2 = SplatColor.FromKnownColor(KnownColor.DarkBlue);
+            Assert.True(fixture1 == fixture2);
+        }
+
+        /// <summary>
+        /// ARGBs the color is equal.
+        /// </summary>
+        [Fact]
+        public void ARGBColorIsEqual()
+        {
+            var fixture1 = SplatColor.FromArgb(255, 0, 0, 139);
+            var fixture2 = SplatColor.FromArgb(0, 0, 139);
+            Assert.True(fixture1 == fixture2);
+        }
+
+        /// <summary>
+        /// ARGBs the hexadecimal color is equal.
+        /// </summary>
+        [Fact]
+        public void ARGBHexColorIsEqual()
+        {
+            var fixture1 = SplatColor.FromArgb(0xFF00008B);
+            var fixture2 = SplatColor.FromArgb(0, 0, 139);
+            Assert.True(fixture1 == fixture2);
+        }
+
+        /// <summary>
+        /// ARGBs the and named color is equal.
+        /// </summary>
+        [Fact]
+        public void ARGBAndNamedColorIsEqual()
+        {
+            var fixture1 = SplatColor.FromName("DarkBlue");
+            var fixture2 = SplatColor.FromArgb(0, 0, 139);
+            Assert.True(fixture1 == fixture2);
+        }
+
+        /// <summary>
+        /// ARGBs the based on named color is equal.
+        /// </summary>
+        [Fact]
+        public void ARGBBasedOnNamedColorIsEqual()
+        {
+            var fixture1 = SplatColor.FromName("DarkBlue");
+            var fixture2 = SplatColor.FromArgb(255, fixture1);
+            Assert.True(fixture1 == fixture2);
+        }
+
+        /// <summary>
+        /// Incorrect named color is equal to empty.
+        /// </summary>
+        [Fact]
+        public void IncorrectNamedColorIsEqualToEmpty()
+        {
+            var fixture1 = SplatColor.FromName("TheBestColor");
+            var fixture2 = SplatColor.Empty;
+            Assert.True(fixture1 == fixture2);
+            Assert.Equal("TheBestColor", fixture1.Name);
+        }
+
+        /// <summary>
+        /// Colors the is not equal.
+        /// </summary>
+        [Fact]
+        public void ColorIsNotEqual()
+        {
+            var fixture1 = SplatColor.FromArgb(255, 0, 0, 138);
+            var fixture2 = SplatColor.FromKnownColor(KnownColor.DarkBlue);
+            Assert.True(fixture1 != fixture2);
+        }
+
+        /// <summary>
+        /// Colors the brightness.
+        /// </summary>
+        [Fact]
+        public void ColorBrightnessHasCorrectValue()
+        {
+            var fixture = SplatColor.FromKnownColor(KnownColor.DarkBlue);
+            var brightness = fixture.GetBrightness();
+            Assert.Equal(0.272549033f, brightness);
+        }
+
+        /// <summary>
+        /// Colors the saturation has correct value.
+        /// </summary>
+        [Fact]
+        public void ColorSaturationHasCorrectValue()
+        {
+            var fixture = SplatColor.FromKnownColor(KnownColor.DarkBlue);
+            var saturation = fixture.GetSaturation();
+            Assert.Equal(1, saturation);
+        }
+
+        /// <summary>
+        /// Colors the hue has correct value.
+        /// </summary>
+        [Fact]
+        public void ColorHueHasCorrectValue()
+        {
+            var fixture = SplatColor.FromKnownColor(KnownColor.DarkBlue);
+            var hue = fixture.GetHue();
+            Assert.Equal(240f, hue);
+        }
+
+        /// <summary>
+        /// Colors to known color has correct value.
+        /// </summary>
+        [Fact]
+        public void ColorToKnownColorHasCorrectValue()
+        {
+            var fixture = SplatColor.FromKnownColor(KnownColor.DarkBlue);
+            var color = fixture.ToKnownColor();
+            Assert.Equal(KnownColor.DarkBlue, color);
+        }
+
+        /// <summary>
+        /// Colors the is equals.
+        /// </summary>
+        [Fact]
+        public void ColorIsEquals()
+        {
+            object fixture1 = SplatColor.FromArgb(0xFF00008B);
+            object fixture2 = SplatColor.FromArgb(0, 0, 139);
+            Assert.True(fixture1.Equals(fixture2));
+        }
+
+        /// <summary>
+        /// Incorrects the named color to string gives value.
+        /// </summary>
+        [Fact]
+        public void IncorrectNamedColorToStringGivesValue()
+        {
+            var fixture1 = SplatColor.FromName("TheBestColor");
+            Assert.Equal("SplatColor [TheBestColor]", fixture1.ToString());
+        }
+
+        /// <summary>
+        /// Nameds the color to string gives value.
+        /// </summary>
+        [Fact]
+        public void NamedColorToStringGivesValue()
+        {
+            var fixture1 = SplatColor.FromKnownColor(KnownColor.DarkBlue);
+            Assert.Equal("SplatColor [DarkBlue]", fixture1.ToString());
+        }
+
+        /// <summary>
+        /// ARGBs the color to string gives value.
+        /// </summary>
+        [Fact]
+        public void ARGBColorToStringGivesValue()
+        {
+            var fixture1 = SplatColor.FromArgb(255, 0, 0, 138);
+            Assert.Equal("SplatColor [A=255, R=0, G=0, B=138]", fixture1.ToString());
+        }
+
+        /// <summary>
+        /// Invalids the ARGB color A throws.
+        /// </summary>
+        [Fact]
+        public void InvalidARGBColorAThrows()
+        {
+            Assert.Throws<ArgumentException>(() => SplatColor.FromArgb(256, 0, 0, 0));
+        }
+
+        /// <summary>
+        /// Invalids the ARGB color r throws.
+        /// </summary>
+        [Fact]
+        public void InvalidARGBColorRThrows()
+        {
+            Assert.Throws<ArgumentException>(() => SplatColor.FromArgb(0, 256, 0, 0));
+        }
+
+        /// <summary>
+        /// Invalids the ARGB color g throws.
+        /// </summary>
+        [Fact]
+        public void InvalidARGBColorGThrows()
+        {
+            Assert.Throws<ArgumentException>(() => SplatColor.FromArgb(0, 0, 256, 0));
+        }
+
+        /// <summary>
+        /// Invalids the ARGB color b throws.
+        /// </summary>
+        [Fact]
+        public void InvalidARGBColorBThrows()
+        {
+            Assert.Throws<ArgumentException>(() => SplatColor.FromArgb(0, 0, 0, 256));
+        }
+    }
+}

--- a/src/Splat.Drawing/Colors/KnownColor.cs
+++ b/src/Splat.Drawing/Colors/KnownColor.cs
@@ -15,10 +15,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -30,12 +30,13 @@
 
 namespace Splat
 {
-
 #if ONLY_1_1
   [Serializable]
 #endif
+
     public enum KnownColor
     {
+        Empty = 0,
         ActiveBorder = 1,
         ActiveCaption = 2,
         ActiveCaptionText = 3,

--- a/src/Splat.Drawing/Colors/KnownColors.cs
+++ b/src/Splat.Drawing/Colors/KnownColors.cs
@@ -15,10 +15,10 @@
 // distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so, subject to
 // the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be
 // included in all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 // EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 // MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
@@ -32,17 +32,18 @@ using System;
 
 namespace Splat
 {
-
 #if NET_2_0
   internal static class KnownColors {
 #else
+
     internal class KnownColors
     {
-
         private KnownColors()
         {
         }
+
 #endif
+
         // FindColorMatch relies on the index + 1 == KnowColor match
         static internal uint[] ArgbValues = new uint[]
         {
@@ -257,6 +258,7 @@ namespace Splat
         {
             switch (kc)
             {
+                case 0: return "Empty";
                 case 1: return "ActiveBorder";
                 case 2: return "ActiveCaption";
                 case 3: return "ActiveCaptionText";

--- a/src/Splat.Drawing/Platforms/Cocoa/Colors/SplatColorExtensions.cs
+++ b/src/Splat.Drawing/Platforms/Cocoa/Colors/SplatColorExtensions.cs
@@ -24,10 +24,8 @@ namespace Splat
         /// </summary>
         /// <param name="value">The color to convert.</param>
         /// <returns>The <see cref="UIColor"/> generated value.</returns>
-        public static UIColor ToNative(this SplatColor value)
-        {
-            return new(value.R / 255.0f, value.G / 255.0f, value.B / 255.0f, value.A / 255.0f);
-        }
+        public static UIColor ToNative(this SplatColor value) =>
+            new(value.R / 255.0f, value.G / 255.0f, value.B / 255.0f, value.A / 255.0f);
 
         /// <summary>
         /// Converts a <see cref="UIColor"/> into the cocoa native <see cref="SplatColor"/>.
@@ -50,10 +48,8 @@ namespace Splat
         /// </summary>
         /// <param name="value">The color to convert.</param>
         /// <returns>The <see cref="NSColor"/> generated.</returns>
-        public static NSColor ToNative(this SplatColor value)
-        {
-            return NSColor.FromSrgb(value.R / 255.0f, value.G / 255.0f, value.B / 255.0f, value.A / 255.0f);
-        }
+        public static NSColor ToNative(this SplatColor value) =>
+            NSColor.FromSrgb(value.R / 255.0f, value.G / 255.0f, value.B / 255.0f, value.A / 255.0f);
 
         /// <summary>
         /// Converts a <see cref="NSColor"/> into the cocoa native <see cref="SplatColor"/>.


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix
feature
tests

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

SplatColor == was looking at how the SplatColor was generated to compare if equal
SplatColor != was just comparing two instances directly

**What is the new behaviour?**
<!-- If this is a feature change -->

Now using ARGB comparision and if all are the same its equal.
the inverse of == is used for !=.

Added KnownName lookup for ARGB which will automatically convert to a KnownName generated Color if it is a match to a KnownColor.

**What might this PR break?**

if user was checking equal and relying on the way it was generated for comparison to be true this will no longer be true.

**Please check if the PR fulfils these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

added a KnownColor of Empty