### PR TITLE
Add Xunit v3 test project support and update tests

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -60,11 +60,7 @@
     <PackageVersion Include="System.Threading.Timer" Version="4.3.0" />
     <PackageVersion Include="System.Xml.ReaderWriter" Version="4.3.1" />
     <PackageVersion Include="System.Xml.XmlDocument" Version="4.3.0" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
-    <PackageVersion Include="Verify.Xunit" Version="30.5.0" />
-    <PackageVersion Include="Xunit.StaFact" Version="1.2.69" />
     <PackageVersion Include="FluentAssertions" Version="8.5.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.0.1" />
@@ -83,5 +79,17 @@
   <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard'))">
     <PackageVersion Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageVersion Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition="$(MSBuildProjectName.Contains('.Tests'))">
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.console" Version="2.9.3" />
+    <PackageVersion Include="Verify.Xunit" Version="30.5.0" />
+    <PackageVersion Include="Xunit.StaFact" Version="1.2.69" />
+  </ItemGroup>
+  <ItemGroup Condition="$(MSBuildProjectName.Contains('.Test3'))">
+    <PackageVersion Include="xunit.v3" Version="3.0.0" />
+    <PackageVersion Include="xunit.v3.runner.console" Version="3.0.0" />
+    <PackageVersion Include="Verify.XunitV3" Version="30.5.0" />
+    <PackageVersion Include="Xunit.StaFact" Version="3.0.13" />
   </ItemGroup>
 </Project>

--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -3,7 +3,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591;1701;1702;1705;VSX1000;IDE0130</NoWarn>
     <Platform>AnyCPU</Platform>
-    <IsTestProject>$(MSBuildProjectName.Contains('Tests'))</IsTestProject>
+    <IsTestProject>$(MSBuildProjectName.Contains('.Tests'))</IsTestProject>
+    <IsV3UnitProject>$(MSBuildProjectName.Contains('.Test3'))</IsV3UnitProject>
     <DebugType>embedded</DebugType>
     <Authors>.NET Foundation and Contributors</Authors>
     <Copyright>Copyright (c) .NET Foundation and Contributors</Copyright>
@@ -40,27 +41,35 @@
     <SplatTargetFrameworks>netstandard2.0;net8.0;net9.0</SplatTargetFrameworks>
     <SplatWindowsTargetFrameworks>net8.0-windows10.0.17763.0;net9.0-windows10.0.17763.0</SplatWindowsTargetFrameworks>
   </PropertyGroup>
-  <PropertyGroup Condition="$(IsTestProject) != 'true'">
+  <PropertyGroup Condition="$(IsTestProject) != 'true' or $(IsV3UnitProject) != 'true'">
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
-  <ItemGroup Condition="$(IsTestProject) or $(MSBuildProjectName.Contains('TestRunner'))">
+  <ItemGroup Condition="$(IsTestProject) or $(IsV3UnitProject) or $(MSBuildProjectName.Contains('TestRunner'))">
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
-    <PackageReference Include="Xunit.StaFact" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.Reactive.Testing" />
     <PackageReference Include="PublicApiGenerator" />
-    <PackageReference Include="Verify.Xunit" />
   </ItemGroup>
-  <ItemGroup Condition="$(IsTestProject)">
+  <ItemGroup Condition="$(MSBuildProjectName.Contains('.Tests'))">
+    <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.console" />
+    <PackageReference Include="Xunit.StaFact" />
+    <PackageReference Include="Verify.Xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="coverlet.msbuild" />
   </ItemGroup>
-  <ItemGroup Condition="'$(IsTestProject)' != 'true'">
+  <ItemGroup Condition="$(MSBuildProjectName.Contains('.Test3'))">
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.runner.console" />
+    <PackageReference Include="Xunit.StaFact" />
+    <PackageReference Include="Verify.XunitV3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.msbuild" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsTestProject)' != 'true' or '$(IsV3UnitProject)' != 'true'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
   </ItemGroup>
   <PropertyGroup>

