### PR TITLE
Handle Lazy<object?> in dependency resolver

### DIFF
--- a/src/Splat/ServiceLocation/DependencyResolverMixins.cs
+++ b/src/Splat/ServiceLocation/DependencyResolverMixins.cs
@@ -158,7 +158,7 @@ public static class DependencyResolverMixins
     {
         resolver.ThrowArgumentNullExceptionIfNull(nameof(resolver));
         var val = new Lazy<object?>(valueFactory, LazyThreadSafetyMode.ExecutionAndPublication);
-        resolver.Register(() => val.Value, serviceType, contract);
+        resolver.Register(() => val, serviceType, contract);
     }
 
     /// <summary>
@@ -177,7 +177,7 @@ public static class DependencyResolverMixins
     {
         resolver.ThrowArgumentNullExceptionIfNull(nameof(resolver));
         var val = new Lazy<object?>(() => valueFactory(), LazyThreadSafetyMode.ExecutionAndPublication);
-        resolver.Register(() => val.Value, typeof(T), contract);
+        resolver.Register(() => val, typeof(T), contract);
     }
 
     /// <summary>

--- a/src/Splat/ServiceLocation/ResolverMixins.cs
+++ b/src/Splat/ServiceLocation/ResolverMixins.cs
@@ -163,7 +163,7 @@ public static class ResolverMixins
         resolver.ThrowArgumentNullExceptionIfNull(nameof(resolver));
 
         var val = new Lazy<object>(valueFactory, LazyThreadSafetyMode.ExecutionAndPublication);
-        resolver.Register(() => val.Value, serviceType, contract);
+        resolver.Register(() => val, serviceType, contract);
         return resolver;
     }
 
@@ -185,7 +185,7 @@ public static class ResolverMixins
         resolver.ThrowArgumentNullExceptionIfNull(nameof(resolver));
 
         var val = new Lazy<object>(() => new T(), LazyThreadSafetyMode.ExecutionAndPublication);
-        resolver.Register(() => val.Value, typeof(T), contract);
+        resolver.Register(() => val, typeof(T), contract);
         return resolver;
     }
 
@@ -203,7 +203,7 @@ public static class ResolverMixins
         resolver.ThrowArgumentNullExceptionIfNull(nameof(resolver));
 
         var val = new Lazy<object>(() => valueFactory()!, LazyThreadSafetyMode.ExecutionAndPublication);
-        resolver.Register(() => val.Value, typeof(T), contract);
+        resolver.Register(() => val, typeof(T), contract);
         return resolver;
     }
 }


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

fix for #1379 

**What is the current behavior?**
<!-- You can also link to an open issue here. -->

Initialises Lazy items before disposing.

**What is the new behavior?**
<!-- If this is a feature change -->

Updated registration and retrieval in DependencyResolverMixins and ModernDependencyResolver to store and unwrap Lazy<object?> instances. Disposal logic now skips uninitialized Lazy values, preventing unnecessary instantiation during cleanup.

**What might this PR break?**

Resolves issue raised with Lazy disposal.

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

