### PR TITLE
Splat.NLog - Reduce allocation when creating new NLogLogger

### DIFF
--- a/src/Splat.NLog/NLogLogger.cs
+++ b/src/Splat.NLog/NLogLogger.cs
@@ -14,6 +14,7 @@ namespace Splat.NLog;
 [DebuggerDisplay("Name={_inner.Name} Level={Level}")]
 public sealed class NLogLogger : IFullLogger, IDisposable
 {
+    private static readonly LogLevel[] _allLogLevels = Enum.GetValues(typeof(LogLevel)).Cast<LogLevel>().ToArray();
     private readonly global::NLog.Logger _inner;
 
     /// <summary>
@@ -564,7 +565,7 @@ public sealed class NLogLogger : IFullLogger, IDisposable
     /// </remarks>
     private void SetLogLevel()
     {
-        foreach (LogLevel logLevel in Enum.GetValues(typeof(LogLevel)))
+        foreach (LogLevel logLevel in _allLogLevels)
         {
             if (_inner.IsEnabled(ResolveLogLevel(logLevel)))
             {


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
- Followup to #1257

**What is the current behavior?**
- For every new NLogLogger then it will allocate new Array

**What is the new behavior?**
- Store array from Enum.GetValues and reuse for every new NLogLogger

**What might this PR break?**
- No breaking changes

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**Other information**: