### PR TITLE
housekeeping: Enable deterministic builds

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -11,11 +11,14 @@
     <PackageProjectUrl>https://github.com/reactiveui/splat/</PackageProjectUrl>
     <PackageIconUrl>https://github.com/reactiveui/styleguide/blob/master/logo_splat/logo.png?raw=true</PackageIconUrl>
     <PackageDescription>A library to make things cross-platform that should be.</PackageDescription>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <Owners>xanaisbettsx;ghuntley</Owners>
     <PackageTags>drawing;colours;geometry;logging;unit test detection;service location;image handling;portable;xamarin;xamarin ios;xamarin mac;android;monodroid;uwp;net45</PackageTags>
     <PackageReleaseNotes>https://github.com/reactiveui/splat/releases</PackageReleaseNotes>
     <RepositoryUrl>https://github.com/reactiveui/splat</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <IncludePackageReferencesDuringMarkupCompilation>true</IncludePackageReferencesDuringMarkupCompilation>
 	<WarningsAsErrors>nullable</WarningsAsErrors>
 
     <!-- disable sourcelink on mono, to workaround https://github.com/dotnet/sourcelink/issues/155 -->
@@ -32,6 +35,10 @@
   <!-- MonoAndroid doesn't seem to want to allow debugging for maintainers -->
   <PropertyGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
     <DebugType>Full</DebugType>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
   
   <ItemGroup Condition="$(IsTestProject) or $(MSBuildProjectName.Contains('TestRunner'))">


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

housekeeping

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Builds aren't considered deterministic, so it's harder for third parties to verify the source of the package. 

**What is the new behavior?**
<!-- If this is a feature change -->

The following settings are turned on
* EmbedUntrackedSources should be enabled so that compiler-generated source, like AssemblyInfo, are included in the PDB.
* ContinuousIntegrationBuild when GitHub actions are running to indicate to outside users the build was done via a CI server.
* IncludePackageReferencesDuringMarkupCompilation which will allow the Markup Compilation to know about the package references

**What might this PR break?**
Shouldn't break anyone.


