### PR TITLE
feature Enable net6 via netstandard2.1

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -38,19 +38,19 @@ jobs:
         dotnet-version: 6.0.x
         include-prerelease: true
 
-    - name: Install VS2022 preview
-      shell: bash
-      run: |
-        dotnet tool update -g dotnet-vs
-        vs install preview -sku:enterprise --quiet +Microsoft.VisualStudio.Component.ManagedDesktop.Core +Microsoft.NetCore.Component.DevelopmentTools +Microsoft.VisualStudio.Workload.NetCrossPlat +Microsoft.VisualStudio.Workload.Universal
-        echo "##vso[task.prependpath]$(vs where preview --prop=InstallationPath)\MSBuild\Current\Bin"
+    #- name: Install VS2022 preview
+    #  shell: bash
+    #  run: |
+    #    dotnet tool update -g dotnet-vs
+    #    vs install preview -sku:enterprise --quiet +Microsoft.VisualStudio.Component.ManagedDesktop.Core +Microsoft.NetCore.Component.DevelopmentTools +Microsoft.VisualStudio.Workload.NetCrossPlat +Microsoft.VisualStudio.Workload.Universal
+    #    echo "##vso[task.prependpath]$(vs where preview --prop=InstallationPath)\MSBuild\Current\Bin"
 
     - name: Add MSBuild to PATH
       uses: glennawatson/setup-msbuild@v1.0.3
 
-    #- name: Update VS2019
-    #  shell: powershell
-    #  run: Start-Process -Wait -PassThru -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" -ArgumentList "update --passive --norestart --installpath ""C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise"""
+    - name: Update VS2019
+      shell: powershell
+      run: Start-Process -Wait -PassThru -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" -ArgumentList "update --passive --norestart --installpath ""C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise"""
 
     - name: NBGV
       id: nbgv
@@ -63,7 +63,7 @@ jobs:
       working-directory: src
       
     - name: Build
-      run: msbuild /t:build,pack /nowarn:MSB4011 /maxcpucount /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=${{ env.configuration }}
+      run: msbuild /t:build,pack /nowarn:MSB4011 /maxcpucount /p:UseVsSdkVersion=17.0 /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=${{ env.configuration }}
       working-directory: src
 
     - name: Run Unit Tests and Generate Coverage

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -23,21 +23,34 @@ jobs:
         fetch-depth: 0
 
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v1.8.1
       with:
         dotnet-version: 3.1.x
 
     - name: Install .NET 5
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v1.8.1
       with:
         dotnet-version: 5.0.x
+
+    - name: Install .NET 6
+      uses: actions/setup-dotnet@v1.8.1
+      with:
+        dotnet-version: 6.0.x
+        include-prerelease: true
+
+    - name: Install VS2022 preview
+      shell: bash
+      run: |
+        dotnet tool update -g dotnet-vs
+        vs install preview -sku:enterprise --quiet +Microsoft.VisualStudio.Component.ManagedDesktop.Core +Microsoft.NetCore.Component.DevelopmentTools +Microsoft.VisualStudio.Workload.NetCrossPlat +Microsoft.VisualStudio.Workload.Universal
+        echo "##vso[task.prependpath]$(vs where preview --prop=InstallationPath)\MSBuild\Current\Bin"
 
     - name: Add MSBuild to PATH
       uses: glennawatson/setup-msbuild@v1.0.3
 
-    - name: Update VS2019
-      shell: powershell
-      run: Start-Process -Wait -PassThru -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" -ArgumentList "update --passive --norestart --installpath ""C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise"""
+    #- name: Update VS2019
+    #  shell: powershell
+    #  run: Start-Process -Wait -PassThru -FilePath "C:\Program Files (x86)\Microsoft Visual Studio\Installer\vs_installer.exe" -ArgumentList "update --passive --norestart --installpath ""C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise"""
 
     - name: NBGV
       id: nbgv

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -78,7 +78,7 @@ jobs:
         dotnet restore ${{ env.SOLUTION_PATH }} /bl:artifacts\\binlog\\restore.binlog
 
     - name: Run Build
-      run: msbuild /t:build /nowarn:MSB4011 /maxcpucount /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=Release /p:UseSharedCompilation=false
+      run: msbuild /t:build /nowarn:MSB4011 /maxcpucount /p:UseVsSdkVersion=17.0 /p:NoPackageAnalysis=true /verbosity:minimal /p:Configuration=Release /p:UseSharedCompilation=false
       working-directory: src
 
 

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -69,7 +69,7 @@
   <ItemGroup>
     <PackageReference Include="stylecop.analyzers" Version="1.2.0-beta.354" PrivateAssets="all" />
     <PackageReference Include="Roslynator.Analyzers" Version="3.2.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="all" />
+    <!--<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3" PrivateAssets="all" />-->
   </ItemGroup>
   <!-- Net Analyzers config taken from : https://docs.microsoft.com/en-gb/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers?view=vs-2019 -->
   <PropertyGroup>

--- a/src/ReactiveUI.DI.Tests/ReactiveUI.DI.Tests.csproj
+++ b/src/ReactiveUI.DI.Tests/ReactiveUI.DI.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net462;net472;netcoreapp3;net5.0;</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <Choose>

--- a/src/Splat.AppCenter/Splat.AppCenter.csproj
+++ b/src/Splat.AppCenter/Splat.AppCenter.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <AssemblyName>Splat.AppCenter</AssemblyName>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>
     <Description>Visual Studio AppCenter integrations for Splat</Description>
     <PackageId>Splat.AppCenter</PackageId>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.ApplicationInsights/Splat.ApplicationInsights.csproj
+++ b/src/Splat.ApplicationInsights/Splat.ApplicationInsights.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <AssemblyName>Splat.ApplicationInsights</AssemblyName>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>
     <Description>ApplicationInsights integrations for Splat</Description>
     <PackageId>Splat.ApplicationInsights</PackageId>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.18.0" />

