### PR TITLE
Splat.NLog - Faster mapping of LogLevel using switch-operation

### DIFF
--- a/src/Splat.NLog/Splat.NLog.csproj
+++ b/src/Splat.NLog/Splat.NLog.csproj
@@ -10,7 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NLog" />
-    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Splat\Splat.csproj" />

--- a/src/Splat/Logging/ILogger.cs
+++ b/src/Splat/Logging/ILogger.cs
@@ -33,7 +33,7 @@ public interface ILogger
     void Write(Exception exception, [Localizable(false)] string message, LogLevel logLevel);
 
     /// <summary>
-    /// Writes a messge to the target.
+    /// Writes a message to the target.
     /// </summary>
     /// <param name="message">The message.</param>
     /// <param name="type">The type.</param>
@@ -41,7 +41,7 @@ public interface ILogger
     void Write([Localizable(false)] string message, [Localizable(false)] Type type, LogLevel logLevel);
 
     /// <summary>
-    /// Writes a messge to the target.
+    /// Writes a message to the target.
     /// </summary>
     /// <param name="exception">The exception that occured.</param>
     /// <param name="message">The message.</param>

--- a/src/Splat/Logging/IStaticFullLogger.cs
+++ b/src/Splat/Logging/IStaticFullLogger.cs
@@ -341,7 +341,7 @@ public interface IStaticFullLogger
     void Write(Exception exception, [Localizable(false)] string message, LogLevel logLevel, [CallerMemberName]string? callerMemberName = null);
 
     /// <summary>
-    /// Writes a messge to the target.
+    /// Writes a message to the target.
     /// </summary>
     /// <param name="message">The message.</param>
     /// <param name="type">The type.</param>
@@ -350,7 +350,7 @@ public interface IStaticFullLogger
     void Write([Localizable(false)] string message, [Localizable(false)] Type type, LogLevel logLevel, [CallerMemberName]string? callerMemberName = null);
 
     /// <summary>
-    /// Writes a messge to the target.
+    /// Writes a message to the target.
     /// </summary>
     /// <param name="exception">The exception that occured.</param>
     /// <param name="message">The message.</param>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
- Minor optimization of mapping from Splat LogLevel to NLog LogLevel
- Removes dependency on System.Collections.Immutable-nuget-package
- Fixes minor spelling issue in XML docs for ILogger-interface

**What is the current behavior?**
- Performs dictionary lookup when mapping from Splat LogLevel to NLog LogLevel
- Has additional dependency on System.Collections.Immutable-nuget-package

**What is the new behavior?**
- Performs switch-operation when mapping from Splat LogLevel to Nlog LogLevel
- No dependency on System.Collections.Immutable-nuget-package

**What might this PR break?**
- No breaking changes

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**: