### PR TITLE
fix: fix CI by adding maui check

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -64,6 +64,8 @@ jobs:
         dotnet workload install tvos
         dotnet workload install macos
         dotnet workload install maui
+        dotnet tool install -g Redth.Net.Maui.Check
+        maui-check --non-interactive --fix
 
     - name: Add MSBuild to PATH
       uses: glennawatson/setup-msbuild@v1.0.3


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Build fix


**What is the current behavior?**
net6 failures due to missing openjdk


**What is the new behavior?**
installs and runs the maui check tool that should cover installing openjdk


**What might this PR break?**
n/a


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

