### PR TITLE
housekeeping: clean up of cocoa null ref check error in build

### DIFF
--- a/src/Splat.Drawing/Platforms/Cocoa/Bitmaps/PlatformBitmapLoader.cs
+++ b/src/Splat.Drawing/Platforms/Cocoa/Bitmaps/PlatformBitmapLoader.cs
@@ -36,6 +36,11 @@ namespace Splat
             {
                 try
                 {
+                    if (data is null)
+                    {
+                        throw new InvalidOperationException("Failed to load stream");
+                    }
+
                     var bitmap = UIImage.LoadFromData(data);
                     if (bitmap is null)
                     {
@@ -46,13 +51,28 @@ namespace Splat
                 }
                 catch (Exception ex)
                 {
-                    LogHost.Default.Debug(ex, "Unable to parse the known colour name.");
+                    LogHost.Default.Debug(ex, "Unable to parse bitmap from byte stream.");
                     tcs.TrySetException(ex);
                 }
             });
 #else
-            tcs.TrySetResult(new CocoaBitmap(new UIImage(data)));
+
+            try
+            {
+                if (data is null)
+                {
+                    throw new InvalidOperationException("Failed to load stream");
+                }
+
+                tcs.TrySetResult(new CocoaBitmap(new UIImage(data)));
+            }
+            catch (Exception ex)
+            {
+                LogHost.Default.Debug(ex, "Unable to parse bitmap from byte stream.");
+                tcs.TrySetException(ex);
+            }
 #endif
+
             return tcs.Task;
         }
 
@@ -76,7 +96,7 @@ namespace Splat
                 }
                 catch (Exception ex)
                 {
-                    LogHost.Default.Debug(ex, "Unable to parse the known colour name.");
+                    LogHost.Default.Debug(ex, "Unable to parse bitmap from resource.");
                     tcs.TrySetException(ex);
                 }
             });
@@ -95,6 +115,7 @@ namespace Splat
                 }
                 catch (Exception ex)
                 {
+                    LogHost.Default.Debug(ex, "Unable to parse bitmap from resource.");
                     tcs.TrySetException(ex);
                 }
             });


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
fixes CI failure that is blocking PR's



**What is the current behavior?**
missing a null check on parsed stream


**What is the new behavior?**
null check on parsed stream



**What might this PR break?**
n/a


**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

