### PR TITLE
Fix Rectangle math

### DIFF
--- a/src/Splat.Tests/RectEdgeTests.cs
+++ b/src/Splat.Tests/RectEdgeTests.cs
@@ -1,0 +1,115 @@
+// Copyright (c) 2025 ReactiveUI. All rights reserved.
+// Licensed to ReactiveUI under one or more agreements.
+// ReactiveUI licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Drawing;
+
+namespace Splat.Tests;
+
+/// <summary>
+/// Unit Tests for the RectEdge enum and its usage.
+/// </summary>
+public class RectEdgeTests
+{
+    /// <summary>
+    /// Test that all RectEdge values work with Divide method.
+    /// </summary>
+    /// <param name="edge">The edge to test.</param>
+    [Theory]
+    [InlineData(RectEdge.Left)]
+    [InlineData(RectEdge.Top)]
+    [InlineData(RectEdge.Right)]
+    [InlineData(RectEdge.Bottom)]
+    public void RectEdge_AllValues_WorkWithDivide(RectEdge edge)
+    {
+        // Arrange
+        var rect = new RectangleF(0.0f, 0.0f, 100.0f, 100.0f);
+
+        // Act & Assert - should not throw
+        var (slice, remainder) = rect.Divide(25.0f, edge);
+
+        // Basic validation
+        Assert.True(slice.Width > 0 || slice.Height > 0);
+        Assert.True(remainder.Width >= 0 && remainder.Height >= 0);
+    }
+
+    /// <summary>
+    /// Test that RectEdge enum has expected values.
+    /// </summary>
+    [Fact]
+    public void RectEdge_HasExpectedValues()
+    {
+        // Assert
+        Assert.Equal(0, (int)RectEdge.Left);
+        Assert.Equal(1, (int)RectEdge.Top);
+        Assert.Equal(2, (int)RectEdge.Right);
+        Assert.Equal(3, (int)RectEdge.Bottom);
+    }
+
+    /// <summary>
+    /// Test that RectEdge enum has all expected names.
+    /// </summary>
+    [Fact]
+    public void RectEdge_HasAllExpectedNames()
+    {
+        // Arrange
+        var expectedNames = new[] { "Left", "Top", "Right", "Bottom" };
+        var actualNames = Enum.GetNames(typeof(RectEdge));
+
+        // Assert
+        Assert.Equal(expectedNames.Length, actualNames.Length);
+        foreach (var expectedName in expectedNames)
+        {
+            Assert.Contains(expectedName, actualNames);
+        }
+    }
+
+    /// <summary>
+    /// Test that each RectEdge value can be parsed from string.
+    /// </summary>
+    /// <param name="edgeName">The name of the edge to parse.</param>
+    /// <param name="expectedEdge">The expected edge value.</param>
+    [Theory]
+    [InlineData("Left", RectEdge.Left)]
+    [InlineData("Top", RectEdge.Top)]
+    [InlineData("Right", RectEdge.Right)]
+    [InlineData("Bottom", RectEdge.Bottom)]
+    public void RectEdge_CanBeParsedFromString(string edgeName, RectEdge expectedEdge)
+    {
+        // Act
+        var parsed = Enum.Parse<RectEdge>(edgeName);
+
+        // Assert
+        Assert.Equal(expectedEdge, parsed);
+    }
+
+    /// <summary>
+    /// Test that each RectEdge value produces different results with Divide.
+    /// </summary>
+    [Fact]
+    public void RectEdge_ProducesDifferentResultsWithDivide()
+    {
+        // Arrange
+        var rect = new RectangleF(10.0f, 20.0f, 100.0f, 80.0f);
+        const float amount = 30.0f;
+
+        // Act
+        var leftResult = rect.Divide(amount, RectEdge.Left);
+        var topResult = rect.Divide(amount, RectEdge.Top);
+        var rightResult = rect.Divide(amount, RectEdge.Right);
+        var bottomResult = rect.Divide(amount, RectEdge.Bottom);
+
+        // Assert - Each should produce different slice positions
+        Assert.NotEqual(leftResult.Item1.X, rightResult.Item1.X);
+        Assert.NotEqual(topResult.Item1.Y, bottomResult.Item1.Y);
+
+        // Left and Right should affect X coordinates differently
+        Assert.Equal(rect.X, leftResult.Item1.X);
+        Assert.NotEqual(rect.X, rightResult.Item1.X);
+
+        // Top and Bottom should affect Y coordinates differently
+        Assert.Equal(rect.Y, topResult.Item1.Y);
+        Assert.NotEqual(rect.Y, bottomResult.Item1.Y);
+    }
+}

--- a/src/Splat.Tests/RectangleMathExtensionsTests.cs
+++ b/src/Splat.Tests/RectangleMathExtensionsTests.cs
@@ -1,0 +1,261 @@
+// Copyright (c) 2025 ReactiveUI. All rights reserved.
+// Licensed to ReactiveUI under one or more agreements.
+// ReactiveUI licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.Drawing;
+
+namespace Splat.Tests;
+
+/// <summary>
+/// Unit Tests for the RectangleMathExtensions class.
+/// </summary>
+public class RectangleMathExtensionsTests
+{
+    /// <summary>
+    /// Test that Center method calculates correctly.
+    /// </summary>
+    [Fact]
+    public void Center_CalculatesCorrectly()
+    {
+        // Arrange
+        var rect = new RectangleF(10.0f, 20.0f, 30.0f, 40.0f);
+
+        // Act
+        var center = rect.Center();
+
+        // Assert
+        Assert.Equal(25.0f, center.X); // 10 + 30/2 = 25
+        Assert.Equal(40.0f, center.Y); // 20 + 40/2 = 40
+    }
+
+    /// <summary>
+    /// Test Divide method from left edge.
+    /// </summary>
+    [Fact]
+    public void Divide_FromLeftEdge_WorksCorrectly()
+    {
+        // Arrange
+        var rect = new RectangleF(0.0f, 0.0f, 100.0f, 50.0f);
+
+        // Act
+        var (slice, remainder) = rect.Divide(30.0f, RectEdge.Left);
+
+        // Assert
+        Assert.Equal(30.0f, slice.Width);
+        Assert.Equal(0.0f, slice.X);
+        Assert.Equal(70.0f, remainder.Width);
+        Assert.Equal(30.0f, remainder.X);
+    }
+
+    /// <summary>
+    /// Test Divide method from right edge.
+    /// </summary>
+    [Fact]
+    public void Divide_FromRightEdge_WorksCorrectly()
+    {
+        // Arrange
+        var rect = new RectangleF(0.0f, 0.0f, 100.0f, 50.0f);
+
+        // Act
+        var (slice, remainder) = rect.Divide(30.0f, RectEdge.Right);
+
+        // Assert
+        Assert.Equal(30.0f, slice.Width);
+        Assert.Equal(70.0f, slice.X);
+        Assert.Equal(70.0f, remainder.Width);
+        Assert.Equal(0.0f, remainder.X);
+    }
+
+    /// <summary>
+    /// Test Divide method from top edge.
+    /// </summary>
+    [Fact]
+    public void Divide_FromTopEdge_WorksCorrectly()
+    {
+        // Arrange
+        var rect = new RectangleF(0.0f, 0.0f, 100.0f, 50.0f);
+
+        // Act
+        var (slice, remainder) = rect.Divide(20.0f, RectEdge.Top);
+
+        // Assert
+        Assert.Equal(20.0f, slice.Height);
+        Assert.Equal(0.0f, slice.Y);
+        Assert.Equal(30.0f, remainder.Height);
+        Assert.Equal(20.0f, remainder.Y);
+    }
+
+    /// <summary>
+    /// Test Divide method from bottom edge.
+    /// </summary>
+    [Fact]
+    public void Divide_FromBottomEdge_WorksCorrectly()
+    {
+        // Arrange
+        var rect = new RectangleF(0.0f, 0.0f, 100.0f, 50.0f);
+
+        // Act
+        var (slice, remainder) = rect.Divide(20.0f, RectEdge.Bottom);
+
+        // Assert
+        Assert.Equal(20.0f, slice.Height);
+        Assert.Equal(30.0f, slice.Y);
+        Assert.Equal(30.0f, remainder.Height);
+        Assert.Equal(0.0f, remainder.Y);
+    }
+
+    /// <summary>
+    /// Test DivideWithPadding method.
+    /// </summary>
+    [Fact]
+    public void DivideWithPadding_WorksCorrectly()
+    {
+        // Arrange
+        var rect = new RectangleF(0.0f, 0.0f, 100.0f, 50.0f);
+
+        // Act
+        var (slice, remainder) = rect.DivideWithPadding(30.0f, 10.0f, RectEdge.Left);
+
+        // Assert
+        Assert.Equal(30.0f, slice.Width);
+        Assert.Equal(0.0f, slice.X);
+        Assert.Equal(90.0f, remainder.Width); // 100 - 10 = 90 (after padding)
+        Assert.Equal(10.0f, remainder.X); // starts after padding
+    }
+
+    /// <summary>
+    /// Test InvertWithin method.
+    /// </summary>
+    [Fact]
+    public void InvertWithin_WorksCorrectly()
+    {
+        // Arrange
+        var rect = new RectangleF(10.0f, 20.0f, 30.0f, 40.0f);
+        var container = new RectangleF(0.0f, 0.0f, 200.0f, 100.0f);
+
+        // Act
+        var inverted = rect.InvertWithin(container);
+
+        // Assert
+        Assert.Equal(10.0f, inverted.X); // X unchanged
+        Assert.Equal(40.0f, inverted.Y); // 100 - (20 + 40) = 40
+        Assert.Equal(30.0f, inverted.Width); // Width unchanged
+        Assert.Equal(40.0f, inverted.Height); // Height unchanged
+    }
+
+    /// <summary>
+    /// Test Copy method with all parameters.
+    /// </summary>
+    [Fact]
+    public void Copy_WithAllParameters_WorksCorrectly()
+    {
+        // Arrange
+        var rect = new RectangleF(10.0f, 20.0f, 30.0f, 40.0f);
+
+        // Act
+        var copy = rect.Copy(x: 15.0f, y: 25.0f, width: 35.0f, height: 45.0f);
+
+        // Assert
+        Assert.Equal(15.0f, copy.X);
+        Assert.Equal(25.0f, copy.Y);
+        Assert.Equal(35.0f, copy.Width);
+        Assert.Equal(45.0f, copy.Height);
+    }
+
+    /// <summary>
+    /// Test Copy method with partial parameters.
+    /// </summary>
+    [Fact]
+    public void Copy_WithPartialParameters_WorksCorrectly()
+    {
+        // Arrange
+        var rect = new RectangleF(10.0f, 20.0f, 30.0f, 40.0f);
+
+        // Act
+        var copy = rect.Copy(x: 15.0f, height: 50.0f);
+
+        // Assert
+        Assert.Equal(15.0f, copy.X);
+        Assert.Equal(20.0f, copy.Y); // unchanged
+        Assert.Equal(30.0f, copy.Width); // unchanged
+        Assert.Equal(50.0f, copy.Height);
+    }
+
+    /// <summary>
+    /// Test Copy method with top parameter.
+    /// </summary>
+    [Fact]
+    public void Copy_WithTopParameter_WorksCorrectly()
+    {
+        // Arrange
+        var rect = new RectangleF(10.0f, 20.0f, 30.0f, 40.0f);
+
+        // Act
+        var copy = rect.Copy(top: 5.0f);
+
+        // Assert
+        Assert.Equal(10.0f, copy.X); // unchanged
+        Assert.Equal(5.0f, copy.Y); // set to top value
+        Assert.Equal(30.0f, copy.Width); // unchanged
+        Assert.Equal(40.0f, copy.Height); // unchanged
+    }
+
+    /// <summary>
+    /// Test Copy method with bottom parameter.
+    /// </summary>
+    [Fact]
+    public void Copy_WithBottomParameter_WorksCorrectly()
+    {
+        // Arrange
+        var rect = new RectangleF(10.0f, 20.0f, 30.0f, 40.0f);
+
+        // Act
+        var copy = rect.Copy(bottom: 80.0f);
+
+        // Assert
+        Assert.Equal(10.0f, copy.X); // unchanged
+        Assert.Equal(20.0f, copy.Y); // unchanged
+        Assert.Equal(30.0f, copy.Width); // unchanged
+        Assert.Equal(100.0f, copy.Height); // 20 + 80 = 100
+    }
+
+    /// <summary>
+    /// Test Copy method throws when Y and Top are both specified.
+    /// </summary>
+    [Fact]
+    public void Copy_WithYAndTop_ThrowsArgumentException()
+    {
+        // Arrange
+        var rect = new RectangleF(10.0f, 20.0f, 30.0f, 40.0f);
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => rect.Copy(y: 25.0f, top: 5.0f));
+    }
+
+    /// <summary>
+    /// Test Copy method throws when Height and Bottom are both specified.
+    /// </summary>
+    [Fact]
+    public void Copy_WithHeightAndBottom_ThrowsArgumentException()
+    {
+        // Arrange
+        var rect = new RectangleF(10.0f, 20.0f, 30.0f, 40.0f);
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => rect.Copy(height: 50.0f, bottom: 80.0f));
+    }
+
+    /// <summary>
+    /// Test Divide with invalid edge throws ArgumentException.
+    /// </summary>
+    [Fact]
+    public void Divide_WithInvalidEdge_ThrowsArgumentException()
+    {
+        // Arrange
+        var rect = new RectangleF(0.0f, 0.0f, 100.0f, 50.0f);
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => rect.Divide(30.0f, (RectEdge)999));
+    }
+}

--- a/src/Splat/Maths/RectangleMathExtensions.cs
+++ b/src/Splat/Maths/RectangleMathExtensions.cs
@@ -25,32 +25,27 @@ public static class RectangleMathExtensions
     /// <param name="value">The rectangle to perform the calculation against.</param>
     /// <param name="amount">Amount to move away from the given edge.</param>
     /// <param name="fromEdge">The edge to create the slice from.</param>
-    /// <returns>The set of rectnagles that are generated.</returns>
+    /// <returns>The set of rectangles that are generated.</returns>
     public static Tuple<RectangleF, RectangleF> Divide(this RectangleF value, float amount, RectEdge fromEdge)
     {
-        float delta;
         switch (fromEdge)
         {
             case RectEdge.Left:
-                delta = Math.Max(value.Width, amount);
                 return Tuple.Create(
-                    value.Copy(width: delta),
-                    value.Copy(x: value.Left + delta, width: value.Width - delta));
+                    value.Copy(width: amount),
+                    value.Copy(x: value.Left + amount, width: value.Width - amount));
             case RectEdge.Top:
-                delta = Math.Max(value.Height, amount);
                 return Tuple.Create(
                     value.Copy(height: amount),
-                    value.Copy(y: value.Top + delta, height: value.Height - delta));
+                    value.Copy(y: value.Top + amount, height: value.Height - amount));
             case RectEdge.Right:
-                delta = Math.Max(value.Width, amount);
                 return Tuple.Create(
-                    value.Copy(x: value.Right - delta, width: delta),
-                    value.Copy(width: value.Width - delta));
+                    value.Copy(x: value.Right - amount, width: amount),
+                    value.Copy(width: value.Width - amount));
             case RectEdge.Bottom:
-                delta = Math.Max(value.Height, amount);
                 return Tuple.Create(
-                    value.Copy(y: value.Bottom - delta, height: delta),
-                    value.Copy(height: value.Height - delta));
+                    value.Copy(y: value.Bottom - amount, height: amount),
+                    value.Copy(height: value.Height - amount));
             default:
                 throw new ArgumentException("edge");
         }
@@ -68,8 +63,8 @@ public static class RectangleMathExtensions
     public static Tuple<RectangleF, RectangleF> DivideWithPadding(this RectangleF value, float sliceAmount, float padding, RectEdge fromEdge)
     {
         var slice = value.Divide(sliceAmount, fromEdge);
-        var pad = value.Divide(padding, fromEdge);
-        return Tuple.Create(slice.Item1, pad.Item2);
+        var paddingRect = value.Divide(padding, fromEdge);
+        return Tuple.Create(slice.Item1, paddingRect.Item2);
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Fix

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Rectangle Math is incorrect

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request introduces comprehensive unit tests for `RectEdge` and `RectangleMathExtensions`, along with improvements to the `Divide` and `DivideWithPadding` methods in `RectangleMathExtensions`. The changes enhance test coverage, ensure correctness, and simplify the implementation of rectangle operations.

### New Unit Tests:

* **`RectEdge` Tests** (`src/Splat.Tests/RectEdgeTests.cs`):
  - Added tests to validate all `RectEdge` values, their names, parsing from strings, and their behavior with the `Divide` method.
  - Ensured that `RectEdge` values produce distinct results when used with `Divide`.

* **`RectangleMathExtensions` Tests** (`src/Splat.Tests/RectangleMathExtensionsTests.cs`):
  - Added tests for `Center`, `Divide`, `DivideWithPadding`, `InvertWithin`, and `Copy` methods to verify their correctness under various scenarios.
  - Included edge cases, such as invalid `RectEdge` values and conflicting parameters in `Copy`, to ensure proper exception handling.

### Code Improvements:

* **Refactored `Divide` Method** (`src/Splat/Maths/RectangleMathExtensions.cs`):
  - Simplified logic by directly using the `amount` parameter instead of calculating a `delta` value.

* **Refactored `DivideWithPadding` Method** (`src/Splat/Maths/RectangleMathExtensions.cs`):
  - Renamed variables for clarity and improved readability by using meaningful names like `paddingRect`.

These changes improve code reliability, maintainability, and clarity while ensuring robust test coverage for critical functionality.

**What might this PR break?**

Existing usage may have been compensated for by end user

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

