### PR TITLE
housekeeping: add grouping to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,25 @@ updates:
   directory: "/"
   schedule:
     # Check for updates to GitHub Actions every weekday
-    interval: "monthly"  
+    interval: "monthly"
+  groups:
+    ms-appcenter:
+      patterns:
+        - "microsoft.appcenter.*"
+    avalonia:
+      patterns:
+        - "avalonia"
+        - "avalonia.*"
+    reactive-extensions:
+      patterns:
+        - "system.reactive.*"
+        - "microsoft.reactive.*"
+    xunit:
+      patterns:
+        - "xunit"
+        - "xunit.*"
+    dotnet:
+      # you may need to add groupings above this if non core .NET projects are getting grouped into this.
+      patterns:
+        - "system.*"
+        - "microsoft.*"


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Added groupings to dependabot to reduce number of PR's being produced and to simplify the patching of groups where we need to intervene to manually group them together, or merge them in a set order.

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

large number of pr's for avalonia, etc.


**What is the new behavior?**
<!-- If this is a feature change -->

less pr's

**What might this PR break?**

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

