### PR TITLE
Fixes #787 About unnecessary ItemGroup with condition in Splat.csproj

### DIFF
--- a/src/Splat/Splat.csproj
+++ b/src/Splat/Splat.csproj
@@ -1,7 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;net472</TargetFrameworks>
     <AssemblyName>Splat</AssemblyName>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>
@@ -11,5 +10,5 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
+  
 </Project>


### PR DESCRIPTION
Fixes #787
Remove ItemGroup that has conditon with TFM that starts with `net46`in Splat.csproj file. 
Having this condition of TFM net46* is unnecessary, Because defined TargetFrameworks does not contain NET Fx related TFM.