--- a/src/ReactiveUI.DI.Tests/ReactiveUI.DI.Test3.csproj
+++ b/src/ReactiveUI.DI.Tests/ReactiveUI.DI.Test3.csproj
@@ -5,6 +5,9 @@
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
   <Choose>
     <When Condition="$(TargetFramework.StartsWith('net472'))">
       <ItemGroup>

--- a/src/Splat.Aot.Tests/Splat.Aot.Test3.csproj
+++ b/src/Splat.Aot.Tests/Splat.Aot.Test3.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
@@ -19,6 +19,9 @@
     
     <!-- Suppress trim warnings for test-specific scenarios -->
     <SuppressTrimAnalysisWarnings>false</SuppressTrimAnalysisWarnings>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Autofac.Tests/Splat.Autofac.Tests.csproj
+++ b/src/Splat.Autofac.Tests/Splat.Autofac.Tests.csproj
@@ -7,6 +7,9 @@
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000;CA1851</NoWarn>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Net.Http" />

--- a/src/Splat.Avalonia.DryIoc1.Tests/Splat.Avalonia.DryIoc1.Tests.csproj
+++ b/src/Splat.Avalonia.DryIoc1.Tests/Splat.Avalonia.DryIoc1.Tests.csproj
@@ -8,6 +8,9 @@
     <IsTestProject>true</IsTestProject>
     <DefineConstants>$(DefineConstants);DRYIOC1</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
   <ItemGroup>
     <AvaloniaXaml Include="..\Splat.Avalonia.Tests\Mocks\App.axaml" Link="Mocks\App.axaml">
       <SubType>Designer</SubType>

--- a/src/Splat.Avalonia.DryIoc2.Tests/Splat.Avalonia.DryIoc2.Tests.csproj
+++ b/src/Splat.Avalonia.DryIoc2.Tests/Splat.Avalonia.DryIoc2.Tests.csproj
@@ -8,6 +8,9 @@
     <IsTestProject>true</IsTestProject>
     <DefineConstants>$(DefineConstants);DRYIOC2</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
   <ItemGroup>
     <AvaloniaXaml Include="..\Splat.Avalonia.Tests\Mocks\App.axaml" Link="Mocks\App.axaml">
       <SubType>Designer</SubType>

--- a/src/Splat.Avalonia.Microsoft1.Tests/Splat.Avalonia.Microsoft1.Tests.csproj
+++ b/src/Splat.Avalonia.Microsoft1.Tests/Splat.Avalonia.Microsoft1.Tests.csproj
@@ -8,6 +8,9 @@
     <IsTestProject>true</IsTestProject>
     <DefineConstants>$(DefineConstants);MICROSOFT1</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
   <ItemGroup>
     <AvaloniaXaml Include="..\Splat.Avalonia.Tests\Mocks\App.axaml" Link="Mocks\App.axaml">
       <SubType>Designer</SubType>

--- a/src/Splat.Avalonia.Microsoft2.Tests/Splat.Avalonia.Microsoft2.Tests.csproj
+++ b/src/Splat.Avalonia.Microsoft2.Tests/Splat.Avalonia.Microsoft2.Tests.csproj
@@ -8,6 +8,9 @@
     <IsTestProject>true</IsTestProject>
     <DefineConstants>$(DefineConstants);MICROSOFT2</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
   <ItemGroup>
     <AvaloniaXaml Include="..\Splat.Avalonia.Tests\Mocks\App.axaml" Link="Mocks\App.axaml">
       <SubType>Designer</SubType>

--- a/src/Splat.Avalonia.Tests/Splat.Avalonia.Tests.csproj
+++ b/src/Splat.Avalonia.Tests/Splat.Avalonia.Tests.csproj
@@ -8,6 +8,9 @@
     <IsTestProject>true</IsTestProject>
     <DefineConstants>$(DefineConstants);MAIN</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Splat.Avalonia.Microsoft.Extensions.DependencyInjection\Splat.Avalonia.Microsoft.Extensions.DependencyInjection.csproj" />
   </ItemGroup>

--- a/src/Splat.Common.Test/DummyObjectClass1.cs
+++ b/src/Splat.Common.Test/DummyObjectClass1.cs
@@ -11,6 +11,6 @@ namespace Splat.Tests.Mocks;
 /// A dummy class used during Locator testing.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class DummyObjectClass1 : IDummyInterface
-{
-}
+#pragma warning disable CA1515 // Consider making public types internal
+public class DummyObjectClass1 : IDummyInterface;
+#pragma warning restore CA1515 // Consider making public types internal

--- a/src/Splat.Common.Test/DummyObjectClass2.cs
+++ b/src/Splat.Common.Test/DummyObjectClass2.cs
@@ -11,6 +11,6 @@ namespace Splat.Tests.Mocks;
 /// A dummy class used during Locator testing.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class DummyObjectClass2 : IDummyInterface
-{
-}
+#pragma warning disable CA1515 // Consider making public types internal
+public class DummyObjectClass2 : IDummyInterface;
+#pragma warning restore CA1515 // Consider making public types internal

--- a/src/Splat.Common.Test/DummyObjectClass3.cs
+++ b/src/Splat.Common.Test/DummyObjectClass3.cs
@@ -11,6 +11,6 @@ namespace Splat.Tests.Mocks;
 /// A dummy class used during Locator testing.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class DummyObjectClass3 : IDummyInterface
-{
-}
+#pragma warning disable CA1515 // Consider making public types internal
+public class DummyObjectClass3 : IDummyInterface;
+#pragma warning restore CA1515 // Consider making public types internal

--- a/src/Splat.Common.Test/IDummyInterface.cs
+++ b/src/Splat.Common.Test/IDummyInterface.cs
@@ -9,6 +9,6 @@ namespace Splat.Tests.Mocks;
 /// A dummy interface used during Locator testing.
 /// </summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1040:Avoid empty interfaces", Justification = "By Design")]
-public interface IDummyInterface
-{
-}
+#pragma warning disable CA1515 // Consider making public types internal
+public interface IDummyInterface;
+#pragma warning restore CA1515 // Consider making public types internal

--- a/src/Splat.Common.Test/IScreen.cs
+++ b/src/Splat.Common.Test/IScreen.cs
@@ -9,6 +9,6 @@ namespace Splat.Common.Test;
 /// Represents a screen.
 /// </summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1040:Avoid empty interfaces", Justification = "By Design")]
-public interface IScreen
-{
-}
+#pragma warning disable CA1515 // Consider making public types internal
+public interface IScreen;
+#pragma warning restore CA1515 // Consider making public types internal

--- a/src/Splat.Common.Test/IViewFor.cs
+++ b/src/Splat.Common.Test/IViewFor.cs
@@ -12,7 +12,9 @@ namespace Splat.Common.Test;
 /// </summary>
 /// <typeparam name="T">The view model type.</typeparam>
 /// <seealso cref="Splat.Common.Test.IViewFor" />
+#pragma warning disable CA1515 // Consider making public types internal
 public interface IViewFor<T> : IViewFor
