### PR TITLE
fix for DryIoc - Change Append to Replace for keyed (contract) registrations

### DIFF
--- a/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
+++ b/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
@@ -250,5 +250,21 @@ namespace Splat.DryIoc.Tests
             var d = Splat.Locator.Current.GetService<ILogManager>();
             Assert.IsType<FuncLogManager>(d);
         }
+
+        /// <summary>
+        /// DryIoc dependency resolver should resolve after duplicate keyed registratoion.
+        /// </summary>
+        [Fact]
+        public void DryIocDependencyResolver_Should_Resolve_AfterDuplicateKeyedRegistratoion()
+        {
+            var container = new Container();
+            container.UseDryIocDependencyResolver();
+            Locator.CurrentMutable.Register(() => new ViewModelOne(), typeof(ViewModelOne), "ViewModelOne");
+            Locator.CurrentMutable.Register(() => new ViewModelOne(), typeof(ViewModelOne), "ViewModelOne");
+
+            var vmOne = Locator.Current.GetService<ViewModelOne>("ViewModelOne");
+
+            vmOne.Should().NotBeNull();
+        }
     }
 }

--- a/src/Splat.DryIoc/DryIocDependencyResolver.cs
+++ b/src/Splat.DryIoc/DryIocDependencyResolver.cs
@@ -5,6 +5,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using DryIoc;
 
@@ -111,10 +112,16 @@ namespace Splat.DryIoc
 
             var key = (serviceType, contract);
 
+            if (HasRegistration(serviceType, contract))
+            {
+                Trace.WriteLine($"Warning: Service {serviceType} already exists with key {contract}, the registration will be replaced.");
+            }
+
+            // Keyed instances can only have a single instance so keep latest
             _container.UseInstance(
                 serviceType,
                 isNull ? new NullServiceType(factory) : factory(),
-                IfAlreadyRegistered.AppendNewImplementation,
+                IfAlreadyRegistered.Replace,
                 serviceKey: key);
         }
 

--- a/src/Splat.sln
+++ b/src/Splat.sln
@@ -69,7 +69,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Prism.Tests", "Splat.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Drawing.Tests", "Splat.Drawing.Tests\Splat.Drawing.Tests.csproj", "{7E350DE5-B8C4-4EF1-9211-7B35643B1971}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReactiveUI.DI.Tests", "ReactiveUI.DI.Tests\ReactiveUI.DI.Tests.csproj", "{FEA4E637-0409-40BC-8518-860509FEEA64}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveUI.DI.Tests", "ReactiveUI.DI.Tests\ReactiveUI.DI.Tests.csproj", "{FEA4E637-0409-40BC-8518-860509FEEA64}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
fix for #752 Keyed instances can only have a single instance so keep latest

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

DryIoc only allows single registrations for keyed (Contract) registrations

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

DryIoc currently crashes when a duplicate registration is made with contract

**What is the new behaviour?**
<!-- If this is a feature change -->

DryIoc now replaces the registration with the new instance

**What might this PR break?**

none expected as would previously throw an exception in this instance

**Please check if the PR fulfils these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

This issue stemmed from Akavache due to a double call to Registrations Akavache.Core.Registrations which registers a default InMemory Cache and Akavache.Sqlite3.Registrations with a db Cache, both are called with the same registration details.