### PR TITLE
Remove AOT attributes and update obsolete code

### DIFF
--- a/src/Splat.Common.Test/DummyObjectClass1.cs
+++ b/src/Splat.Common.Test/DummyObjectClass1.cs
@@ -11,6 +11,4 @@ namespace Splat.Tests.Mocks;
 /// A dummy class used during Locator testing.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class DummyObjectClass1 : IDummyInterface
-{
-}
+public class DummyObjectClass1 : IDummyInterface;

--- a/src/Splat.Common.Test/DummyObjectClass2.cs
+++ b/src/Splat.Common.Test/DummyObjectClass2.cs
@@ -11,6 +11,4 @@ namespace Splat.Tests.Mocks;
 /// A dummy class used during Locator testing.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class DummyObjectClass2 : IDummyInterface
-{
-}
+public class DummyObjectClass2 : IDummyInterface;

--- a/src/Splat.Common.Test/DummyObjectClass3.cs
+++ b/src/Splat.Common.Test/DummyObjectClass3.cs
@@ -11,6 +11,4 @@ namespace Splat.Tests.Mocks;
 /// A dummy class used during Locator testing.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class DummyObjectClass3 : IDummyInterface
-{
-}
+public class DummyObjectClass3 : IDummyInterface;

--- a/src/Splat.Common.Test/MockScreen.cs
+++ b/src/Splat.Common.Test/MockScreen.cs
@@ -12,6 +12,4 @@ namespace Splat.Common.Test;
 /// </summary>
 /// <seealso cref="IScreen" />
 [ExcludeFromCodeCoverage]
-public class MockScreen : IScreen
-{
-}
+public class MockScreen : IScreen;

--- a/src/Splat.Common.Test/ViewModelTwo.cs
+++ b/src/Splat.Common.Test/ViewModelTwo.cs
@@ -11,6 +11,4 @@ namespace Splat.Common.Test;
 /// View Model Two.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class ViewModelTwo
-{
-}
+public class ViewModelTwo;

--- a/src/Splat.Drawing/Platforms/Android/Bitmaps/PlatformBitmapLoader.cs
+++ b/src/Splat.Drawing/Platforms/Android/Bitmaps/PlatformBitmapLoader.cs
@@ -23,8 +23,6 @@ public class PlatformBitmapLoader : IBitmapLoader, IEnableLogger
     /// <summary>
     /// Initializes a new instance of the <see cref="PlatformBitmapLoader"/> class.
     /// </summary>
-    [RequiresUnreferencedCode("Calls Splat.PlatformBitmapLoader.GetDrawableList()")]
-    [RequiresDynamicCode("Calls Splat.PlatformBitmapLoader.GetDrawableList()")]
     public PlatformBitmapLoader() => _drawableList = GetDrawableList();
 
     /// <inheritdoc />
@@ -113,16 +111,12 @@ public class PlatformBitmapLoader : IBitmapLoader, IEnableLogger
 #pragma warning restore CA2000 // Dispose objects before losing scope
     }
 
-    [RequiresDynamicCode("Calls Splat.PlatformBitmapLoader.GetDrawableList(IFullLogger, Assembly[])")]
-    [RequiresUnreferencedCode("Calls Splat.PlatformBitmapLoader.GetDrawableList(IFullLogger, Assembly[])")]
     internal static Dictionary<string, int> GetDrawableList(IFullLogger? log)
     {
         var assemblies = AppDomain.CurrentDomain.GetAssemblies();
         return GetDrawableList(log, assemblies);
     }
 
-    [RequiresDynamicCode("Reflection is required to get drawable resources.")]
-    [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetTypes()")]
     private static Type[] GetTypesFromAssembly(
         Assembly assembly,
         IFullLogger? log)
@@ -160,8 +154,6 @@ public class PlatformBitmapLoader : IBitmapLoader, IEnableLogger
         }
     }
 
-    [RequiresDynamicCode("Reflection is required to get drawable resources.")]
-    [RequiresUnreferencedCode("Calls System.Reflection.Assembly.GetTypes()")]
     private static Dictionary<string, int> GetDrawableList(
         IFullLogger? log,
         Assembly[] assemblies)
@@ -229,8 +221,6 @@ public class PlatformBitmapLoader : IBitmapLoader, IEnableLogger
                && sourceStream.ReadByte() == 0xD9;
     }
 
-    [RequiresDynamicCode("Calls Splat.PlatformBitmapLoader.GetDrawableList(IFullLogger)")]
-    [RequiresUnreferencedCode("Calls Splat.PlatformBitmapLoader.GetDrawableList(IFullLogger)")]
     private static Dictionary<string, int> GetDrawableList() => GetDrawableList(Locator.Current.GetService<ILogManager>()?.GetLogger(typeof(PlatformBitmapLoader)));
 
     private void AttemptStreamByteCorrection(Stream sourceStream)

--- a/src/Splat.Drawing/Platforms/ReflectionStubs.cs
+++ b/src/Splat.Drawing/Platforms/ReflectionStubs.cs
@@ -10,10 +10,6 @@ namespace Splat;
 
 internal static class ReflectionStubs
 {
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode("Type.GetField() may be trimmed.")]
-    [RequiresDynamicCode("Type.GetField() may be trimmed.")]
-#endif
     public static FieldInfo? GetField(this Type value, string name, BindingFlags flags = default)
     {
         var ti = value.GetTypeInfo();
@@ -23,10 +19,6 @@ internal static class ReflectionStubs
             : ti.BaseType.GetField(name, flags);
     }
 
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode("Type.GetMethod() may be trimmed.")]
-    [RequiresDynamicCode("Type.GetMethod() may be trimmed.")]
-#endif
     public static MethodInfo? GetMethod(this Type value, string name, BindingFlags flags = default)
     {
         var ti = value.GetTypeInfo();
@@ -36,10 +28,6 @@ internal static class ReflectionStubs
             : ti.BaseType.GetMethod(name, flags);
     }
 
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode("Type.GetProperty() may be trimmed.")]
-    [RequiresDynamicCode("Type.GetProperty() may be trimmed.")]
-#endif
     public static PropertyInfo? GetProperty(this Type value, string name, BindingFlags flags = default)
     {
         var ti = value.GetTypeInfo();
@@ -49,10 +37,6 @@ internal static class ReflectionStubs
             : ti.BaseType.GetProperty(name, flags);
     }
 
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode("Type.GetEvent() may be trimmed.")]
-    [RequiresDynamicCode("Type.GetEvent() may be trimmed.")]
-#endif
     public static EventInfo? GetEvent(this Type value, string name, BindingFlags flags = default)
     {
         var ti = value.GetTypeInfo();
@@ -62,22 +46,10 @@ internal static class ReflectionStubs
             : ti.BaseType.GetEvent(name, flags);
     }
 
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode("Type.GetProperties() may be trimmed.")]
-    [RequiresDynamicCode("Type.GetProperties() may be trimmed.")]
-#endif
     public static IEnumerable<PropertyInfo> GetProperties(this Type value) => value.GetTypeInfo().DeclaredProperties;
 
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode("Type.GetFields() may be trimmed.")]
-    [RequiresDynamicCode("Type.GetFields() may be trimmed.")]
-#endif
     public static IEnumerable<FieldInfo> GetFields(this Type value) => value.GetTypeInfo().DeclaredFields;
 
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode("Type.GetMethod() may be trimmed.")]
-    [RequiresDynamicCode("Type.GetMethod() may be trimmed.")]
-#endif
     public static MethodInfo? GetMethod(this Type value, string methodName, Type[] paramTypes, BindingFlags flags = default)
     {
         var ti = value.GetTypeInfo();
@@ -89,10 +61,6 @@ internal static class ReflectionStubs
             : ti.BaseType.GetMethod(methodName, paramTypes, flags);
     }
 
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode("Type.GetMethods() may be trimmed.")]
-    [RequiresDynamicCode("Type.GetMethods() may be trimmed.")]
-#endif
     public static IEnumerable<MethodInfo> GetMethods(this Type value) => value.GetTypeInfo().DeclaredMethods;
 
     public static IEnumerable<object> GetCustomAttributes(this Type value, Type attributeType, bool inherit) => value.GetTypeInfo().GetCustomAttributes(attributeType, inherit);

