### PR TITLE
breaking: Remove net 5 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Splat currently supports:
 
 [Always Be NuGetting](https://nuget.org/packages/Splat/). Package contains binaries for:
 
-* .NET Framework 4.6.1, .NET Framework 4.7.2, .NET Standard 2.0 and .NET 5.0
+* .NET Framework 4.6.1, .NET Framework 4.7.2, .NET Standard 2.0 and .NET 6.0
   * WPF
   * Windows Forms
   * UWP

--- a/src/Benchmarks/Splat.Benchmarks.csproj
+++ b/src/Benchmarks/Splat.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>

--- a/src/ReactiveUI.DI.Tests/ReactiveUI.DI.Tests.csproj
+++ b/src/ReactiveUI.DI.Tests/ReactiveUI.DI.Tests.csproj
@@ -8,15 +8,6 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="$(TargetFramework.StartsWith('net462'))">
-      <ItemGroup>
-        <!--<Compile Remove="DryIocReactiveUIDependencyTests.cs" />-->
-        <Compile Remove="AutoFacReactiveUIDependencyTests.cs" />
-        <Compile Remove="NinjectReactiveUIDependencyTests.cs" />
-        <Compile Remove="SimpleInjectorReactiveUIDependencyTests.cs" />
-        <ProjectReference Include="..\Splat.DryIoc\Splat.DryIoc.csproj" />
-      </ItemGroup>
-    </When>
     <When Condition="$(TargetFramework.StartsWith('net472'))">
       <ItemGroup>
         <Compile Remove="DryIocReactiveUIDependencyTests.cs" />
@@ -26,16 +17,7 @@
         <ProjectReference Include="..\Splat.Autofac\Splat.Autofac.csproj" />
       </ItemGroup>
     </When>
-    <When Condition="$(TargetFramework.StartsWith('netcoreapp3.1'))">
-      <ItemGroup>
-        <Compile Remove="DryIocReactiveUIDependencyTests.cs" />
-        <Compile Remove="AutoFacReactiveUIDependencyTests.cs" />
-        <!--<Compile Remove="NinjectReactiveUIDependencyTests.cs" />-->
-        <Compile Remove="SimpleInjectorReactiveUIDependencyTests.cs" />
-        <ProjectReference Include="..\Splat.Ninject\Splat.Ninject.csproj" />
-      </ItemGroup>
-    </When>
-    <When Condition="$(TargetFramework.StartsWith('net5.0'))">
+    <When Condition="$(TargetFramework.StartsWith('net6.0'))">
       <ItemGroup>
         <Compile Remove="DryIocReactiveUIDependencyTests.cs" />
         <Compile Remove="AutoFacReactiveUIDependencyTests.cs" />

--- a/src/ReactiveUI.DI.Tests/ReactiveUI.DI.Tests.csproj
+++ b/src/ReactiveUI.DI.Tests/ReactiveUI.DI.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462;net472;netcoreapp3.1;net5.0;</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>

--- a/src/Splat.AppCenter/Splat.AppCenter.csproj
+++ b/src/Splat.AppCenter/Splat.AppCenter.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0-windows10.0.17763.0;net6.0-windows10.0.17763.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0-windows10.0.17763.0</TargetFrameworks>
     <!--need to consider? monoandroid50;xamarin.ios10,uap10.0 -->
     <AssemblyName>Splat.AppCenter</AssemblyName>
     <RootNamespace>Splat</RootNamespace>

--- a/src/Splat.ApplicationInsights/Splat.ApplicationInsights.csproj
+++ b/src/Splat.ApplicationInsights/Splat.ApplicationInsights.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <AssemblyName>Splat.ApplicationInsights</AssemblyName>
     <RootNamespace>Splat</RootNamespace>

--- a/src/Splat.Autofac.Tests/Splat.Autofac.Tests.csproj
+++ b/src/Splat.Autofac.Tests/Splat.Autofac.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows10.0.17763.0;net6.0-windows10.0.17763.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows10.0.17763.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>

--- a/src/Splat.Autofac/Splat.Autofac.csproj
+++ b/src/Splat.Autofac/Splat.Autofac.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <Description>Autofac adapter for Splat</Description>
     <LangVersion>latest</LangVersion>

--- a/src/Splat.Common.Test/Splat.Common.Test.csproj
+++ b/src/Splat.Common.Test/Splat.Common.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA2000</NoWarn>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.DotNet6_0.verified.txt
+++ b/src/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.DotNet6_0.verified.txt
@@ -1,0 +1,450 @@
+﻿[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.Drawing.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.TestRunner.Android")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.TestRunner.Uwp")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.Tests")]
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows7.0")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName="")]
+[assembly: System.Runtime.Versioning.TargetPlatform("Windows7.0")]
+namespace Splat
+{
+    public static class BitmapLoader
+    {
+        public static Splat.IBitmapLoader Current { get; set; }
+    }
+    [System.Serializable]
+    public class BitmapLoaderException : System.Exception
+    {
+        public BitmapLoaderException() { }
+        public BitmapLoaderException(string message) { }
+        protected BitmapLoaderException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) { }
+        public BitmapLoaderException(string message, System.Exception innerException) { }
+    }
+    public static class BitmapMixins
+    {
+        public static Splat.IBitmap FromNative(this System.Windows.Media.Imaging.BitmapSource value) { }
+        public static System.Windows.Media.Imaging.BitmapSource ToNative(this Splat.IBitmap value) { }
+    }
+    public static class ColorExtensions
+    {
+        public static System.Drawing.Color FromNative(this System.Windows.Media.Color value) { }
+        public static System.Windows.Media.Color ToNative(this System.Drawing.Color value) { }
+        public static System.Windows.Media.SolidColorBrush ToNativeBrush(this System.Drawing.Color value) { }
+    }
+    public enum CompressedBitmapFormat
+    {
+        Png = 0,
+        Jpeg = 1,
+    }
+    public class DefaultPlatformModeDetector : Splat.IPlatformModeDetector
+    {
+        public DefaultPlatformModeDetector() { }
+        public bool? InDesignMode() { }
+    }
+    public interface IBitmap : System.IDisposable
+    {
+        float Height { get; }
+        float Width { get; }
+        System.Threading.Tasks.Task Save(Splat.CompressedBitmapFormat format, float quality, System.IO.Stream target);
+    }
+    public interface IBitmapLoader
+    {
+        Splat.IBitmap? Create(float width, float height);
+        System.Threading.Tasks.Task<Splat.IBitmap?> Load(System.IO.Stream sourceStream, float? desiredWidth, float? desiredHeight);
+        System.Threading.Tasks.Task<Splat.IBitmap?> LoadFromResource(string source, float? desiredWidth, float? desiredHeight);
+    }
+    public interface IPlatformModeDetector
+    {
+        bool? InDesignMode();
+    }
+    public enum KnownColor
+    {
+        Empty = 0,
+        ActiveBorder = 1,
+        ActiveCaption = 2,
+        ActiveCaptionText = 3,
+        AppWorkspace = 4,
+        Control = 5,
+        ControlDark = 6,
+        ControlDarkDark = 7,
+        ControlLight = 8,
+        ControlLightLight = 9,
+        ControlText = 10,
+        Desktop = 11,
+        GrayText = 12,
+        Highlight = 13,
+        HighlightText = 14,
+        HotTrack = 15,
+        InactiveBorder = 16,
+        InactiveCaption = 17,
+        InactiveCaptionText = 18,
+        Info = 19,
+        InfoText = 20,
+        Menu = 21,
+        MenuText = 22,
+        ScrollBar = 23,
+        Window = 24,
+        WindowFrame = 25,
+        WindowText = 26,
+        Transparent = 27,
+        AliceBlue = 28,
+        AntiqueWhite = 29,
+        Aqua = 30,
+        Aquamarine = 31,
+        Azure = 32,
+        Beige = 33,
+        Bisque = 34,
+        Black = 35,
+        BlanchedAlmond = 36,
+        Blue = 37,
+        BlueViolet = 38,
+        Brown = 39,
+        BurlyWood = 40,
+        CadetBlue = 41,
+        Chartreuse = 42,
+        Chocolate = 43,
+        Coral = 44,
+        CornflowerBlue = 45,
+        Cornsilk = 46,
+        Crimson = 47,
+        Cyan = 48,
+        DarkBlue = 49,
+        DarkCyan = 50,
+        DarkGoldenrod = 51,
+        DarkGray = 52,
+        DarkGreen = 53,
+        DarkKhaki = 54,
+        DarkMagenta = 55,
+        DarkOliveGreen = 56,
+        DarkOrange = 57,
+        DarkOrchid = 58,
+        DarkRed = 59,
+        DarkSalmon = 60,
+        DarkSeaGreen = 61,
+        DarkSlateBlue = 62,
+        DarkSlateGray = 63,
+        DarkTurquoise = 64,
+        DarkViolet = 65,
+        DeepPink = 66,
+        DeepSkyBlue = 67,
+        DimGray = 68,
+        DodgerBlue = 69,
+        Firebrick = 70,
+        FloralWhite = 71,
+        ForestGreen = 72,
+        Fuchsia = 73,
+        Gainsboro = 74,
+        GhostWhite = 75,
+        Gold = 76,
+        Goldenrod = 77,
+        Gray = 78,
+        Green = 79,
+        GreenYellow = 80,
+        Honeydew = 81,
+        HotPink = 82,
+        IndianRed = 83,
+        Indigo = 84,
+        Ivory = 85,
+        Khaki = 86,
+        Lavender = 87,
+        LavenderBlush = 88,
+        LawnGreen = 89,
+        LemonChiffon = 90,
+        LightBlue = 91,
+        LightCoral = 92,
+        LightCyan = 93,
+        LightGoldenrodYellow = 94,
+        LightGray = 95,
+        LightGreen = 96,
+        LightPink = 97,
+        LightSalmon = 98,
+        LightSeaGreen = 99,
+        LightSkyBlue = 100,
+        LightSlateGray = 101,
+        LightSteelBlue = 102,
+        LightYellow = 103,
+        Lime = 104,
+        LimeGreen = 105,
+        Linen = 106,
+        Magenta = 107,
+        Maroon = 108,
+        MediumAquamarine = 109,
+        MediumBlue = 110,
+        MediumOrchid = 111,
+        MediumPurple = 112,
+        MediumSeaGreen = 113,
+        MediumSlateBlue = 114,
+        MediumSpringGreen = 115,
+        MediumTurquoise = 116,
+        MediumVioletRed = 117,
+        MidnightBlue = 118,
+        MintCream = 119,
+        MistyRose = 120,
+        Moccasin = 121,
+        NavajoWhite = 122,
+        Navy = 123,
+        OldLace = 124,
+        Olive = 125,
+        OliveDrab = 126,
+        Orange = 127,
+        OrangeRed = 128,
+        Orchid = 129,
+        PaleGoldenrod = 130,
+        PaleGreen = 131,
+        PaleTurquoise = 132,
+        PaleVioletRed = 133,
+        PapayaWhip = 134,
+        PeachPuff = 135,
+        Peru = 136,
+        Pink = 137,
+        Plum = 138,
+        PowderBlue = 139,
+        Purple = 140,
+        Red = 141,
+        RosyBrown = 142,
+        RoyalBlue = 143,
+        SaddleBrown = 144,
+        Salmon = 145,
+        SandyBrown = 146,
+        SeaGreen = 147,
+        SeaShell = 148,
+        Sienna = 149,
+        Silver = 150,
+        SkyBlue = 151,
+        SlateBlue = 152,
+        SlateGray = 153,
+        Snow = 154,
+        SpringGreen = 155,
+        SteelBlue = 156,
+        Tan = 157,
+        Teal = 158,
+        Thistle = 159,
+        Tomato = 160,
+        Turquoise = 161,
+        Violet = 162,
+        Wheat = 163,
+        White = 164,
+        WhiteSmoke = 165,
+        Yellow = 166,
+        YellowGreen = 167,
+        ButtonFace = 168,
+        ButtonHighlight = 169,
+        ButtonShadow = 170,
+        GradientActiveCaption = 171,
+        GradientInactiveCaption = 172,
+        MenuBar = 173,
+        MenuHighlight = 174,
+    }
+    public class PlatformBitmapLoader : Splat.IBitmapLoader
+    {
+        public PlatformBitmapLoader() { }
+        public Splat.IBitmap Create(float width, float height) { }
+        public System.Threading.Tasks.Task<Splat.IBitmap?> Load(System.IO.Stream sourceStream, float? desiredWidth, float? desiredHeight) { }
+        public System.Threading.Tasks.Task<Splat.IBitmap?> LoadFromResource(string source, float? desiredWidth, float? desiredHeight) { }
+    }
+    public static class PlatformModeDetector
+    {
+        public static bool InDesignMode() { }
+        public static void OverrideModeDetector(Splat.IPlatformModeDetector modeDetector) { }
+    }
+    public static class PointExtensions
+    {
+        public static System.Drawing.PointF FromNative(this System.Windows.Point value) { }
+        public static System.Windows.Point ToNative(this System.Drawing.Point value) { }
+        public static System.Windows.Point ToNative(this System.Drawing.PointF value) { }
+    }
+    public static class RectExtensions
+    {
+        public static System.Drawing.RectangleF FromNative(this System.Windows.Rect value) { }
+        public static System.Windows.Rect ToNative(this System.Drawing.Rectangle value) { }
+        public static System.Windows.Rect ToNative(this System.Drawing.RectangleF value) { }
+    }
+    public static class ServiceLocationDrawingInitialization
+    {
+        public static void RegisterPlatformBitmapLoader(this Splat.IMutableDependencyResolver resolver) { }
+    }
+    public static class SizeExtensions
+    {
+        public static System.Drawing.SizeF FromNative(this System.Windows.Size value) { }
+        public static System.Windows.Size ToNative(this System.Drawing.Size value) { }
+        public static System.Windows.Size ToNative(this System.Drawing.SizeF value) { }
+    }
+    [System.Runtime.Serialization.DataContract]
+    public struct SplatColor : System.IEquatable<Splat.SplatColor>
+    {
+        public byte A { get; }
+        public byte B { get; }
+        public byte G { get; }
+        public bool IsEmpty { get; }
+        public bool IsKnownColor { get; }
+        public bool IsNamedColor { get; }
+        public bool IsSystemColor { get; }
+        public string Name { get; }
+        public byte R { get; }
+        public static Splat.SplatColor AliceBlue { get; }
+        public static Splat.SplatColor AntiqueWhite { get; }
+        public static Splat.SplatColor Aqua { get; }
+        public static Splat.SplatColor Aquamarine { get; }
+        public static Splat.SplatColor Azure { get; }
+        public static Splat.SplatColor Beige { get; }
+        public static Splat.SplatColor Bisque { get; }
+        public static Splat.SplatColor Black { get; }
+        public static Splat.SplatColor BlanchedAlmond { get; }
+        public static Splat.SplatColor Blue { get; }
+        public static Splat.SplatColor BlueViolet { get; }
+        public static Splat.SplatColor Brown { get; }
+        public static Splat.SplatColor BurlyWood { get; }
+        public static Splat.SplatColor CadetBlue { get; }
+        public static Splat.SplatColor Chartreuse { get; }
+        public static Splat.SplatColor Chocolate { get; }
+        public static Splat.SplatColor Coral { get; }
+        public static Splat.SplatColor CornflowerBlue { get; }
+        public static Splat.SplatColor Cornsilk { get; }
+        public static Splat.SplatColor Crimson { get; }
+        public static Splat.SplatColor Cyan { get; }
+        public static Splat.SplatColor DarkBlue { get; }
+        public static Splat.SplatColor DarkCyan { get; }
+        public static Splat.SplatColor DarkGoldenrod { get; }
+        public static Splat.SplatColor DarkGray { get; }
+        public static Splat.SplatColor DarkGreen { get; }
+        public static Splat.SplatColor DarkKhaki { get; }
+        public static Splat.SplatColor DarkMagenta { get; }
+        public static Splat.SplatColor DarkOliveGreen { get; }
+        public static Splat.SplatColor DarkOrange { get; }
+        public static Splat.SplatColor DarkOrchid { get; }
+        public static Splat.SplatColor DarkRed { get; }
+        public static Splat.SplatColor DarkSalmon { get; }
+        public static Splat.SplatColor DarkSeaGreen { get; }
+        public static Splat.SplatColor DarkSlateBlue { get; }
+        public static Splat.SplatColor DarkSlateGray { get; }
+        public static Splat.SplatColor DarkTurquoise { get; }
+        public static Splat.SplatColor DarkViolet { get; }
+        public static Splat.SplatColor DeepPink { get; }
+        public static Splat.SplatColor DeepSkyBlue { get; }
+        public static Splat.SplatColor DimGray { get; }
+        public static Splat.SplatColor DodgerBlue { get; }
+        public static Splat.SplatColor Empty { get; }
+        public static Splat.SplatColor Firebrick { get; }
+        public static Splat.SplatColor FloralWhite { get; }
+        public static Splat.SplatColor ForestGreen { get; }
+        public static Splat.SplatColor Fuchsia { get; }
+        public static Splat.SplatColor Gainsboro { get; }
+        public static Splat.SplatColor GhostWhite { get; }
+        public static Splat.SplatColor Gold { get; }
+        public static Splat.SplatColor Goldenrod { get; }
+        public static Splat.SplatColor Gray { get; }
+        public static Splat.SplatColor Green { get; }
+        public static Splat.SplatColor GreenYellow { get; }
+        public static Splat.SplatColor Honeydew { get; }
+        public static Splat.SplatColor HotPink { get; }
+        public static Splat.SplatColor IndianRed { get; }
+        public static Splat.SplatColor Indigo { get; }
+        public static Splat.SplatColor Ivory { get; }
+        public static Splat.SplatColor Khaki { get; }
+        public static Splat.SplatColor Lavender { get; }
+        public static Splat.SplatColor LavenderBlush { get; }
+        public static Splat.SplatColor LawnGreen { get; }
+        public static Splat.SplatColor LemonChiffon { get; }
+        public static Splat.SplatColor LightBlue { get; }
+        public static Splat.SplatColor LightCoral { get; }
+        public static Splat.SplatColor LightCyan { get; }
+        public static Splat.SplatColor LightGoldenrodYellow { get; }
+        public static Splat.SplatColor LightGray { get; }
+        public static Splat.SplatColor LightGreen { get; }
+        public static Splat.SplatColor LightPink { get; }
+        public static Splat.SplatColor LightSalmon { get; }
+        public static Splat.SplatColor LightSeaGreen { get; }
+        public static Splat.SplatColor LightSkyBlue { get; }
+        public static Splat.SplatColor LightSlateGray { get; }
+        public static Splat.SplatColor LightSteelBlue { get; }
+        public static Splat.SplatColor LightYellow { get; }
+        public static Splat.SplatColor Lime { get; }
+        public static Splat.SplatColor LimeGreen { get; }
+        public static Splat.SplatColor Linen { get; }
+        public static Splat.SplatColor Magenta { get; }
+        public static Splat.SplatColor Maroon { get; }
+        public static Splat.SplatColor MediumAquamarine { get; }
+        public static Splat.SplatColor MediumBlue { get; }
+        public static Splat.SplatColor MediumOrchid { get; }
+        public static Splat.SplatColor MediumPurple { get; }
+        public static Splat.SplatColor MediumSeaGreen { get; }
+        public static Splat.SplatColor MediumSlateBlue { get; }
+        public static Splat.SplatColor MediumSpringGreen { get; }
+        public static Splat.SplatColor MediumTurquoise { get; }
+        public static Splat.SplatColor MediumVioletRed { get; }
+        public static Splat.SplatColor MidnightBlue { get; }
+        public static Splat.SplatColor MintCream { get; }
+        public static Splat.SplatColor MistyRose { get; }
+        public static Splat.SplatColor Moccasin { get; }
+        public static Splat.SplatColor NavajoWhite { get; }
+        public static Splat.SplatColor Navy { get; }
+        public static Splat.SplatColor OldLace { get; }
+        public static Splat.SplatColor Olive { get; }
+        public static Splat.SplatColor OliveDrab { get; }
+        public static Splat.SplatColor Orange { get; }
+        public static Splat.SplatColor OrangeRed { get; }
+        public static Splat.SplatColor Orchid { get; }
+        public static Splat.SplatColor PaleGoldenrod { get; }
+        public static Splat.SplatColor PaleGreen { get; }
+        public static Splat.SplatColor PaleTurquoise { get; }
+        public static Splat.SplatColor PaleVioletRed { get; }
+        public static Splat.SplatColor PapayaWhip { get; }
+        public static Splat.SplatColor PeachPuff { get; }
+        public static Splat.SplatColor Peru { get; }
+        public static Splat.SplatColor Pink { get; }
+        public static Splat.SplatColor Plum { get; }
+        public static Splat.SplatColor PowderBlue { get; }
+        public static Splat.SplatColor Purple { get; }
+        public static Splat.SplatColor Red { get; }
+        public static Splat.SplatColor RosyBrown { get; }
+        public static Splat.SplatColor RoyalBlue { get; }
+        public static Splat.SplatColor SaddleBrown { get; }
+        public static Splat.SplatColor Salmon { get; }
+        public static Splat.SplatColor SandyBrown { get; }
+        public static Splat.SplatColor SeaGreen { get; }
+        public static Splat.SplatColor SeaShell { get; }
+        public static Splat.SplatColor Sienna { get; }
+        public static Splat.SplatColor Silver { get; }
+        public static Splat.SplatColor SkyBlue { get; }
+        public static Splat.SplatColor SlateBlue { get; }
+        public static Splat.SplatColor SlateGray { get; }
+        public static Splat.SplatColor Snow { get; }
+        public static Splat.SplatColor SpringGreen { get; }
+        public static Splat.SplatColor SteelBlue { get; }
+        public static Splat.SplatColor Tan { get; }
+        public static Splat.SplatColor Teal { get; }
+        public static Splat.SplatColor Thistle { get; }
+        public static Splat.SplatColor Tomato { get; }
+        public static Splat.SplatColor Transparent { get; }
+        public static Splat.SplatColor Turquoise { get; }
+        public static Splat.SplatColor Violet { get; }
+        public static Splat.SplatColor Wheat { get; }
+        public static Splat.SplatColor White { get; }
+        public static Splat.SplatColor WhiteSmoke { get; }
+        public static Splat.SplatColor Yellow { get; }
+        public static Splat.SplatColor YellowGreen { get; }
+        public bool Equals(Splat.SplatColor other) { }
+        public override bool Equals(object? obj) { }
+        public float GetBrightness() { }
+        public override int GetHashCode() { }
+        public float GetHue() { }
+        public float GetSaturation() { }
+        public uint ToArgb() { }
+        public Splat.KnownColor ToKnownColor() { }
+        public override string ToString() { }
+        public static Splat.SplatColor FromArgb(uint argb) { }
+        public static Splat.SplatColor FromArgb(int alpha, Splat.SplatColor baseColor) { }
+        public static Splat.SplatColor FromArgb(int red, int green, int blue) { }
+        public static Splat.SplatColor FromArgb(int alpha, int red, int green, int blue) { }
+        public static Splat.SplatColor FromKnownColor(Splat.KnownColor color) { }
+        public static Splat.SplatColor FromName(string name) { }
+        public static bool operator !=(Splat.SplatColor left, Splat.SplatColor right) { }
+        public static bool operator ==(Splat.SplatColor left, Splat.SplatColor right) { }
+    }
+    public static class SplatColorExtensions
+    {
+        public static Splat.SplatColor FromNative(this System.Windows.Media.Color value) { }
+        public static System.Windows.Media.Color ToNative(this Splat.SplatColor value) { }
+        public static System.Windows.Media.SolidColorBrush ToNativeBrush(this Splat.SplatColor value) { }
+    }
+}

--- a/src/Splat.Drawing.Tests/Splat.Drawing.Tests.csproj
+++ b/src/Splat.Drawing.Tests/Splat.Drawing.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000;CA1034</NoWarn>
     <LangVersion>latest</LangVersion>

--- a/src/Splat.Drawing/Splat.Drawing.csproj
+++ b/src/Splat.Drawing/Splat.Drawing.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;Xamarin.WatchOS10;tizen40;netstandard2.0;net5.0;net6.0;net6.0-android;net6.0-ios;net6.0-tvos;net6.0-macos</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;net472;uap10.0.16299;netcoreapp3.1;net5.0-windows;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;Xamarin.WatchOS10;tizen40;netstandard2.0;net6.0;net6.0-android;net6.0-ios;net6.0-tvos;net6.0-macos</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;net472;uap10.0.16299;net6.0-windows</TargetFrameworks>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>
     <Description>A library to make things cross-platform that should be</Description>

--- a/src/Splat.DryIoc.Tests/Splat.DryIoc.Tests.csproj
+++ b/src/Splat.DryIoc.Tests/Splat.DryIoc.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/Splat.DryIoc/Splat.DryIoc.csproj
+++ b/src/Splat.DryIoc/Splat.DryIoc.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1801</NoWarn>
     <Description>DryIoc adapter for Splat</Description>