--- a/src/Splat.Autofac.Tests/Splat.Autofac.Tests.csproj
+++ b/src/Splat.Autofac.Tests/Splat.Autofac.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net6.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Splat.Autofac/Splat.Autofac.csproj
+++ b/src/Splat.Autofac/Splat.Autofac.csproj
@@ -1,11 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <Description>Autofac adapter for Splat</Description>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Common.Test/Splat.Common.Test.csproj
+++ b/src/Splat.Common.Test/Splat.Common.Test.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA2000</NoWarn>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.net6.0.approved.txt
+++ b/src/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.net6.0.approved.txt
@@ -1,0 +1,450 @@
+﻿[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.Drawing.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.TestRunner.Android")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.TestRunner.Uwp")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.Tests")]
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows7.0")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName="")]
+[assembly: System.Runtime.Versioning.TargetPlatform("Windows7.0")]
+namespace Splat
+{
+    public static class BitmapLoader
+    {
+        public static Splat.IBitmapLoader Current { get; set; }
+    }
+    [System.Serializable]
+    public class BitmapLoaderException : System.Exception
+    {
+        public BitmapLoaderException() { }
+        public BitmapLoaderException(string message) { }
+        protected BitmapLoaderException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public BitmapLoaderException(string message, System.Exception innerException) { }
+    }
+    public static class BitmapMixins
+    {
+        public static Splat.IBitmap FromNative(this System.Windows.Media.Imaging.BitmapSource value) { }
+        public static System.Windows.Media.Imaging.BitmapSource ToNative(this Splat.IBitmap value) { }
+    }
+    public static class ColorExtensions
+    {
+        public static System.Drawing.Color FromNative(this System.Windows.Media.Color value) { }
+        public static System.Windows.Media.Color ToNative(this System.Drawing.Color value) { }
+        public static System.Windows.Media.SolidColorBrush ToNativeBrush(this System.Drawing.Color value) { }
+    }
+    public enum CompressedBitmapFormat
+    {
+        Png = 0,
+        Jpeg = 1,
+    }
+    public class DefaultPlatformModeDetector : Splat.IPlatformModeDetector
+    {
+        public DefaultPlatformModeDetector() { }
+        public bool? InDesignMode() { }
+    }
+    public interface IBitmap : System.IDisposable
+    {
+        float Height { get; }
+        float Width { get; }
+        System.Threading.Tasks.Task Save(Splat.CompressedBitmapFormat format, float quality, System.IO.Stream target);
+    }
+    public interface IBitmapLoader
+    {
+        Splat.IBitmap? Create(float width, float height);
+        System.Threading.Tasks.Task<Splat.IBitmap?> Load(System.IO.Stream sourceStream, float? desiredWidth, float? desiredHeight);
+        System.Threading.Tasks.Task<Splat.IBitmap?> LoadFromResource(string source, float? desiredWidth, float? desiredHeight);
+    }
+    public interface IPlatformModeDetector
+    {
+        bool? InDesignMode();
+    }
+    public enum KnownColor
+    {
+        Empty = 0,
+        ActiveBorder = 1,
+        ActiveCaption = 2,
+        ActiveCaptionText = 3,
+        AppWorkspace = 4,
+        Control = 5,
+        ControlDark = 6,
+        ControlDarkDark = 7,
+        ControlLight = 8,
+        ControlLightLight = 9,
+        ControlText = 10,
+        Desktop = 11,
+        GrayText = 12,
+        Highlight = 13,
+        HighlightText = 14,
+        HotTrack = 15,
+        InactiveBorder = 16,
+        InactiveCaption = 17,
+        InactiveCaptionText = 18,
+        Info = 19,
+        InfoText = 20,
+        Menu = 21,
+        MenuText = 22,
+        ScrollBar = 23,
+        Window = 24,
+        WindowFrame = 25,
+        WindowText = 26,
+        Transparent = 27,
+        AliceBlue = 28,
+        AntiqueWhite = 29,
+        Aqua = 30,
+        Aquamarine = 31,
+        Azure = 32,
+        Beige = 33,
+        Bisque = 34,
+        Black = 35,
+        BlanchedAlmond = 36,
+        Blue = 37,
+        BlueViolet = 38,
+        Brown = 39,
+        BurlyWood = 40,
+        CadetBlue = 41,
+        Chartreuse = 42,
+        Chocolate = 43,
+        Coral = 44,
+        CornflowerBlue = 45,
+        Cornsilk = 46,
+        Crimson = 47,
+        Cyan = 48,
+        DarkBlue = 49,
+        DarkCyan = 50,
+        DarkGoldenrod = 51,
+        DarkGray = 52,
+        DarkGreen = 53,
+        DarkKhaki = 54,
+        DarkMagenta = 55,
+        DarkOliveGreen = 56,
+        DarkOrange = 57,
+        DarkOrchid = 58,
+        DarkRed = 59,
+        DarkSalmon = 60,
+        DarkSeaGreen = 61,
+        DarkSlateBlue = 62,
+        DarkSlateGray = 63,
+        DarkTurquoise = 64,
+        DarkViolet = 65,
+        DeepPink = 66,
+        DeepSkyBlue = 67,
+        DimGray = 68,
+        DodgerBlue = 69,
+        Firebrick = 70,
+        FloralWhite = 71,
+        ForestGreen = 72,
+        Fuchsia = 73,
+        Gainsboro = 74,
+        GhostWhite = 75,
+        Gold = 76,
+        Goldenrod = 77,
+        Gray = 78,
+        Green = 79,
+        GreenYellow = 80,
+        Honeydew = 81,
+        HotPink = 82,
+        IndianRed = 83,
+        Indigo = 84,
+        Ivory = 85,
+        Khaki = 86,
+        Lavender = 87,
+        LavenderBlush = 88,
+        LawnGreen = 89,
+        LemonChiffon = 90,
+        LightBlue = 91,
+        LightCoral = 92,
+        LightCyan = 93,
+        LightGoldenrodYellow = 94,
+        LightGray = 95,
+        LightGreen = 96,
+        LightPink = 97,
+        LightSalmon = 98,
+        LightSeaGreen = 99,
+        LightSkyBlue = 100,
+        LightSlateGray = 101,
+        LightSteelBlue = 102,
+        LightYellow = 103,
+        Lime = 104,
+        LimeGreen = 105,
+        Linen = 106,
+        Magenta = 107,
+        Maroon = 108,
+        MediumAquamarine = 109,
+        MediumBlue = 110,
+        MediumOrchid = 111,
+        MediumPurple = 112,
+        MediumSeaGreen = 113,
+        MediumSlateBlue = 114,
+        MediumSpringGreen = 115,
+        MediumTurquoise = 116,
+        MediumVioletRed = 117,
+        MidnightBlue = 118,
+        MintCream = 119,
+        MistyRose = 120,
+        Moccasin = 121,
+        NavajoWhite = 122,
+        Navy = 123,
+        OldLace = 124,
+        Olive = 125,
+        OliveDrab = 126,
+        Orange = 127,
+        OrangeRed = 128,
+        Orchid = 129,
+        PaleGoldenrod = 130,
+        PaleGreen = 131,
+        PaleTurquoise = 132,
+        PaleVioletRed = 133,
+        PapayaWhip = 134,
+        PeachPuff = 135,
+        Peru = 136,
+        Pink = 137,
+        Plum = 138,
+        PowderBlue = 139,
+        Purple = 140,
+        Red = 141,
+        RosyBrown = 142,
+        RoyalBlue = 143,
+        SaddleBrown = 144,
+        Salmon = 145,
+        SandyBrown = 146,
+        SeaGreen = 147,
+        SeaShell = 148,
+        Sienna = 149,
+        Silver = 150,
+        SkyBlue = 151,
+        SlateBlue = 152,
+        SlateGray = 153,
+        Snow = 154,
+        SpringGreen = 155,
+        SteelBlue = 156,
+        Tan = 157,
+        Teal = 158,
+        Thistle = 159,
+        Tomato = 160,
+        Turquoise = 161,
+        Violet = 162,
+        Wheat = 163,
+        White = 164,
+        WhiteSmoke = 165,
+        Yellow = 166,
+        YellowGreen = 167,
+        ButtonFace = 168,
+        ButtonHighlight = 169,
+        ButtonShadow = 170,
+        GradientActiveCaption = 171,
+        GradientInactiveCaption = 172,
+        MenuBar = 173,
+        MenuHighlight = 174,
+    }
+    public class PlatformBitmapLoader : Splat.IBitmapLoader
+    {
+        public PlatformBitmapLoader() { }
+        public Splat.IBitmap Create(float width, float height) { }
+        public System.Threading.Tasks.Task<Splat.IBitmap?> Load(System.IO.Stream sourceStream, float? desiredWidth, float? desiredHeight) { }
+        public System.Threading.Tasks.Task<Splat.IBitmap?> LoadFromResource(string source, float? desiredWidth, float? desiredHeight) { }
+    }
+    public static class PlatformModeDetector
+    {
+        public static bool InDesignMode() { }
+        public static void OverrideModeDetector(Splat.IPlatformModeDetector modeDetector) { }
+    }
+    public static class PointExtensions
+    {
+        public static System.Drawing.PointF FromNative(this System.Windows.Point value) { }
+        public static System.Windows.Point ToNative(this System.Drawing.Point value) { }
+        public static System.Windows.Point ToNative(this System.Drawing.PointF value) { }
+    }
+    public static class RectExtensions
+    {
+        public static System.Drawing.RectangleF FromNative(this System.Windows.Rect value) { }
+        public static System.Windows.Rect ToNative(this System.Drawing.Rectangle value) { }
+        public static System.Windows.Rect ToNative(this System.Drawing.RectangleF value) { }
+    }
+    public static class ServiceLocationDrawingInitialization
+    {
+        public static void RegisterPlatformBitmapLoader(this Splat.IMutableDependencyResolver resolver) { }
+    }
+    public static class SizeExtensions
+    {
+        public static System.Drawing.SizeF FromNative(this System.Windows.Size value) { }
+        public static System.Windows.Size ToNative(this System.Drawing.Size value) { }
+        public static System.Windows.Size ToNative(this System.Drawing.SizeF value) { }
+    }
+    [System.Runtime.Serialization.DataContract]
+    public struct SplatColor : System.IEquatable<Splat.SplatColor>
+    {
+        public byte A { get; }
+        public byte B { get; }
+        public byte G { get; }
+        public bool IsEmpty { get; }
+        public bool IsKnownColor { get; }
+        public bool IsNamedColor { get; }
+        public bool IsSystemColor { get; }
+        public string Name { get; }
+        public byte R { get; }
+        public static Splat.SplatColor AliceBlue { get; }
+        public static Splat.SplatColor AntiqueWhite { get; }
+        public static Splat.SplatColor Aqua { get; }
+        public static Splat.SplatColor Aquamarine { get; }
+        public static Splat.SplatColor Azure { get; }
+        public static Splat.SplatColor Beige { get; }
+        public static Splat.SplatColor Bisque { get; }
+        public static Splat.SplatColor Black { get; }
+        public static Splat.SplatColor BlanchedAlmond { get; }
+        public static Splat.SplatColor Blue { get; }
+        public static Splat.SplatColor BlueViolet { get; }
+        public static Splat.SplatColor Brown { get; }
+        public static Splat.SplatColor BurlyWood { get; }
+        public static Splat.SplatColor CadetBlue { get; }
+        public static Splat.SplatColor Chartreuse { get; }
+        public static Splat.SplatColor Chocolate { get; }
+        public static Splat.SplatColor Coral { get; }
+        public static Splat.SplatColor CornflowerBlue { get; }
+        public static Splat.SplatColor Cornsilk { get; }
+        public static Splat.SplatColor Crimson { get; }
+        public static Splat.SplatColor Cyan { get; }
+        public static Splat.SplatColor DarkBlue { get; }
+        public static Splat.SplatColor DarkCyan { get; }
+        public static Splat.SplatColor DarkGoldenrod { get; }
+        public static Splat.SplatColor DarkGray { get; }
+        public static Splat.SplatColor DarkGreen { get; }
+        public static Splat.SplatColor DarkKhaki { get; }
+        public static Splat.SplatColor DarkMagenta { get; }
+        public static Splat.SplatColor DarkOliveGreen { get; }
+        public static Splat.SplatColor DarkOrange { get; }
+        public static Splat.SplatColor DarkOrchid { get; }
+        public static Splat.SplatColor DarkRed { get; }
+        public static Splat.SplatColor DarkSalmon { get; }
+        public static Splat.SplatColor DarkSeaGreen { get; }
+        public static Splat.SplatColor DarkSlateBlue { get; }
+        public static Splat.SplatColor DarkSlateGray { get; }
+        public static Splat.SplatColor DarkTurquoise { get; }
+        public static Splat.SplatColor DarkViolet { get; }
+        public static Splat.SplatColor DeepPink { get; }
+        public static Splat.SplatColor DeepSkyBlue { get; }
+        public static Splat.SplatColor DimGray { get; }
+        public static Splat.SplatColor DodgerBlue { get; }
+        public static Splat.SplatColor Empty { get; }
+        public static Splat.SplatColor Firebrick { get; }
+        public static Splat.SplatColor FloralWhite { get; }
+        public static Splat.SplatColor ForestGreen { get; }
+        public static Splat.SplatColor Fuchsia { get; }
+        public static Splat.SplatColor Gainsboro { get; }
+        public static Splat.SplatColor GhostWhite { get; }
+        public static Splat.SplatColor Gold { get; }
+        public static Splat.SplatColor Goldenrod { get; }
+        public static Splat.SplatColor Gray { get; }
+        public static Splat.SplatColor Green { get; }
+        public static Splat.SplatColor GreenYellow { get; }
+        public static Splat.SplatColor Honeydew { get; }
+        public static Splat.SplatColor HotPink { get; }
+        public static Splat.SplatColor IndianRed { get; }
+        public static Splat.SplatColor Indigo { get; }
+        public static Splat.SplatColor Ivory { get; }
+        public static Splat.SplatColor Khaki { get; }
+        public static Splat.SplatColor Lavender { get; }
+        public static Splat.SplatColor LavenderBlush { get; }
+        public static Splat.SplatColor LawnGreen { get; }
+        public static Splat.SplatColor LemonChiffon { get; }
+        public static Splat.SplatColor LightBlue { get; }
+        public static Splat.SplatColor LightCoral { get; }
+        public static Splat.SplatColor LightCyan { get; }
+        public static Splat.SplatColor LightGoldenrodYellow { get; }
+        public static Splat.SplatColor LightGray { get; }
+        public static Splat.SplatColor LightGreen { get; }
+        public static Splat.SplatColor LightPink { get; }
+        public static Splat.SplatColor LightSalmon { get; }
+        public static Splat.SplatColor LightSeaGreen { get; }
+        public static Splat.SplatColor LightSkyBlue { get; }
+        public static Splat.SplatColor LightSlateGray { get; }
+        public static Splat.SplatColor LightSteelBlue { get; }
+        public static Splat.SplatColor LightYellow { get; }
+        public static Splat.SplatColor Lime { get; }
+        public static Splat.SplatColor LimeGreen { get; }
+        public static Splat.SplatColor Linen { get; }
+        public static Splat.SplatColor Magenta { get; }
+        public static Splat.SplatColor Maroon { get; }
+        public static Splat.SplatColor MediumAquamarine { get; }
+        public static Splat.SplatColor MediumBlue { get; }
+        public static Splat.SplatColor MediumOrchid { get; }
+        public static Splat.SplatColor MediumPurple { get; }
+        public static Splat.SplatColor MediumSeaGreen { get; }
+        public static Splat.SplatColor MediumSlateBlue { get; }
+        public static Splat.SplatColor MediumSpringGreen { get; }
+        public static Splat.SplatColor MediumTurquoise { get; }
+        public static Splat.SplatColor MediumVioletRed { get; }
+        public static Splat.SplatColor MidnightBlue { get; }
+        public static Splat.SplatColor MintCream { get; }
+        public static Splat.SplatColor MistyRose { get; }
+        public static Splat.SplatColor Moccasin { get; }
+        public static Splat.SplatColor NavajoWhite { get; }
+        public static Splat.SplatColor Navy { get; }
+        public static Splat.SplatColor OldLace { get; }
+        public static Splat.SplatColor Olive { get; }
+        public static Splat.SplatColor OliveDrab { get; }
+        public static Splat.SplatColor Orange { get; }
+        public static Splat.SplatColor OrangeRed { get; }
+        public static Splat.SplatColor Orchid { get; }
+        public static Splat.SplatColor PaleGoldenrod { get; }
+        public static Splat.SplatColor PaleGreen { get; }
+        public static Splat.SplatColor PaleTurquoise { get; }
+        public static Splat.SplatColor PaleVioletRed { get; }
+        public static Splat.SplatColor PapayaWhip { get; }
+        public static Splat.SplatColor PeachPuff { get; }
+        public static Splat.SplatColor Peru { get; }
+        public static Splat.SplatColor Pink { get; }
+        public static Splat.SplatColor Plum { get; }
+        public static Splat.SplatColor PowderBlue { get; }
+        public static Splat.SplatColor Purple { get; }
+        public static Splat.SplatColor Red { get; }
+        public static Splat.SplatColor RosyBrown { get; }
+        public static Splat.SplatColor RoyalBlue { get; }
+        public static Splat.SplatColor SaddleBrown { get; }
+        public static Splat.SplatColor Salmon { get; }
+        public static Splat.SplatColor SandyBrown { get; }
+        public static Splat.SplatColor SeaGreen { get; }
+        public static Splat.SplatColor SeaShell { get; }
+        public static Splat.SplatColor Sienna { get; }
+        public static Splat.SplatColor Silver { get; }
+        public static Splat.SplatColor SkyBlue { get; }
+        public static Splat.SplatColor SlateBlue { get; }
+        public static Splat.SplatColor SlateGray { get; }
+        public static Splat.SplatColor Snow { get; }
+        public static Splat.SplatColor SpringGreen { get; }
+        public static Splat.SplatColor SteelBlue { get; }
+        public static Splat.SplatColor Tan { get; }
+        public static Splat.SplatColor Teal { get; }
+        public static Splat.SplatColor Thistle { get; }
+        public static Splat.SplatColor Tomato { get; }
+        public static Splat.SplatColor Transparent { get; }
+        public static Splat.SplatColor Turquoise { get; }
+        public static Splat.SplatColor Violet { get; }
+        public static Splat.SplatColor Wheat { get; }
+        public static Splat.SplatColor White { get; }
+        public static Splat.SplatColor WhiteSmoke { get; }
+        public static Splat.SplatColor Yellow { get; }
+        public static Splat.SplatColor YellowGreen { get; }
+        public bool Equals(Splat.SplatColor other) { }
+        public override bool Equals(object? obj) { }
+        public float GetBrightness() { }
+        public override int GetHashCode() { }
+        public float GetHue() { }
+        public float GetSaturation() { }
+        public uint ToArgb() { }
+        public Splat.KnownColor ToKnownColor() { }
+        public override string ToString() { }
+        public static Splat.SplatColor FromArgb(uint argb) { }
+        public static Splat.SplatColor FromArgb(int alpha, Splat.SplatColor baseColor) { }
+        public static Splat.SplatColor FromArgb(int red, int green, int blue) { }
+        public static Splat.SplatColor FromArgb(int alpha, int red, int green, int blue) { }
+        public static Splat.SplatColor FromKnownColor(Splat.KnownColor color) { }
+        public static Splat.SplatColor FromName(string name) { }
+        public static bool operator !=(Splat.SplatColor left, Splat.SplatColor right) { }
+        public static bool operator ==(Splat.SplatColor left, Splat.SplatColor right) { }
+    }
+    public static class SplatColorExtensions
+    {
+        public static Splat.SplatColor FromNative(this System.Windows.Media.Color value) { }
+        public static System.Windows.Media.Color ToNative(this Splat.SplatColor value) { }
+        public static System.Windows.Media.SolidColorBrush ToNativeBrush(this Splat.SplatColor value) { }
+    }
+}