+#pragma warning restore CA1515 // Consider making public types internal
     where T : class
 {
     /// <summary>
@@ -25,7 +27,9 @@ public interface IViewFor<T> : IViewFor
 /// Represents a view bound to a view model.
 /// </summary>
 /// <seealso cref="Splat.Common.Test.IViewFor" />
+#pragma warning disable CA1515 // Consider making public types internal
 public interface IViewFor
+#pragma warning restore CA1515 // Consider making public types internal
 {
     /// <summary>
     /// Gets or sets the view model.

--- a/src/Splat.Common.Test/IViewModelOne.cs
+++ b/src/Splat.Common.Test/IViewModelOne.cs
@@ -9,6 +9,6 @@ namespace Splat.Common.Test;
 /// Interface for ViewModelOne.
 /// </summary>
 [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1040:Avoid empty interfaces", Justification = "By Design")]
-public interface IViewModelOne
-{
-}
+#pragma warning disable CA1515 // Consider making public types internal
+public interface IViewModelOne;
+#pragma warning restore CA1515 // Consider making public types internal

--- a/src/Splat.Common.Test/MockScreen.cs
+++ b/src/Splat.Common.Test/MockScreen.cs
@@ -12,6 +12,6 @@ namespace Splat.Common.Test;
 /// </summary>
 /// <seealso cref="IScreen" />
 [ExcludeFromCodeCoverage]
-public class MockScreen : IScreen
-{
-}
+#pragma warning disable CA1515 // Consider making public types internal
+public class MockScreen : IScreen;
+#pragma warning restore CA1515 // Consider making public types internal

--- a/src/Splat.Common.Test/Splat.Common.Test.csproj
+++ b/src/Splat.Common.Test/Splat.Common.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA2000</NoWarn>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
 </Project>

--- a/src/Splat.Common.Test/ViewModelOne.cs
+++ b/src/Splat.Common.Test/ViewModelOne.cs
@@ -11,7 +11,9 @@ namespace Splat.Common.Test;
 /// View Model One.
 /// </summary>
 [ExcludeFromCodeCoverage]
+#pragma warning disable CA1515 // Consider making public types internal
 public class ViewModelOne : IViewModelOne
+#pragma warning restore CA1515 // Consider making public types internal
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ViewModelOne"/> class.

--- a/src/Splat.Common.Test/ViewModelTwo.cs
+++ b/src/Splat.Common.Test/ViewModelTwo.cs
@@ -11,6 +11,6 @@ namespace Splat.Common.Test;
 /// View Model Two.
 /// </summary>
 [ExcludeFromCodeCoverage]
-public class ViewModelTwo
-{
-}
+#pragma warning disable CA1515 // Consider making public types internal
+public class ViewModelTwo;
+#pragma warning restore CA1515 // Consider making public types internal

--- a/src/Splat.Common.Test/ViewOne.cs
+++ b/src/Splat.Common.Test/ViewOne.cs
@@ -12,7 +12,9 @@ namespace Splat.Common.Test;
 /// </summary>
 /// <seealso cref="ViewModelOne" />
 [ExcludeFromCodeCoverage]
+#pragma warning disable CA1515 // Consider making public types internal
 public class ViewOne : IViewFor<ViewModelOne>
+#pragma warning restore CA1515 // Consider making public types internal
 {
     /// <inheritdoc />
     object? IViewFor.ViewModel

--- a/src/Splat.Common.Test/ViewThatShouldNotLoad.cs
+++ b/src/Splat.Common.Test/ViewThatShouldNotLoad.cs
@@ -10,7 +10,9 @@ namespace Splat.Common.Test;
 /// It's intended to ensure that view registration by different DI\IoC implementations
 /// does not create an instance at the point of registration.
 /// </summary>
+#pragma warning disable CA1515 // Consider making public types internal
 public sealed class ViewThatShouldNotLoad : IViewFor<ViewModelOne>
+#pragma warning restore CA1515 // Consider making public types internal
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="ViewThatShouldNotLoad"/> class.

--- a/src/Splat.Common.Test/ViewTwo.cs
+++ b/src/Splat.Common.Test/ViewTwo.cs
@@ -12,7 +12,9 @@ namespace Splat.Common.Test;
 /// </summary>
 /// <seealso cref="ViewModelTwo" />
 [ExcludeFromCodeCoverage]
+#pragma warning disable CA1515 // Consider making public types internal
 public class ViewTwo : IViewFor<ViewModelTwo>
+#pragma warning restore CA1515 // Consider making public types internal
 {
     /// <inheritdoc />
     object? IViewFor.ViewModel

--- a/src/Splat.Drawing.Tests/Splat.Drawing.Tests.csproj
+++ b/src/Splat.Drawing.Tests/Splat.Drawing.Tests.csproj
@@ -8,6 +8,9 @@
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Net.Http" />

--- a/src/Splat.DryIoc.Tests/Splat.DryIoc.Test3.csproj
+++ b/src/Splat.DryIoc.Tests/Splat.DryIoc.Test3.csproj
@@ -4,6 +4,10 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/Splat.Microsoft.Extensions.DependencyInjection.Test3.csproj
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection.Tests/Splat.Microsoft.Extensions.DependencyInjection.Test3.csproj
@@ -6,6 +6,9 @@
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\Splat.NLog\LogResolver.cs" Link="LogResolver.cs" />
@@ -17,7 +20,5 @@
     <ProjectReference Include="..\Splat.Common.Test\Splat.Common.Test.csproj" />
     <ProjectReference Include="..\Splat.Microsoft.Extensions.DependencyInjection\Splat.Microsoft.Extensions.DependencyInjection.csproj" />
   </ItemGroup>
-
-
 
 </Project>

--- a/src/Splat.Ninject.Tests/Splat.Ninject.Tests.csproj
+++ b/src/Splat.Ninject.Tests/Splat.Ninject.Tests.csproj
@@ -6,6 +6,9 @@
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
+  </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="..\Splat.Tests\ServiceLocation\BaseDependencyResolverTests.cs" Link="BaseDependencyResolverTests.cs" />

--- a/src/Splat.Prism.Tests/Splat.Prism.Test3.csproj
+++ b/src/Splat.Prism.Tests/Splat.Prism.Test3.csproj
@@ -4,6 +4,10 @@
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <NoWarn>$(NoWarn);CA1707;CS1574</NoWarn>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.SimpleInjector.Tests/Splat.SimpleInjector.Test3.csproj
+++ b/src/Splat.SimpleInjector.Tests/Splat.SimpleInjector.Test3.csproj
@@ -1,9 +1,13 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000</NoWarn>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Splat.Tests/Splat.Tests.csproj
+++ b/src/Splat.Tests/Splat.Tests.csproj
@@ -3,6 +3,10 @@
     <TargetFrameworks>net8.0-windows10.0.17763.0;net9.0-windows10.0.17763.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;CA1707;SA1633;CA2000;CA1034;CA1515;CA1812;CA1852</NoWarn>
     <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(IsV3UnitProject)">
+    <OutputType>exe</OutputType>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Serilog.Exceptions" />

--- a/src/Splat.sln
+++ b/src/Splat.sln
@@ -26,13 +26,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Autofac.Tests", "Spla
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.SimpleInjector", "Splat.SimpleInjector\Splat.SimpleInjector.csproj", "{5A21B576-374D-439E-9303-02A5B0256B26}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.SimpleInjector.Tests", "Splat.SimpleInjector.Tests\Splat.SimpleInjector.Tests.csproj", "{E85B3A4E-6ECA-4171-8605-55792187FAB4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.SimpleInjector.Test3", "Splat.SimpleInjector.Tests\Splat.SimpleInjector.Test3.csproj", "{E85B3A4E-6ECA-4171-8605-55792187FAB4}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.NLog", "Splat.NLog\Splat.NLog.csproj", "{24BCC71A-0998-4B81-9A55-BC00C2A3F8CE}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.DryIoc", "Splat.DryIoc\Splat.DryIoc.csproj", "{941DAAE2-EDCA-41A8-93FF-0C4178639A47}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.DryIoc.Tests", "Splat.DryIoc.Tests\Splat.DryIoc.Tests.csproj", "{E1777877-6F56-46D0-8747-4BB921ED4C8E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.DryIoc.Test3", "Splat.DryIoc.Tests\Splat.DryIoc.Test3.csproj", "{E1777877-6F56-46D0-8747-4BB921ED4C8E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Log4Net", "Splat.Log4Net\Splat.Log4Net.csproj", "{D65C61D8-C073-4761-9BA3-C595A079C42E}"
 EndProject
@@ -60,19 +60,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Raygun", "Splat.Raygu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Microsoft.Extensions.DependencyInjection", "Splat.Microsoft.Extensions.DependencyInjection\Splat.Microsoft.Extensions.DependencyInjection.csproj", "{168CC48D-C28C-48BA-B6F1-234A0C16597E}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Microsoft.Extensions.DependencyInjection.Tests", "Splat.Microsoft.Extensions.DependencyInjection.Tests\Splat.Microsoft.Extensions.DependencyInjection.Tests.csproj", "{85E5821D-CCC3-44DC-96A0-DFC02953943F}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Drawing", "Splat.Drawing\Splat.Drawing.csproj", "{694D2813-14FF-456A-B1E7-C5BB82AEE400}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Prism", "Splat.Prism\Splat.Prism.csproj", "{1D1FE7E6-10FF-4A7F-90D6-6E3696EC7D0D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Prism.Forms", "Splat.Prism.Forms\Splat.Prism.Forms.csproj", "{39195824-8E56-4240-A5A0-7FA4E12099D4}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Prism.Tests", "Splat.Prism.Tests\Splat.Prism.Tests.csproj", "{905A96B2-03C9-4D08-8E8B-E5B0F7F9F33A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Prism.Test3", "Splat.Prism.Tests\Splat.Prism.Test3.csproj", "{905A96B2-03C9-4D08-8E8B-E5B0F7F9F33A}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Drawing.Tests", "Splat.Drawing.Tests\Splat.Drawing.Tests.csproj", "{7E350DE5-B8C4-4EF1-9211-7B35643B1971}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveUI.DI.Tests", "ReactiveUI.DI.Tests\ReactiveUI.DI.Tests.csproj", "{FEA4E637-0409-40BC-8518-860509FEEA64}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReactiveUI.DI.Test3", "ReactiveUI.DI.Tests\ReactiveUI.DI.Test3.csproj", "{FEA4E637-0409-40BC-8518-860509FEEA64}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Avalonia", "Avalonia", "{45E17593-668F-4369-B281-801119B81725}"
 EndProject
@@ -94,7 +92,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Avalonia.DryIoc1.Test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Splat.Avalonia.DryIoc2.Tests", "Splat.Avalonia.DryIoc2.Tests\Splat.Avalonia.DryIoc2.Tests.csproj", "{E47B2228-4EA0-47FF-964B-92EA8E1F0E9A}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Splat.Aot.Tests", "Splat.Aot.Tests\Splat.Aot.Tests.csproj", "{FCE421B3-BEBA-19C5-97E9-D4FBC919EA34}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Splat.Aot.Test3", "Splat.Aot.Tests\Splat.Aot.Test3.csproj", "{FCE421B3-BEBA-19C5-97E9-D4FBC919EA34}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Splat.Microsoft.Extensions.DependencyInjection.Test3", "Splat.Microsoft.Extensions.DependencyInjection.Tests\Splat.Microsoft.Extensions.DependencyInjection.Test3.csproj", "{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -510,26 +510,6 @@ Global
 		{168CC48D-C28C-48BA-B6F1-234A0C16597E}.Release|x64.Build.0 = Release|Any CPU
 		{168CC48D-C28C-48BA-B6F1-234A0C16597E}.Release|x86.ActiveCfg = Release|Any CPU
 		{168CC48D-C28C-48BA-B6F1-234A0C16597E}.Release|x86.Build.0 = Release|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Debug|ARM.ActiveCfg = Debug|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Debug|ARM.Build.0 = Debug|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Debug|ARM64.ActiveCfg = Debug|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Debug|ARM64.Build.0 = Debug|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Debug|x64.Build.0 = Debug|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Debug|x86.Build.0 = Debug|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Release|ARM.ActiveCfg = Release|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Release|ARM.Build.0 = Release|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Release|ARM64.ActiveCfg = Release|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Release|ARM64.Build.0 = Release|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Release|x64.ActiveCfg = Release|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Release|x64.Build.0 = Release|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Release|x86.ActiveCfg = Release|Any CPU
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F}.Release|x86.Build.0 = Release|Any CPU
 		{694D2813-14FF-456A-B1E7-C5BB82AEE400}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{694D2813-14FF-456A-B1E7-C5BB82AEE400}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{694D2813-14FF-456A-B1E7-C5BB82AEE400}.Debug|ARM.ActiveCfg = Debug|Any CPU
@@ -850,6 +830,26 @@ Global
 		{FCE421B3-BEBA-19C5-97E9-D4FBC919EA34}.Release|x64.Build.0 = Release|Any CPU
 		{FCE421B3-BEBA-19C5-97E9-D4FBC919EA34}.Release|x86.ActiveCfg = Release|Any CPU
 		{FCE421B3-BEBA-19C5-97E9-D4FBC919EA34}.Release|x86.Build.0 = Release|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Debug|ARM.Build.0 = Debug|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Debug|x64.Build.0 = Debug|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Debug|x86.Build.0 = Debug|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Release|ARM.Build.0 = Release|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Release|ARM64.Build.0 = Release|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Release|x64.ActiveCfg = Release|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Release|x64.Build.0 = Release|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Release|x86.ActiveCfg = Release|Any CPU
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -875,7 +875,6 @@ Global
 		{DCA3C3B2-DBD1-4C92-AC3B-4DE6FAD598A3} = {651320D6-1048-4F87-9D8E-75134FAFABDA}
 		{A587EF52-4A3F-4375-A335-9ED7C6D410CB} = {651320D6-1048-4F87-9D8E-75134FAFABDA}
 		{168CC48D-C28C-48BA-B6F1-234A0C16597E} = {651320D6-1048-4F87-9D8E-75134FAFABDA}
-		{85E5821D-CCC3-44DC-96A0-DFC02953943F} = {3F8EA9C2-D6D1-4B18-8670-DFC24B96972E}
 		{694D2813-14FF-456A-B1E7-C5BB82AEE400} = {651320D6-1048-4F87-9D8E-75134FAFABDA}
 		{1D1FE7E6-10FF-4A7F-90D6-6E3696EC7D0D} = {651320D6-1048-4F87-9D8E-75134FAFABDA}
 		{39195824-8E56-4240-A5A0-7FA4E12099D4} = {651320D6-1048-4F87-9D8E-75134FAFABDA}
@@ -893,6 +892,7 @@ Global
 		{9CD61101-82AB-4C3E-B559-7323AFF779B4} = {3F8EA9C2-D6D1-4B18-8670-DFC24B96972E}
 		{E47B2228-4EA0-47FF-964B-92EA8E1F0E9A} = {3F8EA9C2-D6D1-4B18-8670-DFC24B96972E}
 		{FCE421B3-BEBA-19C5-97E9-D4FBC919EA34} = {3F8EA9C2-D6D1-4B18-8670-DFC24B96972E}
+		{F7BCB5CA-9AF5-0D1E-9AA7-7ECD6DA6A06B} = {3F8EA9C2-D6D1-4B18-8670-DFC24B96972E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E833ED14-B971-4E09-B27E-76E99BC0FC10}

--- a/src/Splat/Properties/AssemblyInfo.cs
+++ b/src/Splat/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Splat.Tests")]
-[assembly: InternalsVisibleTo("Splat.Drawing")]
 [assembly: InternalsVisibleTo("Splat.Drawing.Tests")]
+[assembly: InternalsVisibleTo("Splat.Drawing")]
 [assembly: InternalsVisibleTo("Splat.TestRunner.Android")]
 [assembly: InternalsVisibleTo("Splat.TestRunner.Uwp")]


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Update

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

xunit.StaFact is stuck on V1 due to lack of xunit V3 support

**What is the new behavior?**
<!-- If this is a feature change -->

Introduces conditional MSBuild properties and package references for xunit v3 test projects, renames several test projects to *.Test3, and updates solution/project files to include new v3 test projects. 

Refactors test class and interface declarations in Splat.Common.Test to use file-scoped types and disables CA1515 warnings. Also fixes InternalsVisibleTo attribute order in AssemblyInfo.cs.

**What might this PR break?**

Tests only

**Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

