### PR TITLE
Fix For Avalonia Router randomly stops showing views on navigation.

### DIFF
--- a/src/ReactiveUI.Avalonia.Autofac/AvaloniaMixins.cs
+++ b/src/ReactiveUI.Avalonia.Autofac/AvaloniaMixins.cs
@@ -29,7 +29,7 @@ namespace Avalonia.ReactiveUI.Splat
             builder switch
             {
                 null => throw new ArgumentNullException(nameof(builder)),
-                _ => builder.UseReactiveUI().AfterPlatformServicesSetup(_ =>
+                _ => builder.AfterPlatformServicesSetup(_ =>
                 {
                     if (Locator.CurrentMutable is null)
                     {
@@ -40,6 +40,11 @@ namespace Avalonia.ReactiveUI.Splat
                     {
                         throw new ArgumentNullException(nameof(containerConfig));
                     }
+
+                    PlatformRegistrationManager.SetRegistrationNamespaces(RegistrationNamespace.Avalonia);
+                    RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
+                    Locator.CurrentMutable.RegisterConstant(new AvaloniaActivationForViewFetcher(), typeof(IActivationForViewFetcher));
+                    Locator.CurrentMutable.RegisterConstant(new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
 
                     var builder = new ContainerBuilder();
                     var autofacResolver = new AutofacDependencyResolver(builder);

--- a/src/ReactiveUI.Avalonia.DryIoc/AvaloniaMixins.cs
+++ b/src/ReactiveUI.Avalonia.DryIoc/AvaloniaMixins.cs
@@ -25,7 +25,7 @@ namespace Avalonia.ReactiveUI.Splat
             builder switch
             {
                 null => throw new ArgumentNullException(nameof(builder)),
-                _ => builder.UseReactiveUI().AfterPlatformServicesSetup(_ =>
+                _ => builder.AfterPlatformServicesSetup(_ =>
                 {
                     if (Locator.CurrentMutable is null)
                     {
@@ -36,6 +36,11 @@ namespace Avalonia.ReactiveUI.Splat
                     {
                         throw new ArgumentNullException(nameof(containerConfig));
                     }
+
+                    PlatformRegistrationManager.SetRegistrationNamespaces(RegistrationNamespace.Avalonia);
+                    RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
+                    Locator.CurrentMutable.RegisterConstant(new AvaloniaActivationForViewFetcher(), typeof(IActivationForViewFetcher));
+                    Locator.CurrentMutable.RegisterConstant(new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
 
                     var container = new Container();
                     Locator.CurrentMutable.RegisterConstant(container, typeof(Container));

--- a/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/AvaloniaMixins.cs
+++ b/src/ReactiveUI.Avalonia.Microsoft.Extensions.DependencyInjection/AvaloniaMixins.cs
@@ -27,7 +27,7 @@ namespace ReactiveUI.Avalonia.Splat
             builder switch
             {
                 null => throw new ArgumentNullException(nameof(builder)),
-                _ => builder.UseReactiveUI().AfterPlatformServicesSetup(_ =>
+                _ => builder.AfterPlatformServicesSetup(_ =>
                 {
                     if (Locator.CurrentMutable is null)
                     {
@@ -38,6 +38,11 @@ namespace ReactiveUI.Avalonia.Splat
                     {
                         throw new ArgumentNullException(nameof(containerConfig));
                     }
+
+                    PlatformRegistrationManager.SetRegistrationNamespaces(RegistrationNamespace.Avalonia);
+                    RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
+                    Locator.CurrentMutable.RegisterConstant(new AvaloniaActivationForViewFetcher(), typeof(IActivationForViewFetcher));
+                    Locator.CurrentMutable.RegisterConstant(new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
 
                     IServiceCollection serviceCollection = new ServiceCollection();
                     Locator.CurrentMutable.RegisterConstant(serviceCollection, typeof(IServiceCollection));

--- a/src/ReactiveUI.Avalonia.Ninject/AvaloniaMixins.cs
+++ b/src/ReactiveUI.Avalonia.Ninject/AvaloniaMixins.cs
@@ -25,7 +25,7 @@ namespace Avalonia.ReactiveUI.Splat
             builder switch
             {
                 null => throw new ArgumentNullException(nameof(builder)),
-                _ => builder.UseReactiveUI().AfterPlatformServicesSetup(_ =>
+                _ => builder.AfterPlatformServicesSetup(_ =>
                 {
                     if (Locator.CurrentMutable is null)
                     {
@@ -36,6 +36,11 @@ namespace Avalonia.ReactiveUI.Splat
                     {
                         throw new ArgumentNullException(nameof(containerConfig));
                     }
+
+                    PlatformRegistrationManager.SetRegistrationNamespaces(RegistrationNamespace.Avalonia);
+                    RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
+                    Locator.CurrentMutable.RegisterConstant(new AvaloniaActivationForViewFetcher(), typeof(IActivationForViewFetcher));
+                    Locator.CurrentMutable.RegisterConstant(new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
 
                     var container = new StandardKernel();
                     Locator.CurrentMutable.RegisterConstant(container, typeof(StandardKernel));

--- a/src/ReactiveUI.Avalonia/AppBuilderExtensions.cs
+++ b/src/ReactiveUI.Avalonia/AppBuilderExtensions.cs
@@ -57,7 +57,7 @@ namespace Avalonia.ReactiveUI
                 builder switch
                 {
                     null => throw new ArgumentNullException(nameof(builder)),
-                    _ => builder.UseReactiveUI().AfterPlatformServicesSetup(_ =>
+                    _ => builder.AfterPlatformServicesSetup(_ =>
                     {
                         if (Locator.CurrentMutable is null)
                         {
@@ -78,6 +78,11 @@ namespace Avalonia.ReactiveUI
                         {
                             throw new ArgumentNullException(nameof(dependencyResolverFactory));
                         }
+
+                        PlatformRegistrationManager.SetRegistrationNamespaces(RegistrationNamespace.Avalonia);
+                        RxApp.MainThreadScheduler = AvaloniaScheduler.Instance;
+                        Locator.CurrentMutable.RegisterConstant(new AvaloniaActivationForViewFetcher(), typeof(IActivationForViewFetcher));
+                        Locator.CurrentMutable.RegisterConstant(new AutoDataTemplateBindingHook(), typeof(IPropertyBindingHook));
 
                         var container = containerFactory();
                         Locator.CurrentMutable.RegisterConstant(container, typeof(Container));

--- a/src/ReactiveUI.Avalonia/RoutedViewHost.cs
+++ b/src/ReactiveUI.Avalonia/RoutedViewHost.cs
@@ -51,7 +51,7 @@ namespace Avalonia.ReactiveUI
     /// ReactiveUI routing documentation website</see> for more info.
     /// </para>
     /// </remarks>
-    public class RoutedViewHost : TransitioningContentControl, IActivatableView, IEnableLogger
+    public class RoutedViewHost : TransitioningContentControlReactiveUI, IActivatableView, IEnableLogger
     {
         /// <summary>
         /// <see cref="AvaloniaProperty"/> for the <see cref="Router"/> property.

--- a/src/ReactiveUI.Avalonia/TransitioningContentControlReactiveUI.cs
+++ b/src/ReactiveUI.Avalonia/TransitioningContentControlReactiveUI.cs
@@ -1,0 +1,165 @@
+﻿// Copyright (c) 2021 .NET Foundation and Contributors. All rights reserved.
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Controls.Templates;
+using ReactiveUI;
+
+namespace Avalonia.ReactiveUI;
+
+/// <summary>
+/// Displays <see cref="ContentControl.Content" /> according to an <see cref="IDataTemplate" />.
+/// </summary>
+/// <seealso cref="Avalonia.Controls.ContentControl" />
+public class TransitioningContentControlReactiveUI : ContentControl, ICancelable
+{
+    private readonly Subject<double> _opacitySubject = new();
+    private readonly SemaphoreSlim _animationSemaphore = new(1);
+    private CompositeDisposable _animationDisposable = new();
+    private ContentPresenter? _contentPresenter2;
+    private ContentPresenter? _contentPresenter1;
+    private int _currentPresenter;
+
+    /// <summary>
+    /// Gets a value indicating whether gets a value that indicates whether the object is disposed.
+    /// </summary>
+    public bool IsDisposed => _animationDisposable.IsDisposed;
+
+    /// <summary>
+    /// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Releases unmanaged and - optionally - managed resources.
+    /// </summary>
+    /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!IsDisposed && disposing)
+        {
+            _animationDisposable.Dispose();
+            _opacitySubject.Dispose();
+            _animationSemaphore.Dispose();
+        }
+    }
+
+    /// <inheritdoc/>
+    protected override bool RegisterContentPresenter(ContentPresenter presenter)
+    {
+        if (!base.RegisterContentPresenter(presenter) &&
+            presenter is ContentPresenter p2 &&
+            p2.Name == "PART_ContentPresenter2")
+        {
+            _contentPresenter2 = p2;
+            _contentPresenter2.IsVisible = false;
+            _contentPresenter1 = Presenter;
+            _contentPresenter1!.IsVisible = false;
+            return _contentPresenter1 != null;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc/>
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        if (change.Property == ContentProperty)
+        {
+            UpdateContent(true);
+        }
+
+        base.OnPropertyChanged(change);
+    }
+
+    private void UpdateContent(bool withTransition)
+    {
+        var (from, to, current) = GetPresenters();
+        if (VisualRoot is null || from is null || to is null)
+        {
+            return;
+        }
+
+#pragma warning disable CA1031 // Do not catch general exception types
+        try
+        {
+            _animationSemaphore.Wait();
+            to.Content = Content;
+            if (withTransition)
+            {
+                to.Opacity = 0d;
+                to.IsVisible = true;
+                from!.IsVisible = false;
+                AnimateContent();
+            }
+            else
+            {
+                _currentPresenter = current == 1 ? 0 : 1;
+                to.IsVisible = true;
+                from.Content = null;
+                from.IsVisible = false;
+            }
+        }
+        catch
+        {
+            _animationSemaphore.Release();
+        }
+#pragma warning restore CA1031 // Do not catch general exception types
+    }
+
+    private void AnimateContent()
+    {
+        // This should be an animation but there is currently an issue with PageTransitions in Avalonia
+        _animationDisposable.Dispose();
+        _animationDisposable = new();
+        var (from, to, current) = GetPresenters();
+        to!.Bind(ContentPresenter.OpacityProperty, _opacitySubject).DisposeWith(_animationDisposable);
+        var opacity = 0d;
+        Observable.Interval(TimeSpan.FromMilliseconds(10)).Subscribe(_ =>
+        {
+            opacity += 0.08;
+            if (opacity > 1d) { opacity = 1d; }
+            _opacitySubject.OnNext(opacity);
+        }).DisposeWith(_animationDisposable);
+#pragma warning disable CA2000 // Dispose objects before losing scope
+        Disposable.Create(() => RxApp.MainThreadScheduler.Schedule(() =>
+            {
+                to!.Opacity = 1d;
+                from!.Opacity = 1d;
+                to.IsVisible = true;
+                from.IsVisible = false;
+                from.Content = null;
+                _currentPresenter = current == 1 ? 0 : 1;
+                _animationSemaphore.Release();
+            })).DisposeWith(_animationDisposable);
+#pragma warning restore CA2000 // Dispose objects before losing scope
+        _opacitySubject
+            .Where(x => x >= 1d)
+            .ObserveOn(RxApp.MainThreadScheduler)
+            .Subscribe(_ =>
+            {
+                if (!_animationDisposable.IsDisposed)
+                {
+                    _animationDisposable.Dispose();
+                }
+            }).DisposeWith(_animationDisposable);
+    }
+
+    private (ContentPresenter? from, ContentPresenter? to, int current) GetPresenters()
+    {
+        var from = _currentPresenter == 1 ? _contentPresenter1 : _contentPresenter2;
+        var to = _currentPresenter == 1 ? _contentPresenter2 : _contentPresenter1;
+        return (from, to, _currentPresenter);
+    }
+}

--- a/src/ReactiveUI.Avalonia/ViewModelViewHost.cs
+++ b/src/ReactiveUI.Avalonia/ViewModelViewHost.cs
@@ -15,7 +15,7 @@ namespace Avalonia.ReactiveUI
     /// the ViewModel property and display it. This control is very useful
     /// inside a DataTemplate to display the View associated with a ViewModel.
     /// </summary>
-    public class ViewModelViewHost : TransitioningContentControl, IViewFor, IEnableLogger
+    public class ViewModelViewHost : TransitioningContentControlReactiveUI, IViewFor, IEnableLogger
     {
         /// <summary>
         /// <see cref="AvaloniaProperty"/> for the <see cref="ViewModel"/> property.


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix for #1027 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Avalonia PageTransitions has an issue with static Page transitions

**What is the new behavior?**
<!-- If this is a feature change -->

An 125ms Opacity animation has been created using reactive methods and bindings to replace the Avalonia Animation

**What might this PR break?**

A new class has been created so no existing code should be affected.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:
Added TransitioningContentControlReactiveUI as a patch for Avalonia's TransitioningContentControl the PageTransitions have an issue after x transitions. The replacement has a fixed Opacity animation.