### PR TITLE
Add support for reproducible builds

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -43,11 +43,6 @@
     <PackageReference Include="PublicApiGenerator" Version="10.2.0" />
     <PackageReference Include="DiffEngine" Version="7.3.0" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="0.1.66" PrivateAssets="All"/>
-  </ItemGroup>
-
   
   <ItemGroup Condition="$(IsTestProject)">
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
@@ -56,7 +51,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" /> 
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="0.1.66" PrivateAssets="All"/>
   </ItemGroup>
   
    <PropertyGroup>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -44,6 +44,11 @@
     <PackageReference Include="DiffEngine" Version="7.3.0" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="0.1.66" PrivateAssets="All"/>
+  </ItemGroup>
+
+  
   <ItemGroup Condition="$(IsTestProject)">
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />


### PR DESCRIPTION
Adds support for reproducible builds as required by the .NET Foundation project requirements: https://github.com/dotnet-foundation/projects#eligibility-criteria under the Code subsection.