### PR TITLE
Housekeeping: Retire Xamarin due to end of support

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -15,5 +15,6 @@ jobs:
     with:
       configuration: Release
       productNamespacePrefix: "Splat"
+      dotNetBuild: true
       useVisualStudioPreview: false
       useMauiCheckDotNetTool: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ jobs:
     with:
       configuration: Release
       productNamespacePrefix: "Splat"
-      useVisualStudioPreview: true
+      dotNetBuild: true
+      useVisualStudioPreview: false
       useMauiCheckDotNetTool: false
     secrets:
       SIGN_CLIENT_USER_ID: ${{ secrets.SIGN_CLIENT_USER_ID }}

--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ Splat currently supports:
 [Always Be NuGetting](https://nuget.org/packages/Splat/). Package contains binaries for:
 
 * .NET Framework 4.6.2, .NET Framework 4.7.2, .NET Standard 2.0, .NET 6.0, .NET 7.0, and .NET 8.0
+- Works with:
   * WPF
   * Windows Forms
-  * UWP
-  * Maui
-  * Xamarin (Android, iOS and Mac)
-  * Tizen
+  * WinUI 3
+  * Maui (WinUI, Android, iOS and Mac)
+  * Avalonia
 
 ## Detecting whether you're in a unit test runner
 

--- a/src/Splat.Drawing/Splat.Drawing.csproj
+++ b/src/Splat.Drawing/Splat.Drawing.csproj
@@ -1,6 +1,6 @@
-<Project Sdk="MSBuild.Sdk.Extras">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>$(SplatTargetFrameworks);MonoAndroid13.0;Xamarin.iOS10;Xamarin.Mac20;Xamarin.TVOS10;Xamarin.WatchOS10;tizen40;net7.0-android;net7.0-ios;net7.0-tvos;net7.0-macos;net7.0-maccatalyst;net8.0-android;net8.0-ios;net8.0-tvos;net8.0-macos;net8.0-maccatalyst</TargetFrameworks>
+    <TargetFrameworks>$(SplatTargetFrameworks);net7.0-android;net7.0-ios;net7.0-tvos;net7.0-macos;net7.0-maccatalyst;net8.0-android;net8.0-ios;net8.0-tvos;net8.0-macos;net8.0-maccatalyst</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);net462;net472;$(SplatWindowsTargetFrameworks)</TargetFrameworks>
     <RootNamespace>Splat</RootNamespace>
     <Authors>.NET Foundation and Contributors</Authors>

--- a/src/Splat.Tests/Splat.Tests.csproj
+++ b/src/Splat.Tests/Splat.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net6.0-windows10.0.17763.0;net7.0-windows10.0.17763.0;net8.0-windows10.0.17763.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000;CA1034</NoWarn>

--- a/src/global.json
+++ b/src/global.json
@@ -2,8 +2,5 @@
     "sdk": {
         "version": "8.0.204",
         "rollForward": "latestFeature"
-    },
-    "msbuild-sdks": {
-        "MSBuild.Sdk.Extras": "3.0.44"
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "14.8",
+  "version": "15.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of master
     "^refs/heads/preview/.*", // we release previews


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Xamarin is supported

**What is the new behavior?**
<!-- If this is a feature change -->

Retire Xamarin due to end of support in line with Microsoft

**What might this PR break?**

Xamarin users will need to continue using V14.8.x

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

