### PR TITLE
Housekeeping : Update Target Frameworks

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -15,5 +15,5 @@ jobs:
     with:
       configuration: Release
       productNamespacePrefix: "Splat"
-      useVisualStudioPreview: false
+      useVisualStudioPreview: true
       useMauiCheckDotNetTool: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     with:
       configuration: Release
       productNamespacePrefix: "Splat"
-      useVisualStudioPreview: false
+      useVisualStudioPreview: true
       useMauiCheckDotNetTool: false
     secrets:
       SIGN_CLIENT_USER_ID: ${{ secrets.SIGN_CLIENT_USER_ID }}

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -58,7 +58,7 @@
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.Reactive.Testing" Version="6.0.0" />
     <PackageReference Include="PublicApiGenerator" Version="11.0.0" />
-    <PackageReference Include="Verify.Xunit" Version="22.3.0" />
+    <PackageReference Include="Verify.Xunit" Version="22.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition="$(IsTestProject)">
@@ -68,7 +68,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.DotNet6_0.verified.txt
+++ b/src/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.DotNet6_0.verified.txt
@@ -3,9 +3,9 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.TestRunner.Android")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.TestRunner.Uwp")]
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.Tests")]
-[assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows7.0")]
+[assembly: System.Runtime.Versioning.SupportedOSPlatform("Windows10.0.17763.0")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName=".NET 6.0")]
-[assembly: System.Runtime.Versioning.TargetPlatform("Windows7.0")]
+[assembly: System.Runtime.Versioning.TargetPlatform("Windows10.0.17763.0")]
 namespace Splat
 {
     public static class BitmapLoader

--- a/src/Splat.Drawing.Tests/BitmapLoaderTests.cs
+++ b/src/Splat.Drawing.Tests/BitmapLoaderTests.cs
@@ -3,6 +3,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.IO;
 using System.Reflection;
 
 #if !NETSTANDARD2_0

--- a/src/Splat.Drawing.Tests/Splat.Drawing.Tests.csproj
+++ b/src/Splat.Drawing.Tests/Splat.Drawing.Tests.csproj
@@ -1,15 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows10.0.17763.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000;CA1034</NoWarn>
     <Nullable>enable</Nullable>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)' == 'Windows_NT' ">
-    <UseWPF Condition="$(TargetFramework.StartsWith('netcoreapp3'))">true</UseWPF>
-    <UseWindowsForms Condition="$(TargetFramework.StartsWith('netcoreapp3'))">true</UseWindowsForms>
+    <UseWPF>true</UseWPF>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Drawing/Splat.Drawing.csproj
+++ b/src/Splat.Drawing/Splat.Drawing.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid12.0;MonoAndroid12.1;MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;Xamarin.WatchOS10;tizen40;netstandard2.0;net6.0;net7.0;net7.0-android;net7.0-ios;net7.0-tvos;net7.0-macos;net7.0-maccatalyst;net8.0;net8.0-android;net8.0-ios;net8.0-tvos;net8.0-macos;net8.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462;net472;net6.0-windows;net7.0-windows;net8.0-windows</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;Xamarin.WatchOS10;tizen40;netstandard2.0;net6.0;net7.0;net7.0-android;net7.0-ios;net7.0-tvos;net7.0-macos;net7.0-maccatalyst;net8.0;net8.0-android;net8.0-ios;net8.0-tvos;net8.0-macos;net8.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462;net472;net6.0-windows10.0.17763.0;net7.0-windows10.0.17763.0;net8.0-windows10.0.17763.0</TargetFrameworks>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>
     <Description>A library to make things cross-platform that should be</Description>
@@ -11,7 +11,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" ($(TargetFramework.StartsWith('net6.0-windows')) or $(TargetFramework.StartsWith('net7.0-windows')) or $(TargetFramework.StartsWith('net8.0-windows')) or $(TargetFramework.StartsWith('net4'))) and '$(OS)' == 'Windows_NT' ">
+  <PropertyGroup Condition=" ($(TargetFramework.EndsWith('-windows10.0.17763.0')) or $(TargetFramework.StartsWith('net4'))) and '$(OS)' == 'Windows_NT' ">
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/src/Splat.SimpleInjector/Splat.SimpleInjector.csproj
+++ b/src/Splat.SimpleInjector/Splat.SimpleInjector.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SimpleInjector" Version="5.4.1" />
+    <PackageReference Include="SimpleInjector" Version="5.4.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.DotNet7_0.verified.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.DotNet7_0.verified.txt
@@ -1,0 +1,783 @@
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.Drawing.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.TestRunner.Android")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.TestRunner.Uwp")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.Tests")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName=".NET 7.0")]
+namespace Splat
+{
+    public class ActionLogger : Splat.ILogger
+    {
+        public ActionLogger(System.Action<string, Splat.LogLevel> writeNoType, System.Action<string, System.Type, Splat.LogLevel> writeWithType, System.Action<System.Exception, string, Splat.LogLevel> writeNoTypeWithException, System.Action<System.Exception, string, System.Type, Splat.LogLevel> writeWithTypeAndException) { }
+        public Splat.LogLevel Level { get; set; }
+        public void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public abstract class AllocationFreeLoggerBase : Splat.IAllocationFreeErrorLogger, Splat.IAllocationFreeLogger, Splat.ILogger
+    {
+        protected AllocationFreeLoggerBase(Splat.ILogger inner) { }
+        public bool IsDebugEnabled { get; }
+        public bool IsErrorEnabled { get; }
+        public bool IsFatalEnabled { get; }
+        public bool IsInfoEnabled { get; }
+        public bool IsWarnEnabled { get; }
+        public Splat.LogLevel Level { get; }
+        public virtual void Debug<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument) { }
+        public virtual void Debug<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Debug<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Debug<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Debug<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Error<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument) { }
+        public void Error<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Error<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Error<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Error<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Fatal<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument) { }
+        public void Fatal<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Fatal<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Fatal<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Info<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument) { }
+        public void Info<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Info<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Info<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Info<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Warn<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument) { }
+        public void Warn<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Warn<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Warn<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Warn<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public class ConsoleLogger : Splat.ILogger
+    {
+        public ConsoleLogger() { }
+        public string ExceptionMessageFormat { get; set; }
+        public Splat.LogLevel Level { get; set; }
+        public void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public class DebugLogger : Splat.ILogger
+    {
+        public DebugLogger() { }
+        public Splat.LogLevel Level { get; set; }
+        public void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public sealed class DefaultLogManager : Splat.ILogManager
+    {
+        public DefaultLogManager(Splat.IReadonlyDependencyResolver? dependencyResolver = null) { }
+        public Splat.IFullLogger GetLogger(System.Type type) { }
+    }
+    public class DefaultModeDetector : Splat.IEnableLogger, Splat.IModeDetector
+    {
+        public DefaultModeDetector() { }
+        public bool? InUnitTestRunner() { }
+    }
+    public static class DependencyResolverMixins
+    {
+        public static T? GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
+        public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
+        public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> factory, string? contract = null) { }
+        public static void Register<TAs, T>(this Splat.IMutableDependencyResolver resolver, string? contract = null)
+            where T : new() { }
+        public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object? value, System.Type? serviceType, string? contract = null) { }
+        public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T? value, string? contract = null) { }
+        public static void RegisterLazySingleton(this Splat.IMutableDependencyResolver resolver, System.Func<object?> valueFactory, System.Type? serviceType, string? contract = null) { }
+        public static void RegisterLazySingleton<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> valueFactory, string? contract = null) { }
+        public static System.IDisposable ServiceRegistrationCallback(this Splat.IMutableDependencyResolver resolver, System.Type serviceType, System.Action<System.IDisposable> callback) { }
+        public static void UnregisterAll<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null) { }
+        public static void UnregisterCurrent<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null) { }
+        public static System.IDisposable WithResolver(this Splat.IDependencyResolver resolver, bool suppressResolverCallback = true) { }
+    }
+    public static class FullLoggerExtensions
+    {
+        public static void Debug(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Debug<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void DebugException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Error(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Error<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void ErrorException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Fatal(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Fatal<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void FatalException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Info(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Info<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void InfoException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Warn(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Warn<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void WarnException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+    }
+    public class FuncDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
+    {
+        public FuncDependencyResolver(System.Func<System.Type?, string?, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object?>, System.Type?, string?>? register = null, System.Action<System.Type?, string?>? unregisterCurrent = null, System.Action<System.Type?, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool isDisposing) { }
+        public object? GetService(System.Type? serviceType, string? contract = null) { }
+        public System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null) { }
+        public bool HasRegistration(System.Type? serviceType, string? contract = null) { }
+        public void Register(System.Func<object?> factory, System.Type? serviceType, string? contract = null) { }
+        public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
+        public void UnregisterAll(System.Type? serviceType, string? contract = null) { }
+        public void UnregisterCurrent(System.Type? serviceType, string? contract = null) { }
+    }
+    public class FuncLogManager : Splat.ILogManager
+    {
+        public FuncLogManager(System.Func<System.Type, Splat.IFullLogger> getLoggerFunc) { }
+        public Splat.IFullLogger GetLogger(System.Type type) { }
+    }
+    public interface IAllocationFreeErrorLogger : Splat.ILogger
+    {
+        void Debug<TArgument>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Debug<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Error<TArgument>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Error<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Fatal<TArgument>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Fatal<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Info<TArgument>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Info<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Warn<TArgument>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Warn<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+    }
+    public interface IAllocationFreeLogger : Splat.IAllocationFreeErrorLogger, Splat.ILogger
+    {
+        bool IsDebugEnabled { get; }
+        bool IsErrorEnabled { get; }
+        bool IsFatalEnabled { get; }
+        bool IsInfoEnabled { get; }
+        bool IsWarnEnabled { get; }
+        void Debug<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Debug<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Error<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Error<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Fatal<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Fatal<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Info<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Info<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Warn<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Warn<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+    }
+    public interface IDependencyResolver : Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable { }
+    [System.Runtime.InteropServices.ComVisible(false)]
+    public interface IEnableLogger { }
+    public interface IFullLogger : Splat.IAllocationFreeErrorLogger, Splat.IAllocationFreeLogger, Splat.ILogger
+    {
+        void Debug([System.ComponentModel.Localizable(false)] string? message);
+        void Debug(System.Exception exception, [System.ComponentModel.Localizable(false)] string? message);
+        void Debug([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Debug(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Debug<T>(T value);
+        void Debug<T>([System.ComponentModel.Localizable(false)] string? message);
+        void Debug<T>(System.IFormatProvider formatProvider, T value);
+        void Debug<T>([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Debug<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument);
+        void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.Obsolete("Use void Debug(Exception exception, [Localizable(false)] string? message)")]
+        void DebugException([System.ComponentModel.Localizable(false)] string? message, System.Exception exception);
+        void Error([System.ComponentModel.Localizable(false)] string? message);
+        void Error(System.Exception exception, [System.ComponentModel.Localizable(false)] string? message);
+        void Error([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Error(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Error<T>(T value);
+        void Error<T>([System.ComponentModel.Localizable(false)] string? message);
+        void Error<T>(System.IFormatProvider formatProvider, T value);
+        void Error<T>([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Error<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument);
+        void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.Obsolete("Use void Error(Exception exception, [Localizable(false)] string? message)")]
+        void ErrorException([System.ComponentModel.Localizable(false)] string? message, System.Exception exception);
+        void Fatal([System.ComponentModel.Localizable(false)] string? message);
+        void Fatal(System.Exception exception, [System.ComponentModel.Localizable(false)] string? message);
+        void Fatal([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Fatal(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Fatal<T>(T value);
+        void Fatal<T>([System.ComponentModel.Localizable(false)] string? message);
+        void Fatal<T>(System.IFormatProvider formatProvider, T value);
+        void Fatal<T>([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Fatal<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument);
+        void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.Obsolete("Use void Fatal(Exception exception, [Localizable(false)] string? message)")]
+        void FatalException([System.ComponentModel.Localizable(false)] string? message, System.Exception exception);
+        void Info([System.ComponentModel.Localizable(false)] string? message);
+        void Info(System.Exception exception, [System.ComponentModel.Localizable(false)] string? message);
+        void Info([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Info(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Info<T>(T value);
+        void Info<T>([System.ComponentModel.Localizable(false)] string? message);
+        void Info<T>(System.IFormatProvider formatProvider, T value);
+        void Info<T>([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Info<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument);
+        void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.Obsolete("Use void Info(Exception exception, [Localizable(false)] string? message)")]
+        void InfoException([System.ComponentModel.Localizable(false)] string? message, System.Exception exception);
+        void Warn([System.ComponentModel.Localizable(false)] string? message);
+        void Warn(System.Exception exception, [System.ComponentModel.Localizable(false)] string? message);
+        void Warn([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Warn(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Warn<T>(T value);
+        void Warn<T>([System.ComponentModel.Localizable(false)] string? message);
+        void Warn<T>(System.IFormatProvider formatProvider, T value);
+        void Warn<T>([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Warn<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument);
+        void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.Obsolete("Use void Warn(Exception exception, [Localizable(false)] string? message)")]
+        void WarnException([System.ComponentModel.Localizable(false)] string? message, System.Exception exception);
+    }
+    public interface ILogManager
+    {
+        Splat.IFullLogger GetLogger(System.Type type);
+    }
+    public interface ILogger
+    {
+        Splat.LogLevel Level { get; }
+        void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel);
+        void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel);
+        void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel);
+        void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel);
+    }
+    public interface IModeDetector
+    {
+        bool? InUnitTestRunner();
+    }
+    public interface IMutableDependencyResolver
+    {
+        bool HasRegistration(System.Type? serviceType, string? contract = null);
+        void Register(System.Func<object?> factory, System.Type? serviceType, string? contract = null);
+        System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback);
+        void UnregisterAll(System.Type? serviceType, string? contract = null);
+        void UnregisterCurrent(System.Type? serviceType, string? contract = null);
+    }
+    public interface IReadonlyDependencyResolver
+    {
+        object? GetService(System.Type? serviceType, string? contract = null);
+        System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null);
+    }
+    public interface IStaticFullLogger
+    {
+        Splat.LogLevel Level { get; }
+        void Debug([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Debug(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Debug<T>([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Debug<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Debug<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Error([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Error(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Error<T>([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Error<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Error<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Fatal([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Fatal(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Fatal<T>([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Fatal<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Fatal<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Info([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Info(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Info<T>([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Info<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Info<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Warn([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Warn(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Warn<T>([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Warn<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+    }
+    public static class Locator
+    {
+        public static Splat.IReadonlyDependencyResolver Current { get; }
+        public static Splat.IMutableDependencyResolver CurrentMutable { get; }
+        public static bool AreResolverCallbackChangedNotificationsEnabled() { }
+        public static Splat.IDependencyResolver GetLocator() { }
+        public static System.IDisposable RegisterResolverCallbackChanged(System.Action callback) { }
+        public static void SetLocator(Splat.IDependencyResolver dependencyResolver) { }
+        public static System.IDisposable SuppressResolverCallbackChangedNotifications() { }
+    }
+    public static class LogHost
+    {
+        public static Splat.IStaticFullLogger Default { get; }
+        public static Splat.IFullLogger Log<T>(this T logClassInstance)
+            where T : Splat.IEnableLogger { }
+    }
+    public enum LogLevel
+    {
+        Debug = 1,
+        Info = 2,
+        Warn = 3,
+        Error = 4,
+        Fatal = 5,
+    }
+    public static class LogManagerMixin
+    {
+        public static Splat.IFullLogger GetLogger<T>(this Splat.ILogManager logManager) { }
+    }
+    [System.Serializable]
+    public class LoggingException : System.Exception
+    {
+        public LoggingException() { }
+        public LoggingException(string message) { }
+        public LoggingException(string message, System.Exception innerException) { }
+    }
+    public sealed class MemoizingMRUCache<TParam, TVal>
+        where TParam :  notnull
+    {
+        public MemoizingMRUCache(System.Func<TParam, object?, TVal> calculationFunc, int maxSize) { }
+        public MemoizingMRUCache(System.Func<TParam, object?, TVal> calculationFunc, int maxSize, System.Action<TVal> onRelease) { }
+        public MemoizingMRUCache(System.Func<TParam, object?, TVal> calculationFunc, int maxSize, System.Collections.Generic.IEqualityComparer<TParam> paramComparer) { }
+        public MemoizingMRUCache(System.Func<TParam, object?, TVal> calculationFunc, int maxSize, System.Action<TVal>? onRelease, System.Collections.Generic.IEqualityComparer<TParam> paramComparer) { }
+        public System.Collections.Generic.IEnumerable<TVal> CachedValues() { }
+        public TVal Get(TParam key) { }
+        public TVal Get(TParam key, object? context = null) { }
+        public void Invalidate(TParam key) { }
+        public void InvalidateAll(bool aggregateReleaseExceptions = false) { }
+        public bool TryGet(TParam key, out TVal? result) { }
+    }
+    public static class ModeDetector
+    {
+        public static bool InUnitTestRunner() { }
+        public static void OverrideModeDetector(Splat.IModeDetector modeDetector) { }
+    }
+    public class ModernDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
+    {
+        public ModernDependencyResolver() { }
+        protected ModernDependencyResolver([System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
+                "serviceType",
+                "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string?>, System.Collections.Generic.List<System.Func<object?>>>? registry) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool isDisposing) { }
+        public Splat.ModernDependencyResolver Duplicate() { }
+        public object? GetService(System.Type? serviceType, string? contract = null) { }
+        public System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null) { }
+        public bool HasRegistration(System.Type? serviceType, string? contract = null) { }
+        public void Register(System.Func<object?> factory, System.Type? serviceType, string? contract = null) { }
+        public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
+        public void UnregisterAll(System.Type? serviceType, string? contract = null) { }
+        public void UnregisterCurrent(System.Type? serviceType, string? contract = null) { }
+    }
+    public class NullLogger : Splat.ILogger
+    {
+        public NullLogger() { }
+        public Splat.LogLevel Level { get; set; }
+        public void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public class NullServiceType
+    {
+        public NullServiceType(System.Func<object?> factory) { }
+        public System.Func<object?> Factory { get; }
+    }
+    public static class PointMathExtensions
+    {
+        public static float AngleInDegrees(this System.Drawing.PointF value) { }
+        public static float DistanceTo(this System.Drawing.PointF value, System.Drawing.PointF other) { }
+        public static float DotProduct(this System.Drawing.PointF value, System.Drawing.PointF other) { }
+        public static System.Drawing.PointF Floor(this System.Drawing.Point value) { }
+        public static float Length(this System.Drawing.PointF value) { }
+        public static System.Drawing.PointF Normalize(this System.Drawing.PointF value) { }
+        public static System.Drawing.PointF ProjectAlong(this System.Drawing.PointF value, System.Drawing.PointF direction) { }
+        public static System.Drawing.PointF ProjectAlongAngle(this System.Drawing.PointF value, float angleInDegrees) { }
+        public static System.Drawing.PointF ScaledBy(this System.Drawing.PointF value, float factor) { }
+        public static bool WithinEpsilonOf(this System.Drawing.PointF value, System.Drawing.PointF other, float epsilon) { }
+    }
+    public enum RectEdge
+    {
+        Left = 0,
+        Top = 1,
+        Right = 2,
+        Bottom = 3,
+    }
+    public static class RectangleMathExtensions
+    {
+        public static System.Drawing.PointF Center(this System.Drawing.RectangleF value) { }
+        public static System.Drawing.RectangleF Copy(this System.Drawing.RectangleF value, float? x = default, float? y = default, float? width = default, float? height = default, float? top = default, float? bottom = default) { }
+        public static System.Tuple<System.Drawing.RectangleF, System.Drawing.RectangleF> Divide(this System.Drawing.RectangleF value, float amount, Splat.RectEdge fromEdge) { }
+        public static System.Tuple<System.Drawing.RectangleF, System.Drawing.RectangleF> DivideWithPadding(this System.Drawing.RectangleF value, float sliceAmount, float padding, Splat.RectEdge fromEdge) { }
+        public static System.Drawing.RectangleF InvertWithin(this System.Drawing.RectangleF value, System.Drawing.RectangleF containingRect) { }
+    }
+    public static class ResolverMixins
+    {
+        public static Splat.IMutableDependencyResolver RegisterAnd<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null)
+            where T : new() { }
+        public static Splat.IMutableDependencyResolver RegisterAnd<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> factory, string? contract = null) { }
+        public static Splat.IMutableDependencyResolver RegisterAnd<TAs, T>(this Splat.IMutableDependencyResolver resolver, string? contract = null)
+            where T : new() { }
+        public static Splat.IMutableDependencyResolver RegisterAnd<TAs, T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> factory, string? contract = null) { }
+        public static Splat.IMutableDependencyResolver RegisterConstantAnd(this Splat.IMutableDependencyResolver resolver, object value, System.Type serviceType, string? contract = null) { }
+        public static Splat.IMutableDependencyResolver RegisterConstantAnd<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null)
+            where T : new() { }
+        public static Splat.IMutableDependencyResolver RegisterConstantAnd<T>(this Splat.IMutableDependencyResolver resolver, T value, string? contract = null) { }
+        public static Splat.IMutableDependencyResolver RegisterLazySingletonAnd(this Splat.IMutableDependencyResolver resolver, System.Func<object> valueFactory, System.Type serviceType, string? contract = null) { }
+        public static Splat.IMutableDependencyResolver RegisterLazySingletonAnd<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null)
+            where T : new() { }
+        public static Splat.IMutableDependencyResolver RegisterLazySingletonAnd<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> valueFactory, string? contract = null) { }
+    }
+    public static class ServiceLocationInitialization
+    {
+        public static void InitializeSplat(this Splat.IMutableDependencyResolver resolver) { }
+    }
+    public static class SizeMathExtensions
+    {
+        public static System.Drawing.SizeF ScaledBy(this System.Drawing.SizeF value, float factor) { }
+        public static bool WithinEpsilonOf(this System.Drawing.SizeF value, System.Drawing.SizeF other, float epsilon) { }
+    }
+    public sealed class StaticFullLogger : Splat.IStaticFullLogger
+    {
+        public StaticFullLogger(Splat.IFullLogger fullLogger) { }
+        public Splat.LogLevel Level { get; }
+        public void Debug(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Debug(System.Exception exception, string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Debug<T>(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Debug<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Debug<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Error(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Error(System.Exception exception, string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Error<T>(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Error<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Error<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Fatal(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Fatal(System.Exception exception, string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Fatal<T>(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Fatal<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Info(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Info(System.Exception exception, string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Info<T>(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Info<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Info<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Warn(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Warn(System.Exception exception, string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Warn<T>(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Warn<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Write(string? message, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Write(System.Exception exception, string? message, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Write([System.ComponentModel.Localizable(false)] string? message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string? message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+    }
+    public static class TargetFrameworkExtensions
+    {
+        public static string? GetTargetFrameworkName(this System.Reflection.Assembly assembly) { }
+    }
+    public class WrappingFullLogger : Splat.AllocationFreeLoggerBase, Splat.IAllocationFreeErrorLogger, Splat.IAllocationFreeLogger, Splat.IFullLogger, Splat.ILogger
+    {
+        public WrappingFullLogger(Splat.ILogger inner) { }
+        public void Debug(string? message) { }
+        public void Debug(System.Exception exception, string? message) { }
+        public void Debug(string message, params object[] args) { }
+        public void Debug(System.IFormatProvider formatProvider, string message, params object[] args) { }
+        public void Debug<T>(T value) { }
+        public void Debug<T>(string? message) { }
+        public void Debug<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Debug<T>(string message, params object[] args) { }
+        public void Debug<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
+        public void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Debug<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void DebugException(string? message, System.Exception exception) { }
+        public void Error(string? message) { }
+        public void Error(System.Exception exception, string? message) { }
+        public void Error(string message, params object[] args) { }
+        public void Error(System.IFormatProvider formatProvider, string message, params object[] args) { }
+        public void Error<T>(T value) { }
+        public void Error<T>(string? message) { }
+        public void Error<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Error<T>(string message, params object[] args) { }
+        public void Error<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
+        public void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Error<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void ErrorException(string? message, System.Exception exception) { }
+        public void Fatal(string? message) { }
+        public void Fatal(System.Exception exception, string? message) { }
+        public void Fatal(string message, params object[] args) { }
+        public void Fatal(System.IFormatProvider formatProvider, string message, params object[] args) { }
+        public void Fatal<T>(T value) { }
+        public void Fatal<T>(string? message) { }
+        public void Fatal<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Fatal<T>(string message, params object[] args) { }
+        public void Fatal<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
+        public void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void FatalException(string? message, System.Exception exception) { }
+        public void Info(string? message) { }
+        public void Info(System.Exception exception, string? message) { }
+        public void Info(string message, params object[] args) { }
+        public void Info(System.IFormatProvider formatProvider, string message, params object[] args) { }
+        public void Info<T>(T value) { }
+        public void Info<T>(string? message) { }
+        public void Info<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Info<T>(string message, params object[] args) { }
+        public void Info<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
+        public void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Info<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void InfoException(string? message, System.Exception exception) { }
+        public void Warn(string? message) { }
+        public void Warn(System.Exception exception, string? message) { }
+        public void Warn(string message, params object[] args) { }
+        public void Warn(System.IFormatProvider formatProvider, string message, params object[] args) { }
+        public void Warn<T>(T value) { }
+        public void Warn<T>(string? message) { }
+        public void Warn<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Warn<T>(string message, params object[] args) { }
+        public void Warn<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
+        public void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void WarnException(string? message, System.Exception exception) { }
+    }
+    public class WrappingLogLevelLogger : Splat.ILogger
+    {
+        public WrappingLogLevelLogger(Splat.ILogger inner) { }
+        public Splat.LogLevel Level { get; }
+        public void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public class WrappingPrefixLogger : Splat.ILogger
+    {
+        public WrappingPrefixLogger(Splat.ILogger inner, System.Type callingType) { }
+        public Splat.LogLevel Level { get; }
+        public void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+}
+namespace Splat.ApplicationPerformanceMonitoring
+{
+    public sealed class DefaultFeatureUsageTrackingManager : Splat.ApplicationPerformanceMonitoring.FuncFeatureUsageTrackingManager
+    {
+        public DefaultFeatureUsageTrackingManager() { }
+    }
+    public sealed class DefaultFeatureUsageTrackingSession : Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession, Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession<System.Guid>, Splat.IEnableLogger, System.IDisposable
+    {
+        public DefaultFeatureUsageTrackingSession(string featureName) { }
+        public string FeatureName { get; }
+        public System.Guid FeatureReference { get; }
+        public System.Guid ParentReference { get; }
+        public void Dispose() { }
+        public void OnException(System.Exception exception) { }
+        public Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession SubFeature(string description) { }
+    }
+    public static class EnableFeatureUsageTrackingExtensions
+    {
+        public static Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession FeatureUsageTrackingSession(this Splat.ApplicationPerformanceMonitoring.IEnableFeatureUsageTracking instance, string featureName) { }
+        public static void WithFeatureUsageTrackingSession(this Splat.ApplicationPerformanceMonitoring.IEnableFeatureUsageTracking instance, string featureName, System.Action<Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession> action) { }
+        public static void WithSubFeatureUsageTrackingSession(this Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession instance, string featureName, System.Action<Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession> action) { }
+    }
+    public class FuncFeatureUsageTrackingManager : Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingManager
+    {
+        public FuncFeatureUsageTrackingManager(System.Func<string, Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession> featureUsageTrackingSessionFunc) { }
+        public Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession GetFeatureUsageTrackingSession(string featureName) { }
+    }
+    [System.Runtime.InteropServices.ComVisible(false)]
+    public interface IEnableFeatureUsageTracking { }
+    public interface IFeatureUsageTrackingManager
+    {
+        Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession GetFeatureUsageTrackingSession(string featureName);
+    }
+    public interface IFeatureUsageTrackingSession : System.IDisposable
+    {
+        string FeatureName { get; }
+        void OnException(System.Exception exception);
+        Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession SubFeature(string description);
+    }
+    public interface IFeatureUsageTrackingSession<out TReferenceType> : Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession, System.IDisposable
+    {
+        TReferenceType FeatureReference { get; }
+        TReferenceType ParentReference { get; }
+    }
+    public interface IViewTracking
+    {
+        void OnViewNavigation(string name);
+    }
+}
+namespace Splat.ModeDetection
+{
+    public sealed class Mode : Splat.IModeDetector
+    {
+        public static readonly Splat.ModeDetection.Mode Run;
+        public static readonly Splat.ModeDetection.Mode Test;
+        public bool? InUnitTestRunner() { }
+    }
+}

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.DotNet8_0.verified.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.DotNet8_0.verified.txt
@@ -1,0 +1,783 @@
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.Drawing.Tests")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.TestRunner.Android")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.TestRunner.Uwp")]
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.Tests")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
+namespace Splat
+{
+    public class ActionLogger : Splat.ILogger
+    {
+        public ActionLogger(System.Action<string, Splat.LogLevel> writeNoType, System.Action<string, System.Type, Splat.LogLevel> writeWithType, System.Action<System.Exception, string, Splat.LogLevel> writeNoTypeWithException, System.Action<System.Exception, string, System.Type, Splat.LogLevel> writeWithTypeAndException) { }
+        public Splat.LogLevel Level { get; set; }
+        public void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public abstract class AllocationFreeLoggerBase : Splat.IAllocationFreeErrorLogger, Splat.IAllocationFreeLogger, Splat.ILogger
+    {
+        protected AllocationFreeLoggerBase(Splat.ILogger inner) { }
+        public bool IsDebugEnabled { get; }
+        public bool IsErrorEnabled { get; }
+        public bool IsFatalEnabled { get; }
+        public bool IsInfoEnabled { get; }
+        public bool IsWarnEnabled { get; }
+        public Splat.LogLevel Level { get; }
+        public virtual void Debug<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument) { }
+        public virtual void Debug<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Debug<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Debug<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Debug<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Error<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument) { }
+        public void Error<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Error<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Error<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Error<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Fatal<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument) { }
+        public void Fatal<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Fatal<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Fatal<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Info<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument) { }
+        public void Info<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Info<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Info<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Info<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public virtual void Warn<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument) { }
+        public void Warn<TArgument>(System.Exception exception, string messageFormat, TArgument argument) { }
+        public virtual void Warn<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public void Warn<TArgument1, TArgument2>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void Warn<TArgument1, TArgument2, TArgument3>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9) { }
+        public virtual void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public class ConsoleLogger : Splat.ILogger
+    {
+        public ConsoleLogger() { }
+        public string ExceptionMessageFormat { get; set; }
+        public Splat.LogLevel Level { get; set; }
+        public void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public class DebugLogger : Splat.ILogger
+    {
+        public DebugLogger() { }
+        public Splat.LogLevel Level { get; set; }
+        public void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public sealed class DefaultLogManager : Splat.ILogManager
+    {
+        public DefaultLogManager(Splat.IReadonlyDependencyResolver? dependencyResolver = null) { }
+        public Splat.IFullLogger GetLogger(System.Type type) { }
+    }
+    public class DefaultModeDetector : Splat.IEnableLogger, Splat.IModeDetector
+    {
+        public DefaultModeDetector() { }
+        public bool? InUnitTestRunner() { }
+    }
+    public static class DependencyResolverMixins
+    {
+        public static T? GetService<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
+        public static System.Collections.Generic.IEnumerable<T> GetServices<T>(this Splat.IReadonlyDependencyResolver resolver, string? contract = null) { }
+        public static void Register<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> factory, string? contract = null) { }
+        public static void Register<TAs, T>(this Splat.IMutableDependencyResolver resolver, string? contract = null)
+            where T : new() { }
+        public static void RegisterConstant(this Splat.IMutableDependencyResolver resolver, object? value, System.Type? serviceType, string? contract = null) { }
+        public static void RegisterConstant<T>(this Splat.IMutableDependencyResolver resolver, T? value, string? contract = null) { }
+        public static void RegisterLazySingleton(this Splat.IMutableDependencyResolver resolver, System.Func<object?> valueFactory, System.Type? serviceType, string? contract = null) { }
+        public static void RegisterLazySingleton<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T?> valueFactory, string? contract = null) { }
+        public static System.IDisposable ServiceRegistrationCallback(this Splat.IMutableDependencyResolver resolver, System.Type serviceType, System.Action<System.IDisposable> callback) { }
+        public static void UnregisterAll<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null) { }
+        public static void UnregisterCurrent<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null) { }
+        public static System.IDisposable WithResolver(this Splat.IDependencyResolver resolver, bool suppressResolverCallback = true) { }
+    }
+    public static class FullLoggerExtensions
+    {
+        public static void Debug(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Debug<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void DebugException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Error(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Error<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void ErrorException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Fatal(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Fatal<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void FatalException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Info(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Info<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void InfoException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+        public static void Warn(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void Warn<T>(this Splat.IFullLogger logger, System.Func<string> function) { }
+        public static void WarnException(this Splat.IFullLogger logger, System.Func<string> function, System.Exception exception) { }
+    }
+    public class FuncDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
+    {
+        public FuncDependencyResolver(System.Func<System.Type?, string?, System.Collections.Generic.IEnumerable<object>> getAllServices, System.Action<System.Func<object?>, System.Type?, string?>? register = null, System.Action<System.Type?, string?>? unregisterCurrent = null, System.Action<System.Type?, string?>? unregisterAll = null, System.IDisposable? toDispose = null) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool isDisposing) { }
+        public object? GetService(System.Type? serviceType, string? contract = null) { }
+        public System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null) { }
+        public bool HasRegistration(System.Type? serviceType, string? contract = null) { }
+        public void Register(System.Func<object?> factory, System.Type? serviceType, string? contract = null) { }
+        public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
+        public void UnregisterAll(System.Type? serviceType, string? contract = null) { }
+        public void UnregisterCurrent(System.Type? serviceType, string? contract = null) { }
+    }
+    public class FuncLogManager : Splat.ILogManager
+    {
+        public FuncLogManager(System.Func<System.Type, Splat.IFullLogger> getLoggerFunc) { }
+        public Splat.IFullLogger GetLogger(System.Type type) { }
+    }
+    public interface IAllocationFreeErrorLogger : Splat.ILogger
+    {
+        void Debug<TArgument>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Debug<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Error<TArgument>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Error<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Fatal<TArgument>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Fatal<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Info<TArgument>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Info<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Warn<TArgument>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Warn<TArgument1, TArgument2>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument1, TArgument2, TArgument3>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>(System.Exception exception, [System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+    }
+    public interface IAllocationFreeLogger : Splat.IAllocationFreeErrorLogger, Splat.ILogger
+    {
+        bool IsDebugEnabled { get; }
+        bool IsErrorEnabled { get; }
+        bool IsFatalEnabled { get; }
+        bool IsInfoEnabled { get; }
+        bool IsWarnEnabled { get; }
+        void Debug<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Debug<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Debug<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Error<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Error<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Error<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Fatal<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Fatal<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Fatal<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Info<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Info<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Info<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+        void Warn<TArgument>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument argument);
+        void Warn<TArgument1, TArgument2>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument1, TArgument2, TArgument3>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9);
+        void Warn<TArgument1, TArgument2, TArgument3, TArgument4, TArgument5, TArgument6, TArgument7, TArgument8, TArgument9, TArgument10>([System.ComponentModel.Localizable(false)] string messageFormat, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, TArgument4 argument4, TArgument5 argument5, TArgument6 argument6, TArgument7 argument7, TArgument8 argument8, TArgument9 argument9, TArgument10 argument10);
+    }
+    public interface IDependencyResolver : Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable { }
+    [System.Runtime.InteropServices.ComVisible(false)]
+    public interface IEnableLogger { }
+    public interface IFullLogger : Splat.IAllocationFreeErrorLogger, Splat.IAllocationFreeLogger, Splat.ILogger
+    {
+        void Debug([System.ComponentModel.Localizable(false)] string? message);
+        void Debug(System.Exception exception, [System.ComponentModel.Localizable(false)] string? message);
+        void Debug([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Debug(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Debug<T>(T value);
+        void Debug<T>([System.ComponentModel.Localizable(false)] string? message);
+        void Debug<T>(System.IFormatProvider formatProvider, T value);
+        void Debug<T>([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Debug<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument);
+        void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Debug<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.Obsolete("Use void Debug(Exception exception, [Localizable(false)] string? message)")]
+        void DebugException([System.ComponentModel.Localizable(false)] string? message, System.Exception exception);
+        void Error([System.ComponentModel.Localizable(false)] string? message);
+        void Error(System.Exception exception, [System.ComponentModel.Localizable(false)] string? message);
+        void Error([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Error(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Error<T>(T value);
+        void Error<T>([System.ComponentModel.Localizable(false)] string? message);
+        void Error<T>(System.IFormatProvider formatProvider, T value);
+        void Error<T>([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Error<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument);
+        void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Error<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.Obsolete("Use void Error(Exception exception, [Localizable(false)] string? message)")]
+        void ErrorException([System.ComponentModel.Localizable(false)] string? message, System.Exception exception);
+        void Fatal([System.ComponentModel.Localizable(false)] string? message);
+        void Fatal(System.Exception exception, [System.ComponentModel.Localizable(false)] string? message);
+        void Fatal([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Fatal(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Fatal<T>(T value);
+        void Fatal<T>([System.ComponentModel.Localizable(false)] string? message);
+        void Fatal<T>(System.IFormatProvider formatProvider, T value);
+        void Fatal<T>([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Fatal<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument);
+        void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Fatal<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.Obsolete("Use void Fatal(Exception exception, [Localizable(false)] string? message)")]
+        void FatalException([System.ComponentModel.Localizable(false)] string? message, System.Exception exception);
+        void Info([System.ComponentModel.Localizable(false)] string? message);
+        void Info(System.Exception exception, [System.ComponentModel.Localizable(false)] string? message);
+        void Info([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Info(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Info<T>(T value);
+        void Info<T>([System.ComponentModel.Localizable(false)] string? message);
+        void Info<T>(System.IFormatProvider formatProvider, T value);
+        void Info<T>([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Info<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument);
+        void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Info<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.Obsolete("Use void Info(Exception exception, [Localizable(false)] string? message)")]
+        void InfoException([System.ComponentModel.Localizable(false)] string? message, System.Exception exception);
+        void Warn([System.ComponentModel.Localizable(false)] string? message);
+        void Warn(System.Exception exception, [System.ComponentModel.Localizable(false)] string? message);
+        void Warn([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Warn(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Warn<T>(T value);
+        void Warn<T>([System.ComponentModel.Localizable(false)] string? message);
+        void Warn<T>(System.IFormatProvider formatProvider, T value);
+        void Warn<T>([System.ComponentModel.Localizable(false)] string message, params object[] args);
+        void Warn<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument);
+        void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2);
+        void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3);
+        [System.Obsolete("Use void Warn(Exception exception, [Localizable(false)] string? message)")]
+        void WarnException([System.ComponentModel.Localizable(false)] string? message, System.Exception exception);
+    }
+    public interface ILogManager
+    {
+        Splat.IFullLogger GetLogger(System.Type type);
+    }
+    public interface ILogger
+    {
+        Splat.LogLevel Level { get; }
+        void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel);
+        void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel);
+        void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel);
+        void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel);
+    }
+    public interface IModeDetector
+    {
+        bool? InUnitTestRunner();
+    }
+    public interface IMutableDependencyResolver
+    {
+        bool HasRegistration(System.Type? serviceType, string? contract = null);
+        void Register(System.Func<object?> factory, System.Type? serviceType, string? contract = null);
+        System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback);
+        void UnregisterAll(System.Type? serviceType, string? contract = null);
+        void UnregisterCurrent(System.Type? serviceType, string? contract = null);
+    }
+    public interface IReadonlyDependencyResolver
+    {
+        object? GetService(System.Type? serviceType, string? contract = null);
+        System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null);
+    }
+    public interface IStaticFullLogger
+    {
+        Splat.LogLevel Level { get; }
+        void Debug([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Debug(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Debug<T>([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Debug<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Debug<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Error([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Error(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Error<T>([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Error<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Error<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Fatal([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Fatal(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Fatal<T>([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Fatal<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Fatal<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Info([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Info(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Info<T>([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Info<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Info<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Warn([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Warn(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Warn<T>([System.ComponentModel.Localizable(false)] string message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Warn<TArgument>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, [System.ComponentModel.Localizable(false)] string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+        void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null);
+    }
+    public static class Locator
+    {
+        public static Splat.IReadonlyDependencyResolver Current { get; }
+        public static Splat.IMutableDependencyResolver CurrentMutable { get; }
+        public static bool AreResolverCallbackChangedNotificationsEnabled() { }
+        public static Splat.IDependencyResolver GetLocator() { }
+        public static System.IDisposable RegisterResolverCallbackChanged(System.Action callback) { }
+        public static void SetLocator(Splat.IDependencyResolver dependencyResolver) { }
+        public static System.IDisposable SuppressResolverCallbackChangedNotifications() { }
+    }
+    public static class LogHost
+    {
+        public static Splat.IStaticFullLogger Default { get; }
+        public static Splat.IFullLogger Log<T>(this T logClassInstance)
+            where T : Splat.IEnableLogger { }
+    }
+    public enum LogLevel
+    {
+        Debug = 1,
+        Info = 2,
+        Warn = 3,
+        Error = 4,
+        Fatal = 5,
+    }
+    public static class LogManagerMixin
+    {
+        public static Splat.IFullLogger GetLogger<T>(this Splat.ILogManager logManager) { }
+    }
+    [System.Serializable]
+    public class LoggingException : System.Exception
+    {
+        public LoggingException() { }
+        public LoggingException(string message) { }
+        public LoggingException(string message, System.Exception innerException) { }
+    }
+    public sealed class MemoizingMRUCache<TParam, TVal>
+        where TParam :  notnull
+    {
+        public MemoizingMRUCache(System.Func<TParam, object?, TVal> calculationFunc, int maxSize) { }
+        public MemoizingMRUCache(System.Func<TParam, object?, TVal> calculationFunc, int maxSize, System.Action<TVal> onRelease) { }
+        public MemoizingMRUCache(System.Func<TParam, object?, TVal> calculationFunc, int maxSize, System.Collections.Generic.IEqualityComparer<TParam> paramComparer) { }
+        public MemoizingMRUCache(System.Func<TParam, object?, TVal> calculationFunc, int maxSize, System.Action<TVal>? onRelease, System.Collections.Generic.IEqualityComparer<TParam> paramComparer) { }
+        public System.Collections.Generic.IEnumerable<TVal> CachedValues() { }
+        public TVal Get(TParam key) { }
+        public TVal Get(TParam key, object? context = null) { }
+        public void Invalidate(TParam key) { }
+        public void InvalidateAll(bool aggregateReleaseExceptions = false) { }
+        public bool TryGet(TParam key, out TVal? result) { }
+    }
+    public static class ModeDetector
+    {
+        public static bool InUnitTestRunner() { }
+        public static void OverrideModeDetector(Splat.IModeDetector modeDetector) { }
+    }
+    public class ModernDependencyResolver : Splat.IDependencyResolver, Splat.IMutableDependencyResolver, Splat.IReadonlyDependencyResolver, System.IDisposable
+    {
+        public ModernDependencyResolver() { }
+        protected ModernDependencyResolver([System.Runtime.CompilerServices.TupleElementNames(new string?[]?[] {
+                "serviceType",
+                "contract"})] System.Collections.Generic.Dictionary<System.ValueTuple<System.Type, string?>, System.Collections.Generic.List<System.Func<object?>>>? registry) { }
+        public void Dispose() { }
+        protected virtual void Dispose(bool isDisposing) { }
+        public Splat.ModernDependencyResolver Duplicate() { }
+        public object? GetService(System.Type? serviceType, string? contract = null) { }
+        public System.Collections.Generic.IEnumerable<object> GetServices(System.Type? serviceType, string? contract = null) { }
+        public bool HasRegistration(System.Type? serviceType, string? contract = null) { }
+        public void Register(System.Func<object?> factory, System.Type? serviceType, string? contract = null) { }
+        public System.IDisposable ServiceRegistrationCallback(System.Type serviceType, string? contract, System.Action<System.IDisposable> callback) { }
+        public void UnregisterAll(System.Type? serviceType, string? contract = null) { }
+        public void UnregisterCurrent(System.Type? serviceType, string? contract = null) { }
+    }
+    public class NullLogger : Splat.ILogger
+    {
+        public NullLogger() { }
+        public Splat.LogLevel Level { get; set; }
+        public void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public class NullServiceType
+    {
+        public NullServiceType(System.Func<object?> factory) { }
+        public System.Func<object?> Factory { get; }
+    }
+    public static class PointMathExtensions
+    {
+        public static float AngleInDegrees(this System.Drawing.PointF value) { }
+        public static float DistanceTo(this System.Drawing.PointF value, System.Drawing.PointF other) { }
+        public static float DotProduct(this System.Drawing.PointF value, System.Drawing.PointF other) { }
+        public static System.Drawing.PointF Floor(this System.Drawing.Point value) { }
+        public static float Length(this System.Drawing.PointF value) { }
+        public static System.Drawing.PointF Normalize(this System.Drawing.PointF value) { }
+        public static System.Drawing.PointF ProjectAlong(this System.Drawing.PointF value, System.Drawing.PointF direction) { }
+        public static System.Drawing.PointF ProjectAlongAngle(this System.Drawing.PointF value, float angleInDegrees) { }
+        public static System.Drawing.PointF ScaledBy(this System.Drawing.PointF value, float factor) { }
+        public static bool WithinEpsilonOf(this System.Drawing.PointF value, System.Drawing.PointF other, float epsilon) { }
+    }
+    public enum RectEdge
+    {
+        Left = 0,
+        Top = 1,
+        Right = 2,
+        Bottom = 3,
+    }
+    public static class RectangleMathExtensions
+    {
+        public static System.Drawing.PointF Center(this System.Drawing.RectangleF value) { }
+        public static System.Drawing.RectangleF Copy(this System.Drawing.RectangleF value, float? x = default, float? y = default, float? width = default, float? height = default, float? top = default, float? bottom = default) { }
+        public static System.Tuple<System.Drawing.RectangleF, System.Drawing.RectangleF> Divide(this System.Drawing.RectangleF value, float amount, Splat.RectEdge fromEdge) { }
+        public static System.Tuple<System.Drawing.RectangleF, System.Drawing.RectangleF> DivideWithPadding(this System.Drawing.RectangleF value, float sliceAmount, float padding, Splat.RectEdge fromEdge) { }
+        public static System.Drawing.RectangleF InvertWithin(this System.Drawing.RectangleF value, System.Drawing.RectangleF containingRect) { }
+    }
+    public static class ResolverMixins
+    {
+        public static Splat.IMutableDependencyResolver RegisterAnd<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null)
+            where T : new() { }
+        public static Splat.IMutableDependencyResolver RegisterAnd<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> factory, string? contract = null) { }
+        public static Splat.IMutableDependencyResolver RegisterAnd<TAs, T>(this Splat.IMutableDependencyResolver resolver, string? contract = null)
+            where T : new() { }
+        public static Splat.IMutableDependencyResolver RegisterAnd<TAs, T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> factory, string? contract = null) { }
+        public static Splat.IMutableDependencyResolver RegisterConstantAnd(this Splat.IMutableDependencyResolver resolver, object value, System.Type serviceType, string? contract = null) { }
+        public static Splat.IMutableDependencyResolver RegisterConstantAnd<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null)
+            where T : new() { }
+        public static Splat.IMutableDependencyResolver RegisterConstantAnd<T>(this Splat.IMutableDependencyResolver resolver, T value, string? contract = null) { }
+        public static Splat.IMutableDependencyResolver RegisterLazySingletonAnd(this Splat.IMutableDependencyResolver resolver, System.Func<object> valueFactory, System.Type serviceType, string? contract = null) { }
+        public static Splat.IMutableDependencyResolver RegisterLazySingletonAnd<T>(this Splat.IMutableDependencyResolver resolver, string? contract = null)
+            where T : new() { }
+        public static Splat.IMutableDependencyResolver RegisterLazySingletonAnd<T>(this Splat.IMutableDependencyResolver resolver, System.Func<T> valueFactory, string? contract = null) { }
+    }
+    public static class ServiceLocationInitialization
+    {
+        public static void InitializeSplat(this Splat.IMutableDependencyResolver resolver) { }
+    }
+    public static class SizeMathExtensions
+    {
+        public static System.Drawing.SizeF ScaledBy(this System.Drawing.SizeF value, float factor) { }
+        public static bool WithinEpsilonOf(this System.Drawing.SizeF value, System.Drawing.SizeF other, float epsilon) { }
+    }
+    public sealed class StaticFullLogger : Splat.IStaticFullLogger
+    {
+        public StaticFullLogger(Splat.IFullLogger fullLogger) { }
+        public Splat.LogLevel Level { get; }
+        public void Debug(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Debug(System.Exception exception, string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Debug<T>(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Debug<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Debug<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Error(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Error(System.Exception exception, string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Error<T>(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Error<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Error<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Fatal(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Fatal(System.Exception exception, string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Fatal<T>(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Fatal<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Info(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Info(System.Exception exception, string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Info<T>(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Info<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Info<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Warn(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Warn(System.Exception exception, string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Warn<T>(string? message, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Warn<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string? message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Write(string? message, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Write(System.Exception exception, string? message, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Write([System.ComponentModel.Localizable(false)] string? message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string? message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel, [System.Runtime.CompilerServices.CallerMemberName] string? callerMemberName = null) { }
+    }
+    public static class TargetFrameworkExtensions
+    {
+        public static string? GetTargetFrameworkName(this System.Reflection.Assembly assembly) { }
+    }
+    public class WrappingFullLogger : Splat.AllocationFreeLoggerBase, Splat.IAllocationFreeErrorLogger, Splat.IAllocationFreeLogger, Splat.IFullLogger, Splat.ILogger
+    {
+        public WrappingFullLogger(Splat.ILogger inner) { }
+        public void Debug(string? message) { }
+        public void Debug(System.Exception exception, string? message) { }
+        public void Debug(string message, params object[] args) { }
+        public void Debug(System.IFormatProvider formatProvider, string message, params object[] args) { }
+        public void Debug<T>(T value) { }
+        public void Debug<T>(string? message) { }
+        public void Debug<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Debug<T>(string message, params object[] args) { }
+        public void Debug<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
+        public void Debug<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Debug<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void DebugException(string? message, System.Exception exception) { }
+        public void Error(string? message) { }
+        public void Error(System.Exception exception, string? message) { }
+        public void Error(string message, params object[] args) { }
+        public void Error(System.IFormatProvider formatProvider, string message, params object[] args) { }
+        public void Error<T>(T value) { }
+        public void Error<T>(string? message) { }
+        public void Error<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Error<T>(string message, params object[] args) { }
+        public void Error<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
+        public void Error<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Error<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void ErrorException(string? message, System.Exception exception) { }
+        public void Fatal(string? message) { }
+        public void Fatal(System.Exception exception, string? message) { }
+        public void Fatal(string message, params object[] args) { }
+        public void Fatal(System.IFormatProvider formatProvider, string message, params object[] args) { }
+        public void Fatal<T>(T value) { }
+        public void Fatal<T>(string? message) { }
+        public void Fatal<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Fatal<T>(string message, params object[] args) { }
+        public void Fatal<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
+        public void Fatal<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Fatal<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void FatalException(string? message, System.Exception exception) { }
+        public void Info(string? message) { }
+        public void Info(System.Exception exception, string? message) { }
+        public void Info(string message, params object[] args) { }
+        public void Info(System.IFormatProvider formatProvider, string message, params object[] args) { }
+        public void Info<T>(T value) { }
+        public void Info<T>(string? message) { }
+        public void Info<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Info<T>(string message, params object[] args) { }
+        public void Info<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
+        public void Info<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Info<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void InfoException(string? message, System.Exception exception) { }
+        public void Warn(string? message) { }
+        public void Warn(System.Exception exception, string? message) { }
+        public void Warn(string message, params object[] args) { }
+        public void Warn(System.IFormatProvider formatProvider, string message, params object[] args) { }
+        public void Warn<T>(T value) { }
+        public void Warn<T>(string? message) { }
+        public void Warn<T>(System.IFormatProvider formatProvider, T value) { }
+        public void Warn<T>(string message, params object[] args) { }
+        public void Warn<TArgument>(System.IFormatProvider formatProvider, string message, TArgument argument) { }
+        public void Warn<TArgument1, TArgument2>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2) { }
+        public void Warn<TArgument1, TArgument2, TArgument3>(System.IFormatProvider formatProvider, string message, TArgument1 argument1, TArgument2 argument2, TArgument3 argument3) { }
+        public void WarnException(string? message, System.Exception exception) { }
+    }
+    public class WrappingLogLevelLogger : Splat.ILogger
+    {
+        public WrappingLogLevelLogger(Splat.ILogger inner) { }
+        public Splat.LogLevel Level { get; }
+        public void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+    public class WrappingPrefixLogger : Splat.ILogger
+    {
+        public WrappingPrefixLogger(Splat.ILogger inner, System.Type callingType) { }
+        public Splat.LogLevel Level { get; }
+        public void Write([System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, Splat.LogLevel logLevel) { }
+        public void Write([System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+        public void Write(System.Exception exception, [System.ComponentModel.Localizable(false)] string message, [System.ComponentModel.Localizable(false)] System.Type type, Splat.LogLevel logLevel) { }
+    }
+}
+namespace Splat.ApplicationPerformanceMonitoring
+{
+    public sealed class DefaultFeatureUsageTrackingManager : Splat.ApplicationPerformanceMonitoring.FuncFeatureUsageTrackingManager
+    {
+        public DefaultFeatureUsageTrackingManager() { }
+    }
+    public sealed class DefaultFeatureUsageTrackingSession : Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession, Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession<System.Guid>, Splat.IEnableLogger, System.IDisposable
+    {
+        public DefaultFeatureUsageTrackingSession(string featureName) { }
+        public string FeatureName { get; }
+        public System.Guid FeatureReference { get; }
+        public System.Guid ParentReference { get; }
+        public void Dispose() { }
+        public void OnException(System.Exception exception) { }
+        public Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession SubFeature(string description) { }
+    }
+    public static class EnableFeatureUsageTrackingExtensions
+    {
+        public static Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession FeatureUsageTrackingSession(this Splat.ApplicationPerformanceMonitoring.IEnableFeatureUsageTracking instance, string featureName) { }
+        public static void WithFeatureUsageTrackingSession(this Splat.ApplicationPerformanceMonitoring.IEnableFeatureUsageTracking instance, string featureName, System.Action<Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession> action) { }
+        public static void WithSubFeatureUsageTrackingSession(this Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession instance, string featureName, System.Action<Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession> action) { }
+    }
+    public class FuncFeatureUsageTrackingManager : Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingManager
+    {
+        public FuncFeatureUsageTrackingManager(System.Func<string, Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession> featureUsageTrackingSessionFunc) { }
+        public Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession GetFeatureUsageTrackingSession(string featureName) { }
+    }
+    [System.Runtime.InteropServices.ComVisible(false)]
+    public interface IEnableFeatureUsageTracking { }
+    public interface IFeatureUsageTrackingManager
+    {
+        Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession GetFeatureUsageTrackingSession(string featureName);
+    }
+    public interface IFeatureUsageTrackingSession : System.IDisposable
+    {
+        string FeatureName { get; }
+        void OnException(System.Exception exception);
+        Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession SubFeature(string description);
+    }
+    public interface IFeatureUsageTrackingSession<out TReferenceType> : Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession, System.IDisposable
+    {
+        TReferenceType FeatureReference { get; }
+        TReferenceType ParentReference { get; }
+    }
+    public interface IViewTracking
+    {
+        void OnViewNavigation(string name);
+    }
+}
+namespace Splat.ModeDetection
+{
+    public sealed class Mode : Splat.IModeDetector
+    {
+        public static readonly Splat.ModeDetection.Mode Run;
+        public static readonly Splat.ModeDetection.Mode Test;
+        public bool? InUnitTestRunner() { }
+    }
+}

--- a/src/Splat.Tests/Splat.Tests.csproj
+++ b/src/Splat.Tests/Splat.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows10.0.17763.0;net7.0-windows10.0.17763.0;net8.0-windows10.0.17763.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000;CA1034</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

target frameworks incorrectly set to netx.0-windows

**What is the new behavior?**
<!-- If this is a feature change -->

update targets to netx.0-windows10.0.17763.0 remove unsupported Android targets.

**What might this PR break?**



**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

