### PR TITLE
Feature Add ReactiveUI modules and builder extensions for Splat

### DIFF
--- a/src/Splat.Autofac/Builder/AutofacSplatModule.cs
+++ b/src/Splat.Autofac/Builder/AutofacSplatModule.cs
@@ -4,10 +4,9 @@
 // See the LICENSE file in the project root for full license information.
 
 using Autofac;
-using Splat;
 using Splat.Autofac;
 
-namespace ReactiveUI.Builder;
+namespace Splat.Builder;
 
 /// <summary>
 /// Splat module for configuring the Autofac dependency resolver.

--- a/src/Splat.Autofac/Builder/AutofacSplatModule.cs
+++ b/src/Splat.Autofac/Builder/AutofacSplatModule.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 ReactiveUI. All rights reserved.
+// Licensed to ReactiveUI under one or more agreements.
+// ReactiveUI licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Autofac;
+using Splat;
+using Splat.Autofac;
+
+namespace ReactiveUI.Builder;
+
+/// <summary>
+/// Splat module for configuring the Autofac dependency resolver.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="AutofacSplatModule"/> class.
+/// </remarks>
+/// <param name="builder">The Autofac container builder.</param>
+public sealed class AutofacSplatModule(ContainerBuilder builder) : IReactiveUIModule
+{
+    private readonly ContainerBuilder _builder = builder ?? throw new ArgumentNullException(nameof(builder));
+
+    /// <inheritdoc />
+    public void Configure(IMutableDependencyResolver resolver)
+    {
+        var autofacResolver = _builder.UseAutofacDependencyResolver();
+
+        // Also register the resolver instance for later retrieval if the container is built after
+        _builder.RegisterInstance(autofacResolver);
+    }
+}

--- a/src/Splat.Autofac/Builder/AutofacSplatModule.cs
+++ b/src/Splat.Autofac/Builder/AutofacSplatModule.cs
@@ -15,7 +15,7 @@ namespace Splat.Builder;
 /// Initializes a new instance of the <see cref="AutofacSplatModule"/> class.
 /// </remarks>
 /// <param name="builder">The Autofac container builder.</param>