--- a/src/Splat.Drawing.Tests/Splat.Drawing.Tests.csproj
+++ b/src/Splat.Drawing.Tests/Splat.Drawing.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0-windows;</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000;CA1034</NoWarn>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Splat.Drawing/Platforms/net6/Bitmaps/BitmapMixins.cs
+++ b/src/Splat.Drawing/Platforms/net6/Bitmaps/BitmapMixins.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.Windows.Media.Imaging;
+
+namespace Splat
+{
+    /// <summary>
+    /// Extension methods to assist with dealing with Bitmaps.
+    /// </summary>
+    public static class BitmapMixins
+    {
+        /// <summary>
+        /// Converts <see cref="IBitmap"/> to a native type.
+        /// </summary>
+        /// <param name="value">The bitmap to convert.</param>
+        /// <returns>A <see cref="BitmapSource"/> bitmap.</returns>
+        public static IBitmap FromNative(this BitmapSource value)
+        {
+            return new BitmapSourceBitmap(value);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="BitmapSource"/> to a splat <see cref="IBitmap"/>.
+        /// </summary>
+        /// <param name="value">The native bitmap to convert from.</param>
+        /// <returns>A <see cref="IBitmap"/> bitmap.</returns>
+        public static BitmapSource ToNative(this IBitmap value)
+        {
+            if (value is null)
+            {
+                throw new System.ArgumentNullException(nameof(value));
+            }
+
+            return ((BitmapSourceBitmap)value).Inner ?? throw new InvalidOperationException("The bitmap is not longer valid");
+        }
+    }
+}

--- a/src/Splat.Drawing/Platforms/net6/Bitmaps/BitmapSourceBitmap.cs
+++ b/src/Splat.Drawing/Platforms/net6/Bitmaps/BitmapSourceBitmap.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows.Media.Imaging;
+
+namespace Splat
+{
+    /// <summary>
+    /// A bitmap that wraps a <see cref="BitmapSourceBitmap"/>.
+    /// </summary>
+    internal sealed class BitmapSourceBitmap : IBitmap
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BitmapSourceBitmap"/> class.
+        /// </summary>
+        /// <param name="bitmap">The platform native bitmap we are wrapping.</param>
+        public BitmapSourceBitmap(BitmapSource bitmap)
+        {
+            Inner = bitmap;
+        }
+
+        /// <inheritdoc />
+        public float Width => (float)(Inner?.Width ?? 0);
+
+        /// <inheritdoc />
+        public float Height => (float)(Inner?.Height ?? 0);
+
+        /// <summary>
+        /// Gets the platform <see cref="BitmapSource"/>.
+        /// </summary>
+        public BitmapSource? Inner { get; private set; }
+
+        /// <inheritdoc />
+        public Task Save(CompressedBitmapFormat format, float quality, Stream target)
+        {
+            if (target is null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
+
+            return Task.Run(() =>
+            {
+                var encoder = format == CompressedBitmapFormat.Jpeg ?
+                    new JpegBitmapEncoder() { QualityLevel = (int)(quality * 100.0f) } :
+                    (BitmapEncoder)new PngBitmapEncoder();
+
+                encoder.Frames.Add(BitmapFrame.Create(Inner));
+                encoder.Save(target);
+            });
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Inner = null;
+        }
+    }
+}

--- a/src/Splat.Drawing/Platforms/net6/Bitmaps/PlatformBitmapLoader.cs
+++ b/src/Splat.Drawing/Platforms/net6/Bitmaps/PlatformBitmapLoader.cs
@@ -1,0 +1,92 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace Splat
+{
+    /// <summary>
+    /// A XAML based platform bitmap loader which will load our bitmaps for us.
+    /// </summary>
+    public class PlatformBitmapLoader : IBitmapLoader
+    {
+        /// <inheritdoc />
+        public Task<IBitmap?> Load(Stream sourceStream, float? desiredWidth, float? desiredHeight)
+        {
+            return Task.Run<IBitmap?>(() =>
+            {
+                var ret = new BitmapImage();
+
+                WithInit(ret, source =>
+                {
+                    if (desiredWidth is not null)
+                    {
+                        source.DecodePixelWidth = (int)desiredWidth;
+                    }
+
+                    if (desiredHeight is not null)
+                    {
+                        source.DecodePixelHeight = (int)desiredHeight;
+                    }
+
+                    source.StreamSource = sourceStream;
+                    source.CacheOption = BitmapCacheOption.OnLoad;
+                });
+
+                return new BitmapSourceBitmap(ret);
+            });
+        }
+
+        /// <inheritdoc />
+        public Task<IBitmap?> LoadFromResource(string source, float? desiredWidth, float? desiredHeight)
+        {
+            return Task.Run<IBitmap?>(() =>
+            {
+                var ret = new BitmapImage();
+                WithInit(ret, x =>
+                {
+                    if (desiredWidth is not null)
+                    {
+                        x.DecodePixelWidth = (int)desiredWidth;
+                    }
+
+                    if (desiredHeight is not null)
+                    {
+                        x.DecodePixelHeight = (int)desiredHeight;
+                    }
+
+                    x.UriSource = new Uri(source, UriKind.RelativeOrAbsolute);
+                });
+
+                return new BitmapSourceBitmap(ret);
+            });
+        }
+
+        /// <inheritdoc />
+        public IBitmap Create(float width, float height)
+        {
+            /*
+             * Taken from MSDN:
+             *
+             * The preferred values for pixelFormat are Bgr32 and Pbgra32.
+             * These formats are natively supported and do not require a format conversion.
+             * Other pixelFormat values require a format conversion for each frame update, which reduces performance.
+             */
+            return new BitmapSourceBitmap(new WriteableBitmap((int)width, (int)height, 96, 96, PixelFormats.Pbgra32, null));
+        }
+
+        private static void WithInit(BitmapImage source, Action<BitmapImage> block)
+        {
+            source.BeginInit();
+            block(source);
+            source.EndInit();
+            source.Freeze();
+        }
+    }
+}

--- a/src/Splat.Drawing/Platforms/net6/Colors/ColorExtensions.cs
+++ b/src/Splat.Drawing/Platforms/net6/Colors/ColorExtensions.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows.Media;
+
+namespace Splat
+{
+    /// <summary>
+    /// Provides extension methods for interacting with colors, to and from the XAML colors.
+    /// </summary>
+    public static class ColorExtensions
+    {
+        /// <summary>
+        /// Converts a <see cref="System.Drawing.Color"/> to a XAML native color.
+        /// </summary>
+        /// <param name="value">The System.Drawing.Color to convert.</param>
+        /// <returns>A native XAML color.</returns>
+        public static Color ToNative(this System.Drawing.Color value)
+        {
+            return Color.FromArgb(value.A, value.R, value.G, value.B);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="System.Drawing.Color"/> into the cocoa native <see cref="SolidColorBrush"/>.
+        /// </summary>
+        /// <param name="value">The color to convert.</param>
+        /// <returns>The <see cref="SolidColorBrush"/> generated.</returns>
+        public static SolidColorBrush ToNativeBrush(this System.Drawing.Color value)
+        {
+            var ret = new SolidColorBrush(value.ToNative());
+            ret.Freeze();
+            return ret;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="SolidColorBrush"/> into the XAML <see cref="System.Drawing.Color"/>.
+        /// </summary>
+        /// <param name="value">The color to convert.</param>
+        /// <returns>The <see cref="System.Drawing.Color"/> generated.</returns>
+        public static System.Drawing.Color FromNative(this Color value)
+        {
+            return System.Drawing.Color.FromArgb(value.A, value.R, value.G, value.B);
+        }
+    }
+}

--- a/src/Splat.Drawing/Platforms/net6/Colors/SplatColorExtensions.cs
+++ b/src/Splat.Drawing/Platforms/net6/Colors/SplatColorExtensions.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows.Media;
+
+namespace Splat
+{
+    /// <summary>
+    /// Extension methods associated with the <see cref="SplatColor"/> struct.
+    /// </summary>
+    public static class SplatColorExtensions
+    {
+        /// <summary>
+        /// Converts a <see cref="SplatColor"/> into the XAML <see cref="Color"/>.
+        /// </summary>
+        /// <param name="value">The color to convert.</param>
+        /// <returns>The <see cref="Color"/> generated.</returns>
+        public static Color ToNative(this SplatColor value)
+        {
+            return Color.FromArgb(value.A, value.R, value.G, value.B);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="SplatColor"/> into the XAML <see cref="SolidColorBrush"/>.
+        /// </summary>
+        /// <param name="value">The color to convert.</param>
+        /// <returns>The <see cref="SolidColorBrush"/> generated.</returns>
+        public static SolidColorBrush ToNativeBrush(this SplatColor value)
+        {
+            var ret = new SolidColorBrush(value.ToNative());
+            ret.Freeze();
+            return ret;
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Color"/> into the XAML <see cref="SplatColor"/>.
+        /// </summary>
+        /// <param name="value">The color to convert.</param>
+        /// <returns>The <see cref="SplatColor"/> generated.</returns>
+        public static SplatColor FromNative(this Color value)
+        {
+            return SplatColor.FromArgb(value.A, value.R, value.G, value.B);
+        }
+    }
+}

--- a/src/Splat.Drawing/Platforms/net6/Maths/PointExtensions.cs
+++ b/src/Splat.Drawing/Platforms/net6/Maths/PointExtensions.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows;
+
+namespace Splat
+{
+    /// <summary>
+    /// A set of extension methods which will convert between System.Drawing point's and a native point classes.
+    /// </summary>
+    public static class PointExtensions
+    {
+        /// <summary>
+        /// Convert a <see cref="System.Drawing.Point"/> to the android native <see cref="Point"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>A <see cref="Point"/> of the value.</returns>
+        public static Point ToNative(this System.Drawing.Point value)
+        {
+            return new Point(value.X, value.Y);
+        }
+
+        /// <summary>
+        /// Convert a <see cref="System.Drawing.PointF"/> to the android native <see cref="Point"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>A <see cref="Point"/> of the value.</returns>
+        public static Point ToNative(this System.Drawing.PointF value)
+        {
+            return new Point(value.X, value.Y);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Point"/> to a <see cref="System.Drawing.PointF"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>A <see cref="System.Drawing.PointF"/> of the value.</returns>
+        public static System.Drawing.PointF FromNative(this Point value)
+        {
+            return new((float)value.X, (float)value.Y);
+        }
+    }
+}

--- a/src/Splat.Drawing/Platforms/net6/Maths/RectExtensions.cs
+++ b/src/Splat.Drawing/Platforms/net6/Maths/RectExtensions.cs
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows;
+
+namespace Splat
+{
+    /// <summary>
+    /// A set of extension methods which will convert between System.Drawing rectangle's and a native rectangle classes.
+    /// </summary>
+    public static class RectExtensions
+    {
+        /// <summary>
+        /// Convert a <see cref="System.Drawing.Rectangle"/> to the android native <see cref="Rect"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>A <see cref="Rect"/> of the value.</returns>
+        public static Rect ToNative(this System.Drawing.Rectangle value)
+        {
+            return new Rect(value.X, value.Y, value.Width, value.Height);
+        }
+
+        /// <summary>
+        /// Convert a <see cref="System.Drawing.RectangleF"/> to the android native <see cref="Rect"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>A <see cref="Rect"/> of the value.</returns>
+        public static Rect ToNative(this System.Drawing.RectangleF value)
+        {
+            return new Rect(value.X, value.Y, value.Width, value.Height);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Point"/> to a <see cref="System.Drawing.RectangleF"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>A <see cref="System.Drawing.RectangleF"/> of the value.</returns>
+        public static System.Drawing.RectangleF FromNative(this Rect value)
+        {
+            return new((float)value.X, (float)value.Y, (float)value.Width, (float)value.Height);
+        }
+    }
+}

--- a/src/Splat.Drawing/Platforms/net6/Maths/SizeExtensions.cs
+++ b/src/Splat.Drawing/Platforms/net6/Maths/SizeExtensions.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Windows;
+
+namespace Splat
+{
+    /// <summary>
+    /// A set of extension methods which will convert between System.Drawing size's and a native size classes.
+    /// </summary>
+    public static class SizeExtensions
+    {
+        /// <summary>
+        /// Convert a <see cref="System.Drawing.Size"/> to the android native <see cref="Size"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>A <see cref="Size"/> of the value.</returns>
+        public static Size ToNative(this System.Drawing.Size value)
+        {
+            return new Size(value.Width, value.Height);
+        }
+
+        /// <summary>
+        /// Convert a <see cref="System.Drawing.SizeF"/> to the android native <see cref="Size"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>A <see cref="Size"/> of the value.</returns>
+        public static Size ToNative(this System.Drawing.SizeF value)
+        {
+            return new Size(value.Width, value.Height);
+        }
+
+        /// <summary>
+        /// Converts a <see cref="Size"/> to a <see cref="System.Drawing.SizeF"/>.
+        /// </summary>
+        /// <param name="value">The value to convert.</param>
+        /// <returns>A <see cref="System.Drawing.SizeF"/> of the value.</returns>
+        public static System.Drawing.SizeF FromNative(this Size value)
+        {
+            return new((float)value.Width, (float)value.Height);
+        }
+    }
+}

--- a/src/Splat.Drawing/Splat.Drawing.csproj
+++ b/src/Splat.Drawing/Splat.Drawing.csproj
@@ -1,18 +1,19 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;Xamarin.WatchOS10;tizen40;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;net472;uap10.0.16299;netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;Xamarin.WatchOS10;tizen40;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;net472;uap10.0.16299;netcoreapp3.1;net5.0-windows;net6.0-windows</TargetFrameworks>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>
     <Description>A library to make things cross-platform that should be</Description>
     <PackageId>Splat.Drawing</PackageId>
     <NoWarn>$(NoWarn);1591</NoWarn>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" ($(TargetFramework.StartsWith('netcoreapp3')) or $(TargetFramework.StartsWith('net5')) or $(TargetFramework.StartsWith('net4'))) and '$(OS)' == 'Windows_NT' ">
+  <PropertyGroup Condition=" ($(TargetFramework.StartsWith('netcoreapp3')) or $(TargetFramework.StartsWith('net5')) or $(TargetFramework.StartsWith('net6')) or $(TargetFramework.StartsWith('net4'))) and '$(OS)' == 'Windows_NT' ">
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
@@ -61,6 +62,17 @@
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('net5')) ">
     <Compile Include="Platforms\net5\**\*.cs" />
+
+    <Compile Include="Platforms\TypeForwardedSystemDrawing.cs" />
+    <Compile Include="Platforms\ReflectionStubs.cs" />
+
+    <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+    <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net6')) ">
+    <Compile Include="Platforms\net6\**\*.cs" />
 
     <Compile Include="Platforms\TypeForwardedSystemDrawing.cs" />
     <Compile Include="Platforms\ReflectionStubs.cs" />

--- a/src/Splat.DryIoc.Tests/Splat.DryIoc.Tests.csproj
+++ b/src/Splat.DryIoc.Tests/Splat.DryIoc.Tests.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Splat.DryIoc/Splat.DryIoc.csproj
+++ b/src/Splat.DryIoc/Splat.DryIoc.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1801</NoWarn>
     <Description>DryIoc adapter for Splat</Description>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Exceptionless/Splat.Exceptionless.csproj
+++ b/src/Splat.Exceptionless/Splat.Exceptionless.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <AssemblyName>Splat.Exceptionless</AssemblyName>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>
     <Description>Exceptionless integrations for Splat</Description>
     <PackageId>Splat.Exceptionless</PackageId>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Exceptionless" Version="4.6.2" />

--- a/src/Splat.Log4Net/Splat.Log4Net.csproj
+++ b/src/Splat.Log4Net/Splat.Log4Net.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <AssemblyName>Splat.Log4Net</AssemblyName>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>
     <Description>Log4Net integrations for Splat</Description>
     <PackageId>Splat.Log4Net</PackageId>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/Splat.Microsoft.Extensions.DependencyInjection.Tests.csproj
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/Splat.Microsoft.Extensions.DependencyInjection.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/Splat.Microsoft.Extensions.DependencyInjection.csproj
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/Splat.Microsoft.Extensions.DependencyInjection.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Microsoft.Extensions.Logging/Splat.Microsoft.Extensions.Logging.csproj
+++ b/src/Splat.Microsoft.Extensions.Logging/Splat.Microsoft.Extensions.Logging.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <AssemblyName>Splat.Microsoft.Extensions.Logging</AssemblyName>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>
     <Description>Microsoft Logging Extensions integrations for Splat</Description>
     <PackageId>Splat.Microsoft.Extensions.Logging</PackageId>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />

--- a/src/Splat.NLog/Splat.NLog.csproj
+++ b/src/Splat.NLog/Splat.NLog.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <AssemblyName>Splat.NLog</AssemblyName>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>
     <Description>NLog integrations for Splat</Description>
     <PackageId>Splat.NLog</PackageId>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NLog" Version="4.7.10" />

--- a/src/Splat.Ninject.Tests/Splat.Ninject.Tests.csproj
+++ b/src/Splat.Ninject.Tests/Splat.Ninject.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <IsPackable>false</IsPackable>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Splat.Ninject/Splat.Ninject.csproj
+++ b/src/Splat.Ninject/Splat.Ninject.csproj
@@ -1,11 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <Description>Autofac adapter for Splat</Description>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Prism.Forms/Splat.Prism.Forms.csproj
+++ b/src/Splat.Prism.Forms/Splat.Prism.Forms.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <Description>Prism adapter for Splat including Xamarin Forms adapters.</Description>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Prism.Tests/Splat.Prism.Tests.csproj
+++ b/src/Splat.Prism.Tests/Splat.Prism.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1707;CS1574</NoWarn>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Splat.Prism/Splat.Prism.csproj
+++ b/src/Splat.Prism/Splat.Prism.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <Description>Prism adapter for Splat</Description>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Raygun/Splat.Raygun.csproj
+++ b/src/Splat.Raygun/Splat.Raygun.csproj
@@ -8,8 +8,9 @@
     <Authors>.NET Foundation and Contributors</Authors>
     <Description>Raygun integrations for Splat</Description>
     <PackageId>Splat.Raygun</PackageId>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <Choose>

--- a/src/Splat.Serilog/Splat.Serilog.csproj
+++ b/src/Splat.Serilog/Splat.Serilog.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <AssemblyName>Splat.Serilog</AssemblyName>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>
     <Description>Serilog integrations for Splat</Description>
     <PackageId>Splat.Serilog</PackageId>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.10.0" />

--- a/src/Splat.SimpleInjector.Tests/Splat.SimpleInjector.Tests.csproj
+++ b/src/Splat.SimpleInjector.Tests/Splat.SimpleInjector.Tests.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Splat.SimpleInjector/Splat.SimpleInjector.csproj
+++ b/src/Splat.SimpleInjector/Splat.SimpleInjector.csproj
@@ -1,11 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <Description>SimpleInjector adapter for Splat</Description>
-	  <LangVersion>latest</LangVersion>
+	  <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net6.0.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.net6.0.approved.txt
@@ -1,4 +1,4 @@
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.Drawing.Tests")]
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.Drawing.Tests")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.TestRunner.Android")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.TestRunner.Uwp")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.Tests")]

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.1.approved.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.netcoreapp3.1.approved.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.TestRunner.Android")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.TestRunner.Uwp")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.Tests")]
-[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName="")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.1", FrameworkDisplayName="")]
 namespace Splat
 {
     public class ActionLogger : Splat.ILogger

--- a/src/Splat.Tests/Splat.Tests.csproj
+++ b/src/Splat.Tests/Splat.Tests.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000;CA1034</NoWarn>
-    <LangVersion>latest</LangVersion>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/src/Splat/Splat.csproj
+++ b/src/Splat/Splat.csproj
@@ -1,18 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;</TargetFrameworks>
     <AssemblyName>Splat</AssemblyName>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>
     <Description>A library to make things cross-platform that should be</Description>
     <PackageId>Splat</PackageId>
     <NoWarn>$(NoWarn);1591</NoWarn>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
+    <ProduceReferenceAssembly>True</ProduceReferenceAssembly>
   </PropertyGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net46')) ">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net461')) ">
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 </Project>

--- a/src/Splat/TargetFrameworkExtensions.cs
+++ b/src/Splat/TargetFrameworkExtensions.cs
@@ -29,6 +29,7 @@ namespace Splat
         {
             return frameworkName switch
             {
+                ".NETCoreApp,Version=v6.0" => "net6.0",
                 ".NETCoreApp,Version=v5.0" => "net5.0",
                 ".NETCoreApp,Version=v3.1" => "netcoreapp3.1",
                 ".NETCoreApp,Version=v3.0" => "netcoreapp3.0",


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

feature

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

targets net461, netstandard 2.0 and .net5.0

**What is the new behaviour?**
<!-- If this is a feature change -->

targets net461, netstandard 2.0 and netstandard 2.1

**What might this PR break?**

Compatibility should be maintained

**Please check if the PR fulfils these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

requires VS2022 to run tests