### PR TITLE
housekeeping: add vs2022 update command to bump ci to vs2022 pre 5

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -20,6 +20,7 @@ jobs:
       shell: bash
       run: |
         dotnet tool update -g dotnet-vs
+        vs update preview
         vs modify preview +mobile +desktop +uwp +web
         echo "##vso[task.prependpath]$(vs where preview --prop=InstallationPath)\MSBuild\Current\Bin"
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
CI fix where MAUI requires later version of vs2022

**What is the current behavior?**
ci failing due to requiring 17.0.0-pre.5.0 for maui

**What is the new behavior?**
ci not to fail

**What might this PR break?**

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