-public sealed class AutofacSplatModule(ContainerBuilder builder) : IReactiveUIModule
+public sealed class AutofacSplatModule(ContainerBuilder builder) : IModule
 {
     private readonly ContainerBuilder _builder = builder ?? throw new ArgumentNullException(nameof(builder));
 

--- a/src/Splat.DryIoc/Builder/DryIocSplatModule.cs
+++ b/src/Splat.DryIoc/Builder/DryIocSplatModule.cs
@@ -15,7 +15,7 @@ namespace Splat.Builder;
 /// Initializes a new instance of the <see cref="DryIocSplatModule"/> class.
 /// </remarks>
 /// <param name="container">The DryIoc container.</param>
-public sealed class DryIocSplatModule(IContainer container) : IReactiveUIModule
+public sealed class DryIocSplatModule(IContainer container) : IModule
 {
     private readonly IContainer _container = container ?? throw new ArgumentNullException(nameof(container));
 

--- a/src/Splat.DryIoc/Builder/DryIocSplatModule.cs
+++ b/src/Splat.DryIoc/Builder/DryIocSplatModule.cs
@@ -4,10 +4,9 @@
 // See the LICENSE file in the project root for full license information.
 
 using DryIoc;
-using Splat;
 using Splat.DryIoc;
 
-namespace ReactiveUI.Builder;
+namespace Splat.Builder;
 
 /// <summary>
 /// Splat module for configuring the DryIoc dependency resolver.

--- a/src/Splat.DryIoc/Builder/DryIocSplatModule.cs
+++ b/src/Splat.DryIoc/Builder/DryIocSplatModule.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 ReactiveUI. All rights reserved.
+// Licensed to ReactiveUI under one or more agreements.
+// ReactiveUI licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using DryIoc;
+using Splat;
+using Splat.DryIoc;
+
+namespace ReactiveUI.Builder;
+
+/// <summary>
+/// Splat module for configuring the DryIoc dependency resolver.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="DryIocSplatModule"/> class.
+/// </remarks>
+/// <param name="container">The DryIoc container.</param>
+public sealed class DryIocSplatModule(IContainer container) : IReactiveUIModule
+{
+    private readonly IContainer _container = container ?? throw new ArgumentNullException(nameof(container));
+
+    /// <inheritdoc />
+    public void Configure(IMutableDependencyResolver resolver) => _container.UseDryIocDependencyResolver();
+}

--- a/src/Splat.Exceptionless/Builder/ExceptionlessSplatModule.cs
+++ b/src/Splat.Exceptionless/Builder/ExceptionlessSplatModule.cs
@@ -7,7 +7,7 @@ using Exceptionless;
 using Splat;
 using Splat.Exceptionless;
 
-namespace ReactiveUI.Builder;
+namespace Splat.Builder;
 
 /// <summary>
 /// Splat module for configuring the Exceptionless dependency resolver.

--- a/src/Splat.Exceptionless/Builder/ExceptionlessSplatModule.cs
+++ b/src/Splat.Exceptionless/Builder/ExceptionlessSplatModule.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 ReactiveUI. All rights reserved.
+// Licensed to ReactiveUI under one or more agreements.
+// ReactiveUI licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Exceptionless;
+using Splat;
+using Splat.Exceptionless;
+
+namespace ReactiveUI.Builder;
+
+/// <summary>
+/// Splat module for configuring the Exceptionless dependency resolver.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="ExceptionlessSplatModule"/> class.
+/// </remarks>
+/// <param name="exceptionlessClient">The Exceptionless container.</param>
+public sealed class ExceptionlessSplatModule(ExceptionlessClient exceptionlessClient) : IReactiveUIModule
+{
+    private readonly ExceptionlessClient _container = exceptionlessClient ?? throw new ArgumentNullException(nameof(exceptionlessClient));
+
+    /// <inheritdoc />
+    public void Configure(IMutableDependencyResolver resolver) => resolver.UseExceptionlessWithWrappingFullLogger(_container);
+}

--- a/src/Splat.Exceptionless/Builder/ExceptionlessSplatModule.cs
+++ b/src/Splat.Exceptionless/Builder/ExceptionlessSplatModule.cs
@@ -16,7 +16,7 @@ namespace Splat.Builder;
 /// Initializes a new instance of the <see cref="ExceptionlessSplatModule"/> class.
 /// </remarks>
 /// <param name="exceptionlessClient">The Exceptionless container.</param>
-public sealed class ExceptionlessSplatModule(ExceptionlessClient exceptionlessClient) : IReactiveUIModule
+public sealed class ExceptionlessSplatModule(ExceptionlessClient exceptionlessClient) : IModule
 {
     private readonly ExceptionlessClient _container = exceptionlessClient ?? throw new ArgumentNullException(nameof(exceptionlessClient));
 

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/Builder/MicrosoftDependencyResolverModule.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/Builder/MicrosoftDependencyResolverModule.cs
@@ -11,8 +11,8 @@ namespace Splat.Builder;
 /// <summary>
 /// Splat module for configuring the Microsoft dependency resolver.
 /// </summary>
-/// <seealso cref="IReactiveUIModule" />
-public sealed class MicrosoftDependencyResolverModule(IServiceCollection serviceCollection) : IReactiveUIModule
+/// <seealso cref="IModule" />
+public sealed class MicrosoftDependencyResolverModule(IServiceCollection serviceCollection) : IModule
 {
     private readonly IServiceCollection _container = serviceCollection ?? throw new ArgumentNullException(nameof(serviceCollection));
 

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/Builder/MicrosoftDependencyResolverModule.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/Builder/MicrosoftDependencyResolverModule.cs
@@ -4,10 +4,9 @@
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.Extensions.DependencyInjection;
-using Splat;
 using Splat.Microsoft.Extensions.DependencyInjection;
 
-namespace ReactiveUI.Builder;
+namespace Splat.Builder;
 
 /// <summary>
 /// Splat module for configuring the Microsoft dependency resolver.

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/Builder/MicrosoftDependencyResolverModule.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/Builder/MicrosoftDependencyResolverModule.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2025 ReactiveUI. All rights reserved.
+// Licensed to ReactiveUI under one or more agreements.
+// ReactiveUI licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.Extensions.DependencyInjection;
+using Splat;
+using Splat.Microsoft.Extensions.DependencyInjection;
+
+namespace ReactiveUI.Builder;
+
+/// <summary>
+/// Splat module for configuring the Microsoft dependency resolver.
+/// </summary>
+/// <seealso cref="IReactiveUIModule" />
+public sealed class MicrosoftDependencyResolverModule(IServiceCollection serviceCollection) : IReactiveUIModule
+{
+    private readonly IServiceCollection _container = serviceCollection ?? throw new ArgumentNullException(nameof(serviceCollection));
+
+    /// <inheritdoc />
+    public void Configure(IMutableDependencyResolver resolver) => _container.UseMicrosoftDependencyResolver();
+}

--- a/src/Splat.Ninject/Builder/NinjectSplatModule.cs
+++ b/src/Splat.Ninject/Builder/NinjectSplatModule.cs
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 ReactiveUI. All rights reserved.
+// Licensed to ReactiveUI under one or more agreements.
+// ReactiveUI licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Ninject;
+using Splat;
+using Splat.Ninject;
+
+namespace ReactiveUI.Builder;
+
+/// <summary>
+/// Splat module for configuring the Ninject dependency resolver.
+/// </summary>
+/// <remarks>
+/// Initializes a new instance of the <see cref="NinjectSplatModule"/> class.
+/// </remarks>
+/// <param name="kernel">The Ninject container.</param>
+public sealed class NinjectSplatModule(IKernel kernel) : IReactiveUIModule
+{
+    private readonly IKernel _container = kernel ?? throw new ArgumentNullException(nameof(kernel));
+
+    /// <inheritdoc />
+    public void Configure(IMutableDependencyResolver resolver) => _container.UseNinjectDependencyResolver();
+}

--- a/src/Splat.Ninject/Builder/NinjectSplatModule.cs
+++ b/src/Splat.Ninject/Builder/NinjectSplatModule.cs
@@ -15,7 +15,7 @@ namespace Splat.Builder;
 /// Initializes a new instance of the <see cref="NinjectSplatModule"/> class.
 /// </remarks>
 /// <param name="kernel">The Ninject container.</param>
-public sealed class NinjectSplatModule(IKernel kernel) : IReactiveUIModule
+public sealed class NinjectSplatModule(IKernel kernel) : IModule
 {
     private readonly IKernel _container = kernel ?? throw new ArgumentNullException(nameof(kernel));
 

--- a/src/Splat.Ninject/Builder/NinjectSplatModule.cs
+++ b/src/Splat.Ninject/Builder/NinjectSplatModule.cs
@@ -4,10 +4,9 @@
 // See the LICENSE file in the project root for full license information.
 
 using Ninject;
-using Splat;
 using Splat.Ninject;
 
-namespace ReactiveUI.Builder;
+namespace Splat.Builder;
 
 /// <summary>
 /// Splat module for configuring the Ninject dependency resolver.

--- a/src/Splat.SimpleInjector/Builder/SimpleInjectorSplatModule.cs
+++ b/src/Splat.SimpleInjector/Builder/SimpleInjectorSplatModule.cs
@@ -4,10 +4,9 @@
 // See the LICENSE file in the project root for full license information.
 
 using SimpleInjector;
-using Splat;
 using Splat.SimpleInjector;
 
-namespace ReactiveUI.Builder;
+namespace Splat.Builder;
 
 /// <summary>
 /// Splat module for configuring the SimpleInjector dependency resolver.

--- a/src/Splat.SimpleInjector/Builder/SimpleInjectorSplatModule.cs
+++ b/src/Splat.SimpleInjector/Builder/SimpleInjectorSplatModule.cs
@@ -11,13 +11,13 @@ namespace Splat.Builder;
 /// <summary>
 /// Splat module for configuring the SimpleInjector dependency resolver.
 /// </summary>
-/// <seealso cref="IReactiveUIModule" />
+/// <seealso cref="IModule" />
 /// <remarks>
 /// Initializes a new instance of the <see cref="SimpleInjectorSplatModule" /> class.
 /// </remarks>
 /// <param name="container">The SimpleInjector container.</param>
 /// <param name="initializer">The SimpleInjector Initializer.</param>
-public sealed class SimpleInjectorSplatModule(Container container, SimpleInjectorInitializer initializer) : IReactiveUIModule
+public sealed class SimpleInjectorSplatModule(Container container, SimpleInjectorInitializer initializer) : IModule
 {
     private readonly Container _container = container ?? throw new ArgumentNullException(nameof(container));
 

--- a/src/Splat.SimpleInjector/Builder/SimpleInjectorSplatModule.cs
+++ b/src/Splat.SimpleInjector/Builder/SimpleInjectorSplatModule.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2025 ReactiveUI. All rights reserved.
+// Licensed to ReactiveUI under one or more agreements.
+// ReactiveUI licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using SimpleInjector;
+using Splat;
+using Splat.SimpleInjector;
+
+namespace ReactiveUI.Builder;
+
+/// <summary>
+/// Splat module for configuring the SimpleInjector dependency resolver.
+/// </summary>
+/// <seealso cref="IReactiveUIModule" />
+/// <remarks>
+/// Initializes a new instance of the <see cref="SimpleInjectorSplatModule" /> class.
+/// </remarks>
+/// <param name="container">The SimpleInjector container.</param>
+/// <param name="initializer">The SimpleInjector Initializer.</param>
+public sealed class SimpleInjectorSplatModule(Container container, SimpleInjectorInitializer initializer) : IReactiveUIModule
+{
+    private readonly Container _container = container ?? throw new ArgumentNullException(nameof(container));
+
+    /// <inheritdoc />
+    public void Configure(IMutableDependencyResolver resolver) => _container.UseSimpleInjectorDependencyResolver(initializer);
+}

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.DotNet8_0.verified.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.DotNet8_0.verified.txt
@@ -775,13 +775,13 @@ namespace Splat.ApplicationPerformanceMonitoring
 }
 namespace Splat.Builder
 {
-    public interface IReactiveUIModule
+    public interface IModule
     {
         void Configure(Splat.IMutableDependencyResolver resolver);
     }
     public static class SplatBuilderExtensions
     {
-        public static void Apply(this Splat.Builder.IReactiveUIModule module) { }
+        public static void Apply(this Splat.Builder.IModule module) { }
     }
 }
 namespace Splat.ModeDetection

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.DotNet8_0.verified.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.DotNet8_0.verified.txt
@@ -773,6 +773,17 @@ namespace Splat.ApplicationPerformanceMonitoring
         void OnViewNavigation(string name);
     }
 }
+namespace Splat.Builder
+{
+    public interface IReactiveUIModule
+    {
+        void Configure(Splat.IMutableDependencyResolver resolver);
+    }
+    public static class SplatBuilderExtensions
+    {
+        public static void Apply(this Splat.Builder.IReactiveUIModule module) { }
+    }
+}
 namespace Splat.ModeDetection
 {
     public sealed class Mode : Splat.IModeDetector

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.DotNet9_0.verified.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.DotNet9_0.verified.txt
@@ -775,13 +775,13 @@ namespace Splat.ApplicationPerformanceMonitoring
 }
 namespace Splat.Builder
 {
-    public interface IReactiveUIModule
+    public interface IModule
     {
         void Configure(Splat.IMutableDependencyResolver resolver);
     }
     public static class SplatBuilderExtensions
     {
-        public static void Apply(this Splat.Builder.IReactiveUIModule module) { }
+        public static void Apply(this Splat.Builder.IModule module) { }
     }
 }
 namespace Splat.ModeDetection

--- a/src/Splat.Tests/API/ApiApprovalTests.SplatProject.DotNet9_0.verified.txt
+++ b/src/Splat.Tests/API/ApiApprovalTests.SplatProject.DotNet9_0.verified.txt
@@ -773,6 +773,17 @@ namespace Splat.ApplicationPerformanceMonitoring
         void OnViewNavigation(string name);
     }
 }
+namespace Splat.Builder
+{
+    public interface IReactiveUIModule
+    {
+        void Configure(Splat.IMutableDependencyResolver resolver);
+    }
+    public static class SplatBuilderExtensions
+    {
+        public static void Apply(this Splat.Builder.IReactiveUIModule module) { }
+    }
+}
 namespace Splat.ModeDetection
 {
     public sealed class Mode : Splat.IModeDetector

--- a/src/Splat/Builder/IModule.cs
+++ b/src/Splat/Builder/IModule.cs
@@ -11,7 +11,7 @@ namespace Splat.Builder;
 /// Defines a contract for ReactiveUI modules that can configure dependency injection.
 /// This provides an AOT-compatible way to register services.
 /// </summary>
-public interface IReactiveUIModule
+public interface IModule
 {
     /// <summary>
     /// Configures the dependency resolver with the module's services.

--- a/src/Splat/Builder/IReactiveUIModule.cs
+++ b/src/Splat/Builder/IReactiveUIModule.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 ReactiveUI. All rights reserved.
+// Licensed to ReactiveUI under one or more agreements.
+// ReactiveUI licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Splat;
+
+namespace ReactiveUI.Builder;
+
+/// <summary>
+/// Defines a contract for ReactiveUI modules that can configure dependency injection.
+/// This provides an AOT-compatible way to register services.
+/// </summary>
+public interface IReactiveUIModule
+{
+    /// <summary>
+    /// Configures the dependency resolver with the module's services.
+    /// </summary>
+    /// <param name="resolver">The dependency resolver to configure.</param>
+    void Configure(IMutableDependencyResolver resolver);
+}

--- a/src/Splat/Builder/IReactiveUIModule.cs
+++ b/src/Splat/Builder/IReactiveUIModule.cs
@@ -5,7 +5,7 @@
 
 using Splat;
 
-namespace ReactiveUI.Builder;
+namespace Splat.Builder;
 
 /// <summary>
 /// Defines a contract for ReactiveUI modules that can configure dependency injection.

--- a/src/Splat/Builder/SplatBuilderExtensions.cs
+++ b/src/Splat/Builder/SplatBuilderExtensions.cs
@@ -4,9 +4,8 @@
 // See the LICENSE file in the project root for full license information.
 
 using System;
-using Splat;
 
-namespace ReactiveUI.Builder;
+namespace Splat.Builder;
 
 /// <summary>
 /// Common extension helpers for registering Splat modules.

--- a/src/Splat/Builder/SplatBuilderExtensions.cs
+++ b/src/Splat/Builder/SplatBuilderExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 ReactiveUI. All rights reserved.
+// Licensed to ReactiveUI under one or more agreements.
+// ReactiveUI licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System;
+using Splat;
+
+namespace ReactiveUI.Builder;
+
+/// <summary>
+/// Common extension helpers for registering Splat modules.
+/// </summary>
+public static class SplatBuilderExtensions
+{
+    /// <summary>
+    /// Runs the provided configuration action imediately against the current Splat Locator.
+    /// </summary>
+    /// <param name="module">The module to configure.</param>
+    public static void Apply(this IReactiveUIModule module)
+    {
+        if (module is null)
+        {
+            throw new ArgumentNullException(nameof(module));
+        }
+
+        module.Configure(Locator.CurrentMutable);
+    }
+}

--- a/src/Splat/Builder/SplatBuilderExtensions.cs
+++ b/src/Splat/Builder/SplatBuilderExtensions.cs
@@ -16,7 +16,7 @@ public static class SplatBuilderExtensions
     /// Runs the provided configuration action imediately against the current Splat Locator.
     /// </summary>
     /// <param name="module">The module to configure.</param>
-    public static void Apply(this IReactiveUIModule module)
+    public static void Apply(this IModule module)
     {
         if (module is null)
         {


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Feature

**What is the new behavior?**
<!-- If this is a feature change -->

Introduces IReactiveUIModule interface and implementation modules for Autofac, DryIoc, Exceptionless, Microsoft.Extensions.DependencyInjection, Ninject, and SimpleInjector. Adds Splat Builder Extensions for applying modules to the Splat dependency resolver, enabling AOT-compatible service registration from a ReactiveUI application.

**What might this PR break?**

Non, separated feature.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