--- a/src/Splat.Exceptionless/Splat.Exceptionless.csproj
+++ b/src/Splat.Exceptionless/Splat.Exceptionless.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <AssemblyName>Splat.Exceptionless</AssemblyName>
     <RootNamespace>Splat</RootNamespace>

--- a/src/Splat.Log4Net/Splat.Log4Net.csproj
+++ b/src/Splat.Log4Net/Splat.Log4Net.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <AssemblyName>Splat.Log4Net</AssemblyName>
     <RootNamespace>Splat</RootNamespace>

--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/Splat.Microsoft.Extensions.DependencyInjection.Tests.csproj
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/Splat.Microsoft.Extensions.DependencyInjection.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
@@ -46,7 +46,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
         /// Gets the internal Microsoft conainer,
         /// or build new if this instance was not initialized with one.
         /// </summary>
-        protected virtual IServiceProvider ServiceProvider
+        protected virtual IServiceProvider? ServiceProvider
         {
             get
             {
@@ -54,7 +54,7 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
                 {
                     if (_serviceProvider is null)
                     {
-                        _serviceProvider = _serviceCollection.BuildServiceProvider();
+                        _serviceProvider = _serviceCollection?.BuildServiceProvider();
                     }
 
                     return _serviceProvider;
@@ -88,6 +88,11 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
         /// <inheritdoc />
         public virtual IEnumerable<object> GetServices(Type? serviceType, string? contract = null)
         {
+            if (ServiceProvider is null)
+            {
+                throw new InvalidOperationException("The ServiceProvider is null.");
+            }
+
             var isNull = serviceType is null;
             if (serviceType is null)
             {
@@ -323,6 +328,11 @@ namespace Splat.Microsoft.Extensions.DependencyInjection
         private ContractDictionary? GetContractDictionary(Type serviceType, bool createIfNotExists)
         {
             var dicType = GetDictionaryType(serviceType);
+
+            if (ServiceProvider is null)
+            {
+                throw new InvalidOperationException("The ServiceProvider is null.");
+            }
 
             if (_isImmutable)
             {

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/Splat.Microsoft.Extensions.DependencyInjection.csproj
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/Splat.Microsoft.Extensions.DependencyInjection.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/Splat.Microsoft.Extensions.DependencyInjection.csproj
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/Splat.Microsoft.Extensions.DependencyInjection.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Splat.Microsoft.Extensions.Logging/Splat.Microsoft.Extensions.Logging.csproj
+++ b/src/Splat.Microsoft.Extensions.Logging/Splat.Microsoft.Extensions.Logging.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <AssemblyName>Splat.Microsoft.Extensions.Logging</AssemblyName>
     <RootNamespace>Splat</RootNamespace>

--- a/src/Splat.NLog/Splat.NLog.csproj
+++ b/src/Splat.NLog/Splat.NLog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <AssemblyName>Splat.NLog</AssemblyName>
     <RootNamespace>Splat</RootNamespace>

--- a/src/Splat.Ninject.Tests/Splat.Ninject.Tests.csproj
+++ b/src/Splat.Ninject.Tests/Splat.Ninject.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>

--- a/src/Splat.Ninject/Splat.Ninject.csproj
+++ b/src/Splat.Ninject/Splat.Ninject.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <Description>Autofac adapter for Splat</Description>
     <LangVersion>latest</LangVersion>

--- a/src/Splat.Prism.Forms/Splat.Prism.Forms.csproj
+++ b/src/Splat.Prism.Forms/Splat.Prism.Forms.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <Description>Prism adapter for Splat including Xamarin Forms adapters.</Description>
     <LangVersion>latest</LangVersion>

--- a/src/Splat.Prism.Tests/Splat.Prism.Tests.csproj
+++ b/src/Splat.Prism.Tests/Splat.Prism.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1707;CS1574</NoWarn>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/Splat.Prism/Splat.Prism.csproj
+++ b/src/Splat.Prism/Splat.Prism.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <Description>Prism adapter for Splat</Description>
     <LangVersion>latest</LangVersion>

--- a/src/Splat.Raygun/Splat.Raygun.csproj
+++ b/src/Splat.Raygun/Splat.Raygun.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <AssemblyName>Splat.Raygun</AssemblyName>
     <RootNamespace>Splat</RootNamespace>

--- a/src/Splat.Serilog/Splat.Serilog.csproj
+++ b/src/Splat.Serilog/Splat.Serilog.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <AssemblyName>Splat.Serilog</AssemblyName>
     <RootNamespace>Splat</RootNamespace>

--- a/src/Splat.SimpleInjector.Tests/Splat.SimpleInjector.Tests.csproj
+++ b/src/Splat.SimpleInjector.Tests/Splat.SimpleInjector.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/Splat.SimpleInjector/Splat.SimpleInjector.csproj
+++ b/src/Splat.SimpleInjector/Splat.SimpleInjector.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461</TargetFrameworks>
     <Description>SimpleInjector adapter for Splat</Description>
 	  <LangVersion>latest</LangVersion>

--- a/src/Splat.TestRunner.Android/Splat.TestRunner.Android.csproj
+++ b/src/Splat.TestRunner.Android/Splat.TestRunner.Android.csproj
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <CopyNuGetImplementations>true</CopyNuGetImplementations>
     <NoStdLib>false</NoStdLib>

--- a/src/Splat.Tests/Splat.Tests.csproj
+++ b/src/Splat.Tests/Splat.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0-windows10.0.17763.0;net6.0-windows10.0.17763.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000;CA1034</NoWarn>
     <LangVersion>latest</LangVersion>
     <LangVersion>latest</LangVersion>

--- a/src/Splat/Splat.csproj
+++ b/src/Splat/Splat.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AssemblyName>Splat</AssemblyName>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>

--- a/src/Splat/TargetFrameworkExtensions.cs
+++ b/src/Splat/TargetFrameworkExtensions.cs
@@ -29,6 +29,7 @@ namespace Splat
         {
             return frameworkName switch
             {
+                ".NETCoreApp,Version=v6.0" => "net6.0",
                 ".NETCoreApp,Version=v5.0" => "net5.0",
                 ".NETCoreApp,Version=v3.1" => "netcoreapp3.1",
                 ".NETCoreApp,Version=v3.0" => "netcoreapp3.0",


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
breaking change


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
net 5 is supported, but increasing libraries coming from Microsoft don't support net5 anymore. Despite support still existing for another 6 months. We have made the decision to remove support early.


**What is the new behavior?**
<!-- If this is a feature change -->
Have netstandard and net6 as targets.


**What might this PR break?**
Uses using net5. Recommend upgrading to net 6


**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**:

