### PR TITLE
Add Disposable Tests

### DIFF
--- a/src/Splat.Tests/DisposableTests.cs
+++ b/src/Splat.Tests/DisposableTests.cs
@@ -1,0 +1,271 @@
+// Copyright (c) 2025 ReactiveUI. All rights reserved.
+// Licensed to ReactiveUI under one or more agreements.
+// ReactiveUI licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Splat.Tests;
+
+/// <summary>
+/// Unit Tests for the disposable classes.
+/// </summary>
+public class DisposableTests
+{
+    /// <summary>
+    /// Test BooleanDisposable initial state.
+    /// </summary>
+    [Fact]
+    public void BooleanDisposable_InitialState_IsNotDisposed()
+    {
+        // Arrange & Act
+        var disposable = new BooleanDisposable();
+
+        // Assert
+        Assert.False(disposable.IsDisposed);
+    }
+
+    /// <summary>
+    /// Test BooleanDisposable dispose sets IsDisposed to true.
+    /// </summary>
+    [Fact]
+    public void BooleanDisposable_Dispose_SetsIsDisposedToTrue()
+    {
+        // Arrange
+        var disposable = new BooleanDisposable();
+
+        // Act
+        disposable.Dispose();
+
+        // Assert
+        Assert.True(disposable.IsDisposed);
+    }
+
+    /// <summary>
+    /// Test BooleanDisposable multiple dispose calls.
+    /// </summary>
+    [Fact]
+    public void BooleanDisposable_MultipleDisposeCallsAreSafe()
+    {
+        // Arrange
+        var disposable = new BooleanDisposable();
+
+        // Act
+        disposable.Dispose();
+        disposable.Dispose();
+        disposable.Dispose();
+
+        // Assert
+        Assert.True(disposable.IsDisposed);
+    }
+
+    /// <summary>
+    /// Test ActionDisposable executes action on dispose.
+    /// </summary>
+    [Fact]
+    public void ActionDisposable_Dispose_ExecutesAction()
+    {
+        // Arrange
+        var actionExecuted = false;
+        var disposable = new ActionDisposable(() => actionExecuted = true);
+
+        // Act
+        disposable.Dispose();
+
+        // Assert
+        Assert.True(actionExecuted);
+    }
+
+    /// <summary>
+    /// Test ActionDisposable executes action only once.
+    /// </summary>
+    [Fact]
+    public void ActionDisposable_MultipleDispose_ExecutesActionOnlyOnce()
+    {
+        // Arrange
+        var executionCount = 0;
+        var disposable = new ActionDisposable(() => executionCount++);
+
+        // Act
+        disposable.Dispose();
+        disposable.Dispose();
+        disposable.Dispose();
+
+        // Assert
+        Assert.Equal(1, executionCount);
+    }
+
+    /// <summary>
+    /// Test ActionDisposable.Empty does nothing.
+    /// </summary>
+    [Fact]
+    public void ActionDisposable_Empty_DoesNothing()
+    {
+        // Arrange & Act
+        var disposable = ActionDisposable.Empty;
+
+        // Assert - should not throw
+        disposable.Dispose();
+        disposable.Dispose();
+    }
+
+    /// <summary>
+    /// Test CompositeDisposable default constructor.
+    /// </summary>
+    [Fact]
+    public void CompositeDisposable_DefaultConstructor_Works()
+    {
+        // Arrange & Act
+        var disposable = new CompositeDisposable();
+
+        // Assert - should not throw
+        disposable.Dispose();
+    }
+
+    /// <summary>
+    /// Test CompositeDisposable with capacity constructor.
+    /// </summary>
+    [Fact]
+    public void CompositeDisposable_CapacityConstructor_Works()
+    {
+        // Arrange & Act
+        var disposable = new CompositeDisposable(10);
+
+        // Assert - should not throw
+        disposable.Dispose();
+    }
+
+    /// <summary>
+    /// Test CompositeDisposable with negative capacity throws ArgumentOutOfRangeException.
+    /// </summary>
+    [Fact]
+    public void CompositeDisposable_NegativeCapacity_ThrowsArgumentOutOfRangeException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => new CompositeDisposable(-1));
+    }
+
+    /// <summary>
+    /// Test CompositeDisposable with array constructor.
+    /// </summary>
+    [Fact]
+    public void CompositeDisposable_ArrayConstructor_DisposesAllItems()
+    {
+        // Arrange
+        var disposed1 = false;
+        var disposed2 = false;
+        var action1 = new ActionDisposable(() => disposed1 = true);
+        var action2 = new ActionDisposable(() => disposed2 = true);
+
+        var disposable = new CompositeDisposable(action1, action2);
+
+        // Act
+        disposable.Dispose();
+
+        // Assert
+        Assert.True(disposed1);
+        Assert.True(disposed2);
+    }
+
+    /// <summary>
+    /// Test CompositeDisposable with enumerable constructor.
+    /// </summary>
+    [Fact]
+    public void CompositeDisposable_EnumerableConstructor_DisposesAllItems()
+    {
+        // Arrange
+        var disposed1 = false;
+        var disposed2 = false;
+        var disposed3 = false;
+        var disposables = new List<IDisposable>
+        {
+            new ActionDisposable(() => disposed1 = true),
+            new ActionDisposable(() => disposed2 = true),
+            new ActionDisposable(() => disposed3 = true)
+        };
+
+        var compositeDisposable = new CompositeDisposable(disposables);
+
+        // Act
+        compositeDisposable.Dispose();
+
+        // Assert
+        Assert.True(disposed1);
+        Assert.True(disposed2);
+        Assert.True(disposed3);
+    }
+
+    /// <summary>
+    /// Test CompositeDisposable throws for null array.
+    /// </summary>
+    [Fact]
+    public void CompositeDisposable_NullArray_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new CompositeDisposable((IDisposable[])null!));
+    }
+
+    /// <summary>
+    /// Test CompositeDisposable throws for null enumerable.
+    /// </summary>
+    [Fact]
+    public void CompositeDisposable_NullEnumerable_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => new CompositeDisposable((IEnumerable<IDisposable>)null!));
+    }
+
+    /// <summary>
+    /// Test CompositeDisposable throws for null item in array.
+    /// </summary>
+    [Fact]
+    public void CompositeDisposable_NullItemInArray_ThrowsArgumentException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new CompositeDisposable(new ActionDisposable(() => { }), null!));
+    }
+
+    /// <summary>
+    /// Test CompositeDisposable throws for null item in enumerable.
+    /// </summary>
+    [Fact]
+    public void CompositeDisposable_NullItemInEnumerable_ThrowsArgumentException()
+    {
+        // Arrange
+        var disposables = new List<IDisposable> { new ActionDisposable(() => { }), null! };
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => new CompositeDisposable(disposables));
+    }
+
+    /// <summary>
+    /// Test CompositeDisposable multiple dispose calls are safe.
+    /// </summary>
+    [Fact]
+    public void CompositeDisposable_MultipleDisposeCallsAreSafe()
+    {
+        // Arrange
+        var executionCount = 0;
+        var action = new ActionDisposable(() => executionCount++);
+        var disposable = new CompositeDisposable(action);
+
+        // Act
+        disposable.Dispose();
+        disposable.Dispose();
+        disposable.Dispose();
+
+        // Assert
+        Assert.Equal(1, executionCount);
+    }
+
+    /// <summary>
+    /// Test CompositeDisposable with empty enumerable.
+    /// </summary>
+    [Fact]
+    public void CompositeDisposable_EmptyEnumerable_Works()
+    {
+        // Arrange & Act
+        var disposable = new CompositeDisposable(new List<IDisposable>());
+
+        // Assert - should not throw
+        disposable.Dispose();
+    }
+}

--- a/src/Splat/Disposables/ActionDisposable.cs
+++ b/src/Splat/Disposables/ActionDisposable.cs
@@ -8,9 +8,20 @@ namespace Splat;
 /// <summary>
 /// A disposable which will call the specified action.
 /// </summary>
-internal sealed class ActionDisposable(Action block) : IDisposable
+internal sealed class ActionDisposable : IDisposable
 {
-    private Action _block = block;
+    private Action _block;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActionDisposable"/> class.
+    /// </summary>
+    /// <param name="block">The action to execute when disposed.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="block"/> is null.</exception>
+    public ActionDisposable(Action block)
+    {
+        block.ThrowArgumentNullExceptionIfNull(nameof(block));
+        _block = block;
+    }
 
     /// <summary>
     /// Gets a action disposable which does nothing.

--- a/src/Splat/Disposables/CompositeDisposable.cs
+++ b/src/Splat/Disposables/CompositeDisposable.cs
@@ -31,7 +31,10 @@ internal sealed class CompositeDisposable : IDisposable
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than zero.</exception>
     public CompositeDisposable(int capacity)
     {
-        capacity.ThrowArgumentNullExceptionIfNull(nameof(capacity));
+        if (capacity < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity cannot be negative.");
+        }
 
         _disposables = new(capacity);
     }

--- a/src/Splat/Disposables/CompositeDisposable.cs
+++ b/src/Splat/Disposables/CompositeDisposable.cs
@@ -31,10 +31,14 @@ internal sealed class CompositeDisposable : IDisposable
     /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is less than zero.</exception>
     public CompositeDisposable(int capacity)
     {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfNegative(capacity);
+#else
         if (capacity < 0)
         {
             throw new ArgumentOutOfRangeException(nameof(capacity), "Capacity cannot be negative.");
         }
+#endif
 
         _disposables = new(capacity);
     }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Disposable tests are incomplete

**What is the new behavior?**
<!-- If this is a feature change -->

This pull request introduces comprehensive unit tests for disposable classes and improves the robustness of the `ActionDisposable` and `CompositeDisposable` implementations by adding better validation and error handling. The most important changes include the addition of a new test suite, refactoring of `ActionDisposable` to use a traditional constructor, and improved validation for `CompositeDisposable`.

### Additions to Unit Tests:
* [`src/Splat.Tests/DisposableTests.cs`](diffhunk://#diff-0b8a096b7e1e941cabd49f84b9ff03e7ee0829c41c5bb85214d1d12d5fcd09eeR1-R271): Added a new test suite for disposable classes, covering `BooleanDisposable`, `ActionDisposable`, and `CompositeDisposable`. Tests include validation of initial states, multiple dispose calls, and error handling for invalid inputs.

### Improvements to `ActionDisposable`:
* [`src/Splat/Disposables/ActionDisposable.cs`](diffhunk://#diff-6ad52cb231ca87835ada371c487acf27958826b6070e8e009303dcdc1be0bdfcL11-R24): Refactored `ActionDisposable` to use a traditional constructor instead of a record-like syntax. Added a null-check for the provided action with a `ThrowArgumentNullExceptionIfNull` helper to ensure robustness.

### Improvements to `CompositeDisposable`:
* [`src/Splat/Disposables/CompositeDisposable.cs`](diffhunk://#diff-9835d2a954a12d7d448763b433c038e09391a2eae1be52e68374bfdfef136d15L34-R37): Replaced the unnecessary null-check for `capacity` with a proper validation that throws an `ArgumentOutOfRangeException` if the capacity is negative. This ensures meaningful error messages and better code clarity.

**What might this PR break?**

None expected

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

