### PR TITLE
housekeeping: Contributing documentation branch conventions updated

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Before you submit your pull request consider the following guidelines:
     git push origin my-fix-branch
     ```
 
-In GitHub, send a pull request to `splat:develop`.
+In GitHub, send a pull request to `splat:main`.
 
 If we suggest changes, then:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Before you submit your pull request consider the following guidelines:
 * Make your changes in a new git branch:
 
     ```shell
-    git checkout -b my-fix-branch develop
+    git checkout -b my-fix-branch main
     ```
 
 * Create your patch, **including appropriate test cases**.
@@ -101,7 +101,7 @@ If we suggest changes, then:
 If the PR gets too outdated we may ask you to rebase and force push to update the PR:
 
 ```shell
-git rebase master -i
+git rebase main -i
 git push origin my-fix-branch -f
 ```
 
@@ -122,10 +122,10 @@ from the main (upstream) repository:
     git push origin --delete my-fix-branch
     ```
 
-* Check out the master branch:
+* Check out the main branch:
 
     ```shell
-    git checkout master -f
+    git checkout main -f
     ```
 
 * Delete the local branch:
@@ -134,10 +134,10 @@ from the main (upstream) repository:
     git branch -D my-fix-branch
     ```
 
-* Update your master with the latest upstream version:
+* Update your main with the latest upstream version:
 
     ```shell
-    git pull --ff upstream master
+    git pull --ff upstream main
     ```
 
 ## <a name="rules"></a> Coding Rules


### PR DESCRIPTION
**What kind of change does this PR introduce?**
closes #780 by changing references to master and develop to main



**What is the current behavior?**
old gitflow document


**What is the new behavior?**



**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

