### PR TITLE
feature: add mac catalyst targets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -157,6 +157,7 @@ dotnet_diagnostic.AvoidAsyncVoid.severity = suggestion
 dotnet_diagnostic.CA1000.severity = none
 dotnet_diagnostic.CA1001.severity = error
 dotnet_diagnostic.CA1009.severity = error
+dotnet_diagnostic.CA1014.severity = none
 dotnet_diagnostic.CA1016.severity = error
 dotnet_diagnostic.CA1030.severity = none
 dotnet_diagnostic.CA1031.severity = none

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -48,7 +48,7 @@
     <PackageReference Include="FluentAssertions" Version="6.5.1" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="5.0.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
-    <PackageReference Include="Verify.Xunit" Version="16.4.3" />
+    <PackageReference Include="Verify.Xunit" Version="16.4.4" />
   </ItemGroup>
 
   <ItemGroup Condition="$(IsTestProject)">

--- a/src/Directory.build.targets
+++ b/src/Directory.build.targets
@@ -38,6 +38,9 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-tvos'))">
     <DefineConstants>$(DefineConstants);MONO;UIKIT;COCOA;TVOS</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net6.0-maccatalyst'))">
+    <DefineConstants>$(DefineConstants);MONO;UIKIT;COCOA;MACCATALYST</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('Xamarin.WatchOS'))">
     <DefineConstants>$(DefineConstants);MONO;UIKIT;COCOA</DefineConstants>
   </PropertyGroup>

--- a/src/Splat.Drawing/Platforms/WinRT/Bitmaps/PlatformBitmapLoader.cs
+++ b/src/Splat.Drawing/Platforms/WinRT/Bitmaps/PlatformBitmapLoader.cs
@@ -54,7 +54,7 @@ namespace Splat
                     using (var bmpStream = bmp.PixelBuffer.AsStream())
                     {
                         bmpStream.Seek(0, SeekOrigin.Begin);
-                        bmpStream.Write(pixels, 0, (int)bmpStream.Length);
+                        await bmpStream.WriteAsync(pixels, 0, (int)bmpStream.Length);
                         return (IBitmap?)new WriteableBitmapImageBitmap(bmp);
                     }
                 }

--- a/src/Splat.Drawing/Splat.Drawing.csproj
+++ b/src/Splat.Drawing/Splat.Drawing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;Xamarin.WatchOS10;tizen40;netstandard2.0;net6.0;net6.0-android;net6.0-ios;net6.0-tvos;net6.0-macos</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid90;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;Xamarin.WatchOS10;tizen40;netstandard2.0;net6.0;net6.0-android;net6.0-ios;net6.0-tvos;net6.0-macos;net6.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net461;net472;uap10.0.16299;net6.0-windows</TargetFrameworks>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>
@@ -84,7 +84,7 @@
     <Reference Include="System.Runtime.Serialization" />
   </ItemGroup>
 
-  <ItemGroup Condition=" $(TargetFramework.StartsWith('net6.0-ios')) or $(TargetFramework.StartsWith('net6.0-tvos'))">
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net6.0-ios')) or $(TargetFramework.StartsWith('net6.0-tvos')) or $(TargetFramework.StartsWith('net6.0-maccatalyst'))">
     <Compile Include="Platforms\Cocoa\**\*.cs" />
     <Compile Include="Platforms\TypeForwardedSystemDrawing.cs" />
   </ItemGroup>

--- a/src/Splat.NLog/Splat.NLog.csproj
+++ b/src/Splat.NLog/Splat.NLog.csproj
@@ -11,7 +11,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="NLog" Version="4.7.15" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Splat.TestRunner.Android/Splat.TestRunner.Android.csproj
+++ b/src/Splat.TestRunner.Android/Splat.TestRunner.Android.csproj
@@ -112,7 +112,7 @@
     <PackageReference Include="xunit.runner.devices">
       <Version>2.*</Version>
     </PackageReference>
-    <PackageReference Include="Serilog.Exceptions" Version="5.7.0" />
+    <PackageReference Include="Serilog.Exceptions" Version="8.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Splat.AppCenter\Splat.AppCenter.csproj">

--- a/src/Splat.TestRunner.Uwp/Splat.TestRunner.Uwp.csproj
+++ b/src/Splat.TestRunner.Uwp/Splat.TestRunner.Uwp.csproj
@@ -141,18 +141,18 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.2.10</Version>
+      <Version>6.2.13</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestAdapter">
-      <Version>2.1.2</Version>
+      <Version>2.2.8</Version>
     </PackageReference>
     <PackageReference Include="MSTest.TestFramework">
-      <Version>2.1.2</Version>
+      <Version>2.2.8</Version>
     </PackageReference>
     <PackageReference Include="xunit.runner.devices">
       <Version>2.5.25</Version>
     </PackageReference>
-    <PackageReference Include="Serilog.Exceptions" Version="5.7.0" />
+    <PackageReference Include="Serilog.Exceptions" Version="8.1.0" />
   </ItemGroup>
   <ItemGroup>
     <SDKReference Include="TestPlatform.Universal, Version=$(UnitTestPlatformVersion)" />

--- a/src/Splat.Tests/API/ApiApprovalTests.cs
+++ b/src/Splat.Tests/API/ApiApprovalTests.cs
@@ -22,7 +22,7 @@ namespace Splat.Tests
         /// <summary>
         /// Tests to make sure the splat project is approved.
         /// </summary>
-        /// <returns>A task to monitor the usage.<returns>
+        /// <returns>A task to monitor the usage.</returns>
         [Fact]
         public Task SplatProject() => typeof(AssemblyFinder).Assembly.CheckApproval();
     }

--- a/src/Splat.Tests/Logging/WrappingFullLoggers/ConsoleLoggerTests.cs
+++ b/src/Splat.Tests/Logging/WrappingFullLoggers/ConsoleLoggerTests.cs
@@ -38,7 +38,7 @@ namespace Splat.Tests.Logging
             public override void WriteLine(string? value)
             {
                 var colonIndex = value!.IndexOf(":", StringComparison.InvariantCulture);
-                var level = (LogLevel)Enum.Parse(typeof(LogLevel), value.Substring(0, colonIndex));
+                var level = (LogLevel)Enum.Parse(typeof(LogLevel), value.AsSpan(0, colonIndex));
                 var message = value.Substring(colonIndex + 1).Trim();
                 _logs.Add((level, message));
                 base.WriteLine(value);

--- a/src/Splat.Tests/Splat.Tests.csproj
+++ b/src/Splat.Tests/Splat.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Exceptions" Version="7.0.0" />
+    <PackageReference Include="Serilog.Exceptions" Version="8.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Splat/TargetFrameworkExtensions.cs
+++ b/src/Splat/TargetFrameworkExtensions.cs
@@ -29,6 +29,7 @@ namespace Splat
         {
             return frameworkName switch
             {
+                ".NETCoreApp,Version=v7.0" => "net7.0",
                 ".NETCoreApp,Version=v6.0" => "net6.0",
                 ".NETCoreApp,Version=v5.0" => "net5.0",
                 ".NETCoreApp,Version=v3.1" => "netcoreapp3.1",


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature


**What is the current behavior?**
<!-- You can also link to an open issue here. -->
No mac catalyst


**What is the new behavior?**
<!-- If this is a feature change -->

Adds mac catalyst targets
Adds net7.0 target to the version helper (not a net7 framework target)
updates some packages

**What might this PR break?**
No-one

