### PR TITLE
bump to version 16.3 and refactor DefaultModeDetector for enhanced unit test

### DIFF
--- a/src/Splat/ModeDetection/DefaultModeDetector.cs
+++ b/src/Splat/ModeDetection/DefaultModeDetector.cs
@@ -3,32 +3,115 @@
 // ReactiveUI licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+using System.Diagnostics.CodeAnalysis;
+
 namespace Splat;
 
 /// <summary>
-/// Contains the default mode detector to detect if we are currently in a unit test.
+/// Provides a mechanism to detect if the current execution context is a unit test using
+/// various heuristics such as environment signals, process names, and legacy assembly scans.
 /// </summary>
+/// <remarks>
+/// Implements the <see cref="IModeDetector"/> interface to define mode detection functionality.
+/// Implements the <see cref="IEnableLogger"/> interface to enable logging capabilities.
+/// </remarks>
+[SuppressMessage("ReSharper", "ForCanBeConvertedToForeach", Justification = "Performance")]
+[SuppressMessage("ReSharper", "LoopCanBeConvertedToQuery", Justification = "Performance")]
 public class DefaultModeDetector : IModeDetector, IEnableLogger
 {
+    /// <summary>
+    /// A static array containing known markers of test assemblies.
+    /// These markers are utilized as part of the detection logic to determine
+    /// if the current process is running in a unit test environment. Each marker
+    /// represents a known identifier or namespace commonly used in unit testing frameworks.
+    /// </summary>
+    private static readonly string[] _testAssemblyMarkers =
+    [
+        "CSUNIT",
+        "NUNIT",
+        "XUNIT",
+        "MBUNIT",
+        "NBEHAVE",
+        "VISUALSTUDIO.QUALITYTOOLS",
+        "VISUALSTUDIO.TESTPLATFORM",
+        "FIXIE",
+        "NCRUNCH"
+    ];
+
+    /// <summary>
+    /// A static array containing the names of known test host processes.
+    /// These process names are used to detect whether the current application
+    /// is being executed in a unit testing environment. Each entry indicates
+    /// a common test host or console runner associated with various testing frameworks.
+    /// </summary>
+    private static readonly string[] _knownTestHostProcesses =
+    [
+        "testhost",
+        "testhost.x86",
+        "vstest.console",
+        "vstest.executionengine",
+        "xunit.console",
+        "nunit3-console",
+        "nunit-console",
+        "nunit-agent",
+        "resharpertestrunner",
+        "jetbrains.resharper.taskrunner.clr45"
+    ];
+
+    /// <summary>
+    /// A static array containing exact environment variable names commonly used to identify
+    /// test runners. Each variable in this list is checked to directly determine
+    /// whether the application is running in a unit test environment.
+    /// </summary>
+    private static readonly string[] _exactEnvVars =
+    [
+        "XUNIT_TEST",
+        "NUNIT_TEST"
+    ];
+
+    /// <summary>
+    /// A static array containing prefixes for environment variable names that are indicative of test runners.
+    /// These prefixes are used to detect if the current process is executing in a unit test environment by checking
+    /// whether any environment variables start with these prefixes.
+    /// </summary>
+    private static readonly string[] _envPrefixes =
+    [
+        "VSTEST_",
+        "NUNIT_",
+        "XUNIT_"
+    ];
+
     /// <inheritdoc />
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Records to the log")]
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Records to the log")]
     public bool? InUnitTestRunner()
     {
-        var testAssemblies = new[]
-        {
-            "CSUNIT",
-            "NUNIT",
-            "XUNIT",
-            "MBUNIT",
-            "NBEHAVE",
-            "VISUALSTUDIO.QUALITYTOOLS",
-            "VISUALSTUDIO.TESTPLATFORM",
-            "FIXIE",
-            "NCRUNCH",
-        };
         try
         {
-            return SearchForAssembly(testAssemblies);
+            // Prefer explicit, deterministic signals first (opt-in).
+            if (IsExplicitTestEnvironment())
+            {
+                return true;
+            }
+
+            // Then look for common runner environment variables.
+            if (HasTestRunnerEnvironmentSignals())
+            {
+                return true;
+            }
+
+            // Next, fall back to process-name heuristics (no assembly scans).
+            if (IsKnownTestHostProcess())
+            {
+                return true;
+            }
+
+            // Worst-case: fall back to legacy assembly scan.
+            if (LegacyAssemblyScan(_testAssemblyMarkers))
+            {
+                return true;
+            }
+
+            return false;
         }
         catch (Exception e)
         {
@@ -37,14 +120,204 @@ public class DefaultModeDetector : IModeDetector, IEnableLogger
         }
     }
 
-    private static bool SearchForAssembly(IEnumerable<string> assemblyList) =>
-        AppDomain.CurrentDomain.GetAssemblies()
-            .Select(x => x.FullName?.ToUpperInvariant())
-            .Where(x => x is not null)
-            .Select(x => x!)
+    /// <summary>
+    /// Determines if the current environment explicitly indicates a test environment based on specific environment variables.
+    /// Explicit env var that users can set in their test setup for deterministic behavior.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> if the environment explicitly signals a test environment; otherwise, <c>false</c>.
+    /// </returns>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Records to the log")]
+    private static bool IsExplicitTestEnvironment()
+    {
+        try
+        {
+            var value = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_TEST");
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                var appCtx = AppContext.GetData("DOTNET_RUNNING_IN_TEST") as string;
+                if (!string.IsNullOrWhiteSpace(appCtx))
+                {
+                    value = appCtx;
+                }
+            }
+
+            if (value is null)
+            {
+                return false;
+            }
+
+            // Normalize checks without allocating additional strings.
+            return value.Length switch
+            {
+                1 => value == "1",
+                3 => value.Equals("yes", StringComparison.OrdinalIgnoreCase),
+                4 => value.Equals("true", StringComparison.OrdinalIgnoreCase),
+                _ => false
+            };
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Determines if current environment has test runner signals present.
+    /// Common signals emitted by popular test runners or their hosts.
+    /// </summary>
+    /// <returns>
+    /// A boolean value indicating whether test runner environment signals are detected.
+    /// </returns>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Records to the log")]
+    private static bool HasTestRunnerEnvironmentSignals()
+    {
+        try
+        {
+            // Fast-path: exact-name checks (no enumeration).
+            for (var i = 0; i < _exactEnvVars.Length; i++)
+            {
+                var v = Environment.GetEnvironmentVariable(_exactEnvVars[i]);
+                if (!string.IsNullOrEmpty(v))
+                {
+                    return true;
+                }
+            }
+
+            // Slower path: enumerate env vars once and check prefixes.
+            var vars = Environment.GetEnvironmentVariables();
+            foreach (System.Collections.DictionaryEntry kv in vars)
+            {
+                var key = kv.Key as string;
+                if (string.IsNullOrEmpty(key))
+                {
+                    continue;
+                }
+
+                for (var i = 0; i < _envPrefixes.Length; i++)
+                {
+                    if (key.StartsWith(_envPrefixes[i], StringComparison.OrdinalIgnoreCase))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Ignore enumeration/access issues and treat as not found.
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the current process is a known test host process by examining the process name
+    /// and other runtime-specific signals.
+    /// Last-resort heuristic: detect known test hosts by process name.
+    /// </summary>
+    /// <returns>
+    /// True if the process is identified as a known test host; otherwise, false.
+    /// </returns>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Records to the log")]
+    private static bool IsKnownTestHostProcess()
+    {
+        try
+        {
+            var procName = System.Diagnostics.Process.GetCurrentProcess().ProcessName;
+            if (!string.IsNullOrEmpty(procName))
+            {
+                for (var i = 0; i < _knownTestHostProcesses.Length; i++)
+                {
 #if NETSTANDARD || NET_45
-            .Any(x => assemblyList.Any(name => x.IndexOf(name, StringComparison.InvariantCultureIgnoreCase) != -1));
+                    if (procName.IndexOf(knownTestHostProcesses[i], StringComparison.OrdinalIgnoreCase) >= 0)
 #else
-            .Any(x => assemblyList.Any(name => x.Contains(name, StringComparison.InvariantCultureIgnoreCase)));
+                    if (procName.Contains(_knownTestHostProcesses[i], StringComparison.OrdinalIgnoreCase))
 #endif
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            // In some environments, the process may be "dotnet" hosting testhost/vstest.
+            try
+            {
+                using var p = System.Diagnostics.Process.GetCurrentProcess();
+                var mainModule = p.MainModule?.FileName;
+                if (!string.IsNullOrEmpty(mainModule))
+                {
+#if NETSTANDARD || NET_45
+                    if (mainModule.IndexOf("testhost", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                        mainModule.IndexOf("vstest", StringComparison.OrdinalIgnoreCase) >= 0)
+#else
+                    if (mainModule.Contains("testhost", StringComparison.OrdinalIgnoreCase) ||
+                        mainModule.Contains("vstest", StringComparison.OrdinalIgnoreCase))
+#endif
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch
+            {
+                // Access to MainModule can fail in restricted environments; ignore.
+            }
+        }
+        catch
+        {
+            // Ignore all process inspection failures.
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Legacy assembly-name scan fallback (avoids LINQ to reduce allocations).
+    /// Checks if any of the loaded assemblies in the current application domain
+    /// match the specified assembly markers, using case-insensitive comparison.
+    /// Typically used as a fallback mechanism for detecting test environments.
+    /// </summary>
+    /// <param name="assemblyMarkers">
+    /// An array of string markers representing partial or full names of assemblies
+    /// to be matched against the loaded assemblies in the application domain.
+    /// </param>
+    /// <returns>
+    /// A boolean value indicating whether at least one of the loaded assemblies
+    /// matches an assembly marker. Returns <c>true</c> if a match is found; otherwise, <c>false</c>.
+    /// </returns>
+    [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Records to the log")]
+    private static bool LegacyAssemblyScan(string[] assemblyMarkers)
+    {
+        try
+        {
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            for (var i = 0; i < assemblies.Length; i++)
+            {
+                var fullName = assemblies[i].FullName;
+                if (string.IsNullOrEmpty(fullName))
+                {
+                    continue;
+                }
+
+                for (var j = 0; j < assemblyMarkers.Length; j++)
+                {
+#if NETSTANDARD || NET_45
+                    if (fullName.IndexOf(assemblyMarkers[j], StringComparison.InvariantCultureIgnoreCase) >= 0)
+#else
+                    if (fullName.Contains(assemblyMarkers[j], StringComparison.InvariantCultureIgnoreCase))
+#endif
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Ignore assembly loading/introspection failures and treat as not found.
+        }
+
+        return false;
+    }
 }

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "16.2",
+  "version": "16.3",
   "publicReleaseRefSpec": [
     "^refs/heads/main$", // we release out of master
     "^refs/heads/preview/.*", // we release previews


### PR DESCRIPTION
Refactor `DefaultModeDetector`; improve unit test detection and bump to 16.3

<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
Refactor / reliability + perf improvement (and version bump to 16.3).

**What is the current behavior?**
Detection primarily relied on scanning loaded assemblies for test-related markers via LINQ. This could be allocation-heavy and miss scenarios where tests run under host processes (e.g., `vstest`, `testhost`) or when runners signal presence via environment variables.

**What is the new behavior?**
A tiered, deterministic-first detection pipeline:

1. **Explicit opt-in** via `DOTNET_RUNNING_IN_TEST` (env var or `AppContext` data; accepts `1`, `true`, `yes` ignoring case).
2. **Runner environment signals**:

   * Exact vars: `XUNIT_TEST`, `NUNIT_TEST`
   * Prefixes: `VSTEST_`, `NUNIT_`, `XUNIT_`
3. **Known host process names** (e.g., `testhost`, `vstest.console`, `xunit.console`, `nunit3-console`, `resharpertestrunner`, etc.), with an additional check against the process main module path for `testhost`/`vstest`.
4. **Legacy assembly-name scan fallback** rewritten without LINQ to reduce allocations and improve resilience.

Additional notes:

* Added targeted `SuppressMessage` attributes and comments for performance justifications.
* Maintains `bool?` return with `null` on unexpected errors (logged).
* Updates `version.json` from `16.2` to `16.3`.

**What might this PR break?**

* Behavior may change in edge cases: environments previously returning `false` could now return `true` due to new, explicit signals (env vars/process names).
* Very unusual or custom test hosts not in the known list may still require explicit env signaling.
* In restricted environments, accessing process metadata can fail—but such exceptions are handled and will not crash detection.

**Please check if the PR fulfills these requirements**

* [ ] Tests for the changes have been added (for bug fixes / features)
* [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

* Arrays of markers and prefixes centralize heuristics (`_testAssemblyMarkers`, `_knownTestHostProcesses`, `_exactEnvVars`, `_envPrefixes`).
* The fallback assembly scan now avoids LINQ to minimize allocations and improve startup performance under test.
