### PR TITLE
Fix DryIOC dependencies being created twice

### DIFF
--- a/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
+++ b/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
@@ -266,5 +266,29 @@ namespace Splat.DryIoc.Tests
 
             vmOne.Should().NotBeNull();
         }
+
+        /// <summary>
+        /// DryIoc dependency resolver should create a resolved object only once when resolving.
+        /// </summary>
+        [Fact]
+        public void DryIocDependencyResolver_Should_Create_Once_When_Resolving()
+        {
+            var container = new Container();
+            var count = 0;
+            container.RegisterDelegate(() =>
+            {
+                count++;
+                return new ViewModelOne();
+            });
+
+            var resolver = new DryIocDependencyResolver(container);
+
+            // Imitate a call to Locator.Current.GetService<ViewModelOne>()
+            var vms = resolver.GetServices(typeof(ViewModelOne));
+            count.Should().Be(1);
+            var vmOne = vms.LastOrDefault();
+            vmOne.Should().NotBeNull();
+            count.Should().Be(1);
+        }
     }
 }

--- a/src/Splat.DryIoc/DryIocDependencyResolver.cs
+++ b/src/Splat.DryIoc/DryIocDependencyResolver.cs
@@ -43,19 +43,19 @@ namespace Splat.DryIoc
             }
 
             var key = (serviceType, contract ?? string.Empty);
-            var registeredinSplat = _container.ResolveMany(serviceType, serviceKey: key).Select(x => isNull ? ((NullServiceType)x).Factory()! : x);
+            var registeredinSplat = _container.ResolveMany(serviceType, behavior: ResolveManyBehavior.AsFixedArray, serviceKey: key).Select(x => isNull ? ((NullServiceType)x).Factory()! : x);
             if (registeredinSplat.Any())
             {
                 return registeredinSplat;
             }
 
-            var registeredWithContract = _container.ResolveMany(serviceType, serviceKey: contract).Select(x => isNull ? ((NullServiceType)x).Factory()! : x);
+            var registeredWithContract = _container.ResolveMany(serviceType, behavior: ResolveManyBehavior.AsFixedArray, serviceKey: contract).Select(x => isNull ? ((NullServiceType)x).Factory()! : x);
             if (registeredWithContract.Any())
             {
                 return registeredWithContract;
             }
 
-            return _container.ResolveMany(serviceType).Select(x => isNull ? ((NullServiceType)x).Factory()! : x);
+            return _container.ResolveMany(serviceType, behavior: ResolveManyBehavior.AsFixedArray).Select(x => isNull ? ((NullServiceType)x).Factory()! : x);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
The optional `behavior` parameter is set on DryIoCs `ResolveMany` to ensure the dependencies are actually only resolved once and not every time the Enumerable resulting from the `ResolveMany` call is evaluated.
<!-- Bug fix, feature, docs update, ... -->



**What is the current behavior?**
Fix #890, possibly fix #889
<!-- You can also link to an open issue here. -->



**What is the new behavior?**
Dependencies are resolved as a fixed array the first time the DependencyResolver uses `ResolveMany`.
<!-- If this is a feature change -->



**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

