### PR TITLE
fix for Project targeting net5.0 won't build Splat.Drawing

### DIFF
--- a/src/Splat.Drawing/Platforms/ServiceLocationDrawingInitialization.cs
+++ b/src/Splat.Drawing/Platforms/ServiceLocationDrawingInitialization.cs
@@ -23,8 +23,8 @@ namespace Splat
                 throw new ArgumentNullException(nameof(resolver));
             }
 
-#if !NETSTANDARD
-            // not supported in netstandard2.0
+#if !NETSTANDARD && !NET5_0 && !NET6_0
+            // not supported in netstandard2.0 or NET5/6 library
             if (!resolver.HasRegistration(typeof(IBitmapLoader)))
             {
                 resolver.RegisterLazySingleton(() => new PlatformBitmapLoader(), typeof(IBitmapLoader));

--- a/src/Splat.Drawing/Splat.Drawing.csproj
+++ b/src/Splat.Drawing/Splat.Drawing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;Xamarin.WatchOS10;tizen40;netstandard2.0;net6.0-android;net6.0-ios;net6.0-tvos;net6.0-macos</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;Xamarin.WatchOS10;tizen40;netstandard2.0;net5.0;net6.0;net6.0-android;net6.0-ios;net6.0-tvos;net6.0-macos</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;net472;uap10.0.16299;netcoreapp3.1;net5.0-windows;net6.0-windows</TargetFrameworks>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix for #809 

**What is the current behaviour?**
<!-- You can also link to an open issue here. -->

Net5.0 and Net6.0 libraries have no targets

**What is the new behaviour?**
<!-- If this is a feature change -->

Added targets for Net5.0 and Net6.0 libraries

**What might this PR break?**

none expected

**Please check if the PR fulfils these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

