### PR TITLE
Fix: 889 DryIoC creating instances at point of registration

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -48,7 +48,7 @@
     <PackageReference Include="FluentAssertions" Version="6.7.0" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="5.0.0" />
     <PackageReference Include="PublicApiGenerator" Version="10.3.0" />
-    <PackageReference Include="Verify.Xunit" Version="17.1.6" />
+    <PackageReference Include="Verify.Xunit" Version="17.2.1" />
   </ItemGroup>
 
   <ItemGroup Condition="$(IsTestProject)">
@@ -70,7 +70,7 @@
   </ItemGroup>
    
   <ItemGroup>	
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.107" PrivateAssets="all" />	
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.108" PrivateAssets="all" />	
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.DI.Tests/DryIocReactiveUIDependencyTests.cs
+++ b/src/ReactiveUI.DI.Tests/DryIocReactiveUIDependencyTests.cs
@@ -3,12 +3,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using DryIoc;
 using FluentAssertions;
 using Splat;
+using Splat.Common.Test;
 using Splat.DryIoc;
 using Xunit;
 
@@ -20,7 +20,7 @@ namespace ReactiveUI.DI.Tests
     public class DryIocReactiveUIDependencyTests
     {
         /// <summary>
-        /// Dries the ioc dependency resolver should register reactive UI creates command binding.
+        /// DyyIoC dependency resolver should register reactive UI creates command binding.
         /// </summary>
         [Fact]
         public void DryIocDependencyResolverShouldRegisterReactiveUI()
@@ -28,6 +28,7 @@ namespace ReactiveUI.DI.Tests
             // Invoke RxApp which initializes the ReactiveUI platform.
             var container = new Container();
             container.UseDryIocDependencyResolver();
+            Locator.CurrentMutable.RegisterViewsForViewModels(typeof(ViewWithViewContractThatShouldNotLoad).Assembly);
             Locator.CurrentMutable.InitializeReactiveUI();
 
             var converters = container.Resolve<IEnumerable<ICreatesCommandBinding>>().ToList();

--- a/src/ReactiveUI.DI.Tests/DryIocReactiveUIDependencyTests.cs
+++ b/src/ReactiveUI.DI.Tests/DryIocReactiveUIDependencyTests.cs
@@ -27,9 +27,10 @@ namespace ReactiveUI.DI.Tests
         {
             // Invoke RxApp which initializes the ReactiveUI platform.
             var container = new Container();
-            container.UseDryIocDependencyResolver();
-            Locator.CurrentMutable.RegisterViewsForViewModels(typeof(ViewWithViewContractThatShouldNotLoad).Assembly);
-            Locator.CurrentMutable.InitializeReactiveUI();
+
+            var locator = new DryIocDependencyResolver(container);
+            locator.RegisterViewsForViewModels(typeof(ViewWithViewContractThatShouldNotLoad).Assembly);
+            locator.InitializeReactiveUI();
 
             var converters = container.Resolve<IEnumerable<ICreatesCommandBinding>>().ToList();
 

--- a/src/ReactiveUI.DI.Tests/Mocks/ActivatingView.cs
+++ b/src/ReactiveUI.DI.Tests/Mocks/ActivatingView.cs
@@ -18,7 +18,7 @@ namespace ReactiveUI.DI.Tests.Mocks
     public sealed class ActivatingView : ReactiveObject, IViewFor<ActivatingViewModel>, IDisposable
     {
         private int _count;
-        private ActivatingViewModel _viewModel;
+        private ActivatingViewModel? _viewModel;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ActivatingView"/> class.
@@ -53,7 +53,7 @@ namespace ReactiveUI.DI.Tests.Mocks
         /// <summary>
         /// Gets or sets the view model.
         /// </summary>
-        public ActivatingViewModel ViewModel
+        public ActivatingViewModel? ViewModel
         {
             get => _viewModel;
             set => this.RaiseAndSetIfChanged(ref _viewModel, value);
@@ -62,10 +62,10 @@ namespace ReactiveUI.DI.Tests.Mocks
         /// <summary>
         /// Gets or sets the view model.
         /// </summary>
-        object IViewFor.ViewModel
+        object? IViewFor.ViewModel
         {
             get => ViewModel;
-            set => ViewModel = (ActivatingViewModel)value;
+            set => ViewModel = (ActivatingViewModel?)value;
         }
 
         /// <summary>

--- a/src/ReactiveUI.DI.Tests/ReactiveUI.DI.Tests.csproj
+++ b/src/ReactiveUI.DI.Tests/ReactiveUI.DI.Tests.csproj
@@ -28,7 +28,7 @@
   </Choose>
 
   <ItemGroup>
-    <PackageReference Include="ReactiveUI" Version="18.2.5" />
+    <PackageReference Include="ReactiveUI" Version="18.2.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ReactiveUI.DI.Tests/ReactiveUI.DI.Tests.csproj
+++ b/src/ReactiveUI.DI.Tests/ReactiveUI.DI.Tests.csproj
@@ -5,12 +5,12 @@
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <Choose>
     <When Condition="$(TargetFramework.StartsWith('net472'))">
       <ItemGroup>
-        <Compile Remove="DryIocReactiveUIDependencyTests.cs" />
         <!--<Compile Remove="AutoFacReactiveUIDependencyTests.cs" />-->
         <Compile Remove="NinjectReactiveUIDependencyTests.cs" />
         <Compile Remove="SimpleInjectorReactiveUIDependencyTests.cs" />
@@ -19,7 +19,6 @@
     </When>
     <When Condition="$(TargetFramework.StartsWith('net6.0'))">
       <ItemGroup>
-        <Compile Remove="DryIocReactiveUIDependencyTests.cs" />
         <Compile Remove="AutoFacReactiveUIDependencyTests.cs" />
         <Compile Remove="NinjectReactiveUIDependencyTests.cs" />
         <!--<Compile Remove="SimpleInjectorReactiveUIDependencyTests.cs" />-->
@@ -30,6 +29,11 @@
 
   <ItemGroup>
     <PackageReference Include="ReactiveUI" Version="18.2.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Splat.Common.Test\Splat.Common.Test.csproj" />
+    <ProjectReference Include="..\Splat.DryIoc\Splat.DryIoc.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ReactiveUI.DI.Tests/SimpleInjectorReactiveUIDependencyTests.cs
+++ b/src/ReactiveUI.DI.Tests/SimpleInjectorReactiveUIDependencyTests.cs
@@ -27,10 +27,8 @@ namespace ReactiveUI.DI.Tests
             Container container = new();
             SimpleInjectorInitializer initializer = new();
 
-            Locator.SetLocator(initializer);
-            Locator.CurrentMutable.InitializeReactiveUI();
-            container.UseSimpleInjectorDependencyResolver(initializer);
-            var converters = Locator.Current.GetServices<IBindingTypeConverter>().ToList();
+            initializer.InitializeReactiveUI();
+            var converters = initializer.GetServices<IBindingTypeConverter>().ToList();
 
             converters.Should().NotBeNull();
             converters.Should().Contain(x => x.GetType() == typeof(StringConverter));
@@ -47,11 +45,9 @@ namespace ReactiveUI.DI.Tests
             Container container = new();
             SimpleInjectorInitializer initializer = new();
 
-            Locator.SetLocator(initializer);
-            Locator.CurrentMutable.InitializeReactiveUI();
-            container.UseSimpleInjectorDependencyResolver(initializer);
+            initializer.InitializeReactiveUI();
 
-            var converters = Locator.Current.GetServices<ICreatesCommandBinding>().ToList();
+            var converters = initializer.GetServices<ICreatesCommandBinding>().ToList();
 
             converters.Should().NotBeNull();
             converters.Should().Contain(x => x.GetType() == typeof(CreatesCommandBindingViaEvent));

--- a/src/ReactiveUI.DI.Tests/ViewWithViewContractThatShouldNotLoad.cs
+++ b/src/ReactiveUI.DI.Tests/ViewWithViewContractThatShouldNotLoad.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Splat.Common.Test;
+
+namespace ReactiveUI.DI.Tests
+{
+    /// <summary>
+    /// This is a test view relating to issue #889.
+    /// It's intended to ensure that view registration by different DI\IoC implementations
+    /// does not create an instance at the point of registration.
+    /// </summary>
+    [ViewContract("somecontract")]
+    public sealed class ViewWithViewContractThatShouldNotLoad : IViewFor<ViewModelOne>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ViewWithViewContractThatShouldNotLoad"/> class.
+        /// </summary>
+        public ViewWithViewContractThatShouldNotLoad()
+        {
+            throw new InvalidOperationException("This view should not be created.");
+        }
+
+        /// <inheritdoc />
+        object? IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (ViewModelOne?)value;
+        }
+
+        /// <inheritdoc />
+        public ViewModelOne? ViewModel { get; set; }
+    }
+}

--- a/src/Splat.Common.Test/ViewThatShouldNotLoad.cs
+++ b/src/Splat.Common.Test/ViewThatShouldNotLoad.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Splat.Common.Test
+{
+    /// <summary>
+    /// This is a test view relating to issue #889.
+    /// It's intended to ensure that view registration by different DI\IoC implementations
+    /// does not create an instance at the point of registration.
+    /// </summary>
+    public sealed class ViewThatShouldNotLoad : IViewFor<ViewModelOne>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ViewThatShouldNotLoad"/> class.
+        /// </summary>
+        public ViewThatShouldNotLoad()
+        {
+            throw new InvalidOperationException("This view should not be created.");
+        }
+
+        /// <inheritdoc />
+        object? IViewFor.ViewModel
+        {
+            get => ViewModel;
+            set => ViewModel = (ViewModelOne?)value;
+        }
+
+        /// <inheritdoc />
+        public ViewModelOne? ViewModel { get; set; }
+    }
+}

--- a/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
+++ b/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
@@ -65,6 +65,30 @@ namespace Splat.DryIoc.Tests
         /// Should resolve the views.
         /// </summary>
         [Fact]
+        public void DryIocDependencyResolver_Should_Register_But_Not_Create_Views()
+        {
+            var container = new Container();
+            container.UseDryIocDependencyResolver();
+
+            Splat.Locator.CurrentMutable.Register(() => new ViewThatShouldNotLoad(), typeof(IViewFor<ViewModelOne>));
+        }
+
+        /// <summary>
+        /// Should resolve the views.
+        /// </summary>
+        [Fact]
+        public void DryIocDependencyResolver_Should_Register_With_Contract_But_Not_Create_Views()
+        {
+            var container = new Container();
+            container.UseDryIocDependencyResolver();
+
+            Splat.Locator.CurrentMutable.Register(() => new ViewThatShouldNotLoad(), typeof(IViewFor<ViewModelOne>), "name");
+        }
+
+        /// <summary>
+        /// Should resolve the views.
+        /// </summary>
+        [Fact]
         public void DryIocDependencyResolver_Should_Resolve_Views()
         {
             var container = new Container();
@@ -107,6 +131,8 @@ namespace Splat.DryIoc.Tests
             container.Register<ViewModelOne>();
             container.Register<ViewModelTwo>();
             container.UseDryIocDependencyResolver();
+
+            Splat.Locator.CurrentMutable.Register(() => new ViewThatShouldNotLoad(), typeof(IViewFor<ViewModelOne>), "name");
 
             var vmOne = Locator.Current.GetService<ViewModelOne>();
             var vmTwo = Locator.Current.GetService<ViewModelTwo>();
@@ -255,7 +281,7 @@ namespace Splat.DryIoc.Tests
         /// DryIoc dependency resolver should resolve after duplicate keyed registratoion.
         /// </summary>
         [Fact]
-        public void DryIocDependencyResolver_Should_Resolve_AfterDuplicateKeyedRegistratoion()
+        public void DryIocDependencyResolver_Should_Resolve_AfterDuplicateKeyedRegistration()
         {
             var container = new Container();
             container.UseDryIocDependencyResolver();

--- a/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
+++ b/src/Splat.DryIoc.Tests/DependencyResolverTests.cs
@@ -21,15 +21,17 @@ namespace Splat.DryIoc.Tests
         /// <summary>
         /// Shoulds the resolve nulls.
         /// </summary>
-        [Fact(Skip = "Further investigation required")]
+        [Fact] //// (Skip = "Further investigation required")]
         public void Can_Register_And_Resolve_Null_Types()
         {
             var builder = new Container();
             builder.UseDryIocDependencyResolver();
 
             var foo = 5;
-            Locator.CurrentMutable.Register(() => foo, null);
+            Assert.Throws<ArgumentNullException>(() => Locator.CurrentMutable.Register(() => foo, null));
 
+            // Tests skipped as functionality removed.
+#if SKIP_TEST
             var bar = 4;
             var contract = "foo";
             Locator.CurrentMutable.Register(() => bar, null, contract);
@@ -59,6 +61,7 @@ namespace Splat.DryIoc.Tests
             Locator.CurrentMutable.UnregisterAll(null, contract);
             valuesC = Locator.Current.GetServices(null, contract);
             Assert.Equal(0, valuesC.Count());
+#endif
         }
 
         /// <summary>
@@ -71,6 +74,7 @@ namespace Splat.DryIoc.Tests
             container.UseDryIocDependencyResolver();
 
             Splat.Locator.CurrentMutable.Register(() => new ViewThatShouldNotLoad(), typeof(IViewFor<ViewModelOne>));
+            Assert.Throws<InvalidOperationException>(() => Locator.Current.GetService<IViewFor<ViewModelOne>>());
         }
 
         /// <summary>
@@ -83,6 +87,7 @@ namespace Splat.DryIoc.Tests
             container.UseDryIocDependencyResolver();
 
             Splat.Locator.CurrentMutable.Register(() => new ViewThatShouldNotLoad(), typeof(IViewFor<ViewModelOne>), "name");
+            Assert.Throws<InvalidOperationException>(() => Locator.Current.GetService<IViewFor<ViewModelOne>>("name"));
         }
 
         /// <summary>

--- a/src/Splat.DryIoc/DryIocDependencyResolver.cs
+++ b/src/Splat.DryIoc/DryIocDependencyResolver.cs
@@ -6,7 +6,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using DryIoc;
@@ -38,26 +37,25 @@ namespace Splat.DryIoc
         /// <inheritdoc />
         public virtual IEnumerable<object> GetServices(Type? serviceType, string? contract = null)
         {
-            var isNull = serviceType is null;
             if (serviceType is null)
             {
-                serviceType = typeof(NullServiceType);
+                throw new ArgumentNullException(nameof(serviceType));
             }
 
             var key = (serviceType, contract ?? string.Empty);
-            var registeredinSplat = _container.ResolveMany(serviceType, behavior: ResolveManyBehavior.AsFixedArray, serviceKey: key).Select(x => isNull ? ((NullServiceType)x).Factory()! : x);
+            var registeredinSplat = _container.ResolveMany(serviceType, behavior: ResolveManyBehavior.AsFixedArray, serviceKey: key);
             if (registeredinSplat.Any())
             {
                 return registeredinSplat;
             }
 
-            var registeredWithContract = _container.ResolveMany(serviceType, behavior: ResolveManyBehavior.AsFixedArray, serviceKey: contract).Select(x => isNull ? ((NullServiceType)x).Factory()! : x);
+            var registeredWithContract = _container.ResolveMany(serviceType, behavior: ResolveManyBehavior.AsFixedArray, serviceKey: contract);
             if (registeredWithContract.Any())
             {
                 return registeredWithContract;
             }
 
-            return _container.ResolveMany(serviceType, behavior: ResolveManyBehavior.AsFixedArray).Select(x => isNull ? ((NullServiceType)x).Factory()! : x);
+            return _container.ResolveMany(serviceType, behavior: ResolveManyBehavior.AsFixedArray);
         }
 
         /// <inheritdoc />
@@ -65,7 +63,7 @@ namespace Splat.DryIoc
         {
             if (serviceType is null)
             {
-                serviceType = typeof(NullServiceType);
+                throw new ArgumentNullException(nameof(serviceType));
             }
 
             return _container.GetServiceRegistrations().Any(x =>
@@ -97,18 +95,10 @@ namespace Splat.DryIoc
                 throw new ArgumentNullException(nameof(factory));
             }
 
-#if TBC
-            var isNull = serviceType is null;
-            if (serviceType is null)
-            {
-                serviceType = typeof(NullServiceType);
-            }
-#else
             if (serviceType is null)
             {
                 throw new ArgumentNullException(nameof(serviceType));
             }
-#endif
 
             if (string.IsNullOrEmpty(contract))
             {
@@ -140,7 +130,7 @@ namespace Splat.DryIoc
         {
             if (serviceType is null)
             {
-                serviceType = typeof(NullServiceType);
+                throw new ArgumentNullException(nameof(serviceType));
             }
 
             var key = (serviceType, contract ?? string.Empty);
@@ -179,7 +169,7 @@ namespace Splat.DryIoc
         {
             if (serviceType is null)
             {
-                serviceType = typeof(NullServiceType);
+                throw new ArgumentNullException(nameof(serviceType));
             }
 
             var key = (serviceType, contract ?? string.Empty);


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Closes #889, but needs a look at as it feels dirty.
It stops the instant creation of objects during registration
But it also needs to use a cast because the factory func returns object, and DryIoC throws. So there's an expression used to do the casting.

The alternative might be to break the interface and add a generic Register<T> method? (instead of the static extension that does <T> to typeof(T) and ultimately ends up as Func<object?>)

I have also removed the NullServiceType registration as I can't see a way out of any pain of using it with DryIoC.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

objects registered via splat into DryIoc are instantly instantiated


**What is the new behavior?**
<!-- If this is a feature change -->

Delayed creation


**What might this PR break?**

Usages of null type registrations with DryIoC (but did it ever work correctly?)

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