--- a/src/Splat.Drawing/Platforms/ServiceLocationDrawingInitialization.cs
+++ b/src/Splat.Drawing/Platforms/ServiceLocationDrawingInitialization.cs
@@ -16,10 +16,6 @@ public static class ServiceLocationDrawingInitialization
     /// Registers the platform bitmap loader for the current platform.
     /// </summary>
     /// <param name="resolver">The resolver to register against.</param>
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode("Calls IMutableDependencyResolver.RegisterLazySingleton<TService>(Func<TService>)")]
-    [RequiresDynamicCode("Calls IMutableDependencyResolver.RegisterLazySingleton<TService>(Func<TService>)")]
-#endif
     public static void RegisterPlatformBitmapLoader(this IMutableDependencyResolver resolver)
     {
         resolver.ThrowArgumentNullExceptionIfNull(nameof(resolver));

--- a/src/Splat.Drawing/Splat.Drawing.csproj
+++ b/src/Splat.Drawing/Splat.Drawing.csproj
@@ -9,9 +9,9 @@
     <NoWarn>$(NoWarn);1591</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0'))">
+  <!--<PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0'))">
     <IsAotCompatible>true</IsAotCompatible>
-  </PropertyGroup>
+  </PropertyGroup>-->
   <PropertyGroup Condition="($(TargetFramework.EndsWith('-windows10.0.17763.0')) or $(TargetFramework.StartsWith('net4'))) and '$(OS)' == 'Windows_NT'">
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>

--- a/src/Splat/AssemblyFinder.cs
+++ b/src/Splat/AssemblyFinder.cs
@@ -3,7 +3,6 @@
 // ReactiveUI licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Splat;
@@ -16,11 +15,7 @@ internal static class AssemblyFinder
     /// <typeparam name="T">The type to cast the value to if we find it.</typeparam>
     /// <param name="fullTypeName">The name of the full type.</param>
     /// <returns>The created object or the default value.</returns>
-#if NET6_0_OR_GREATER
-    [RequiresUnreferencedCode("Calls AssemblyFinder.AttemptToLoadType<T>(string)")]
-    [RequiresDynamicCode("Calls AssemblyFinder.AttemptToLoadType<T>(string)")]
-#endif
-    public static T? AttemptToLoadType<T>(string fullTypeName)
+public static T? AttemptToLoadType<T>(string fullTypeName)
     {
         var thisType = typeof(AssemblyFinder);
 

--- a/src/Splat/Logging/FullLoggerExtensions.cs
+++ b/src/Splat/Logging/FullLoggerExtensions.cs
@@ -110,9 +110,7 @@ public static class FullLoggerExtensions
 
         if (logger.IsInfoEnabled)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            logger.InfoException(function.Invoke(), exception);
-#pragma warning restore CS0618 // Type or member is obsolete
+            logger.Info(exception, function.Invoke());
         }
     }
 
@@ -162,9 +160,7 @@ public static class FullLoggerExtensions
 
         if (logger.IsWarnEnabled)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            logger.WarnException(function.Invoke(), exception);
-#pragma warning restore CS0618 // Type or member is obsolete
+            logger.Warn(exception, function.Invoke());
         }
     }
 
@@ -214,9 +210,7 @@ public static class FullLoggerExtensions
 
         if (logger.IsErrorEnabled)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            logger.ErrorException(function.Invoke(), exception);
-#pragma warning restore CS0618 // Type or member is obsolete
+            logger.Error(exception, function.Invoke());
         }
     }
 
@@ -266,9 +260,7 @@ public static class FullLoggerExtensions
 
         if (logger.IsFatalEnabled)
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            logger.ErrorException(function.Invoke(), exception);
-#pragma warning restore CS0618 // Type or member is obsolete
+            logger.Error(exception, function.Invoke());
         }
     }
 }

--- a/src/Splat/Splat.csproj
+++ b/src/Splat/Splat.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(SplatTargetFrameworks)</TargetFrameworks>
     <AssemblyName>Splat</AssemblyName>
@@ -8,9 +8,9 @@
     <PackageId>Splat</PackageId>
     <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0'))">
+  <!--<PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0'))">
     <IsAotCompatible>true</IsAotCompatible>
-  </PropertyGroup>
-
+  </PropertyGroup>-->
+  
 </Project>
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

AOT markup is causing issues with linking and compilation

**What is the new behavior?**
<!-- If this is a feature change -->

Eliminated [RequiresUnreferencedCode] and [RequiresDynamicCode] attributes from multiple files to simplify code and improve compatibility. Updated test dummy classes to use file-scoped declarations. Refactored logger extension methods to use non-obsolete overloads. Removed IsAotCompatible property groups in project files for .NET 8/9.

**What might this PR break?**

Assembly will no longer be marked as AOT compatible until a better resolution can be made

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

