### PR TITLE
Rename Locator.Current to AppLocator.Current throughout docs and code

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,17 +95,17 @@ Desktop and Mobile applications, while still remaining reasonably flexible.
 
 There are 2 parts to the locator design:
 
-* **Locator.Current** The property to use to **retrieve** services. Locator.Current is a static variable that can be set on startup, to adapt Splat to other DI/IoC frameworks. We're currently working from v7 onward to make it easier to use your DI/IoC framework of choice. (see below)
-* **Locator.CurrentMutable** The property to use to **register** services
+* **AppLocator.Current** The property to use to **retrieve** services. AppLocator.Current is a static variable that can be set on startup, to adapt Splat to other DI/IoC frameworks. We're currently working from v7 onward to make it easier to use your DI/IoC framework of choice. (see below)
+* **AppLocator.CurrentMutable** The property to use to **register** services
 
 To get a service:
 
 ```cs
 // To get a single service registration
-var toaster = Locator.Current.GetService<IToaster>();
+var toaster = AppLocator.Current.GetService<IToaster>();
 
 // To get all service registrations
-var allToasterImpls = Locator.Current.GetServices<IToaster>();
+var allToasterImpls = AppLocator.Current.GetServices<IToaster>();
 ```
 
 Locator.Current is a static variable that can be set on startup, to adapt Splat
@@ -167,7 +167,7 @@ When targeting AOT or trimming scenarios, you can configure Splat (and consumers
 
 - IModule defines a single Configure(IMutableDependencyResolver) method where you register services.
 - AppBuilder gathers modules and custom registrations, then applies them to a chosen resolver when Build() is called.
-- You can target the current Locator.CurrentMutable or an external container that implements IMutableDependencyResolver via UseCurrentSplatLocator().
+- You can target the current AppLocator.CurrentMutable or an external container that implements IMutableDependencyResolver via UseCurrentSplatLocator().
 
 ### Define modules
 
@@ -244,17 +244,17 @@ using Splat.Microsoft.Extensions.DependencyInjection;
 using Splat.Microsoft.Extensions.Logging;
 
 var services = new ServiceCollection();
-services.UseMicrosoftDependencyResolver(); // set Locator.Current to MS.DI resolver backed by IServiceCollection
+services.UseMicrosoftDependencyResolver(); // set AppLocator.Current to MS.DI resolver backed by IServiceCollection
 
 // register framework logging provider that forwards to Splat
 services.AddLogging(b => b.AddSplat());
 
-// build container and rebind Locator.Current to the built provider
+// build container and rebind AppLocator.Current to the built provider
 var provider = services.BuildServiceProvider();
 provider.UseMicrosoftDependencyResolver();
 
-new AppBuilder(Locator.CurrentMutable)
-    .UseCurrentSplatLocator() // target whatever Locator.CurrentMutable points to (MS.DI in this case)
+new AppBuilder(AppLocator.CurrentMutable)
+    .UseCurrentSplatLocator() // target whatever AppLocator.CurrentMutable points to (MS.DI in this case)
     .UsingModule(new CoreModule())
     .WithCustomRegistration(r =>
     {
@@ -265,7 +265,7 @@ new AppBuilder(Locator.CurrentMutable)
     .Build();
 ```
 
-The same pattern works with other adapters (Autofac, DryIoc, SimpleInjector, Ninject) after setting Locator.Current to the adapter’s resolver.
+The same pattern works with other adapters (Autofac, DryIoc, SimpleInjector, Ninject) after setting AppLocator.Current to the adapter’s resolver.
 
 ### Extending AppBuilder
 

--- a/src/Splat.Autofac/README.md
+++ b/src/Splat.Autofac/README.md
@@ -45,4 +45,4 @@ autofacResolver.SetLifetimeScope(container);`
 
 ### Use the Locator
 
-Now, when registering or resolving services using Locator.Current, or via ReactiveUI, they will be directed to the Autofac DI container.
+Now, when registering or resolving services using AppLocator.Current, or via ReactiveUI, they will be directed to the Autofac DI container.

--- a/src/Splat.Builder/SplatBuilderExtensions.cs
+++ b/src/Splat.Builder/SplatBuilderExtensions.cs
@@ -11,7 +11,7 @@ namespace Splat.Builder;
 public static class SplatBuilderExtensions
 {
     /// <summary>
-    /// Runs the provided configuration action immediately against the current Splat Locator.
+    /// Runs the provided configuration action immediately against the current Splat AppLocator.
     /// </summary>
     /// <param name="module">The module to configure.</param>
     public static void Apply(this IModule module)

--- a/src/Splat.Drawing/Splat.Drawing.csproj
+++ b/src/Splat.Drawing/Splat.Drawing.csproj
@@ -29,8 +29,6 @@
     <None Include="Resources\**\*.*"/>
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
-    <PackageReference Include="System.Diagnostics.Contracts"/>
-    <PackageReference Include="System.Runtime.Serialization.Primitives"/>
     <PackageReference Include="System.Drawing.Primitives"/>
     <Compile Include="Platforms\ReflectionStubs.cs"/>
   </ItemGroup>

--- a/src/Splat.DryIoc/README.md
+++ b/src/Splat.DryIoc/README.md
@@ -22,4 +22,4 @@ container.UseDryIocDependencyResolver();
 
 ### Use the Locator
 
-Now, when registering or resolving services using Locator.Current, or via ReactiveUI, they will be directed to the DryIoc DI container.
+Now, when registering or resolving services using AppLocator.Current, or via ReactiveUI, they will be directed to the DryIoc DI container.

--- a/src/Splat.Exceptionless/MutableDependencyResolverExtensions.cs
+++ b/src/Splat.Exceptionless/MutableDependencyResolverExtensions.cs
@@ -24,7 +24,7 @@ public static class MutableDependencyResolverExtensions
     /// <param name="exceptionlessClient">The configured Exceptionless client instance.</param>
     /// <example>
     /// <code>
-    /// Locator.CurrentMutable.UseExceptionlessWithWrappingFullLogger(exception);
+    /// AppLocator.CurrentMutable.UseExceptionlessWithWrappingFullLogger(exception);
     /// </code>
     /// </example>
     public static void UseExceptionlessWithWrappingFullLogger(this IMutableDependencyResolver instance, ExceptionlessClient exceptionlessClient)

--- a/src/Splat.Log4Net/MutableDependencyResolverExtensions.cs
+++ b/src/Splat.Log4Net/MutableDependencyResolverExtensions.cs
@@ -21,7 +21,7 @@ public static class MutableDependencyResolverExtensions
     /// </param>
     /// <example>
     /// <code>
-    /// Locator.CurrentMutable.UseLog4NetWithWrappingFullLogger();
+    /// AppLocator.CurrentMutable.UseLog4NetWithWrappingFullLogger();
     /// </code>
     /// </example>
     public static void UseLog4NetWithWrappingFullLogger(this IMutableDependencyResolver instance)

--- a/src/Splat.Logging/LogHost.cs
+++ b/src/Splat.Logging/LogHost.cs
@@ -25,7 +25,7 @@ public static class LogHost
              * RegisterLazy(Func<IReadOnlyDependencyResolver, object> factory);
              * which will allow a lazy instance of the static logger.
              *
-             * return Locator.Current.GetService<IStaticFullLogger>();
+             * return AppLocator.Current.GetService<IStaticFullLogger>();
              */
 
             var factory = AppLocator.Current.GetService<ILogManager>() ?? throw new LoggingException("ILogManager is null. This should never happen, your dependency resolver is broken");

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/README.md
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/README.md
@@ -39,7 +39,7 @@ sealed partial class App // : Application
       .ConfigureServices(services =>
       {
         services.UseMicrosoftDependencyResolver();
-        var resolver = Locator.CurrentMutable;
+        var resolver = AppLocator.CurrentMutable;
         resolver.InitializeSplat();
         resolver.InitializeReactiveUI();
 
@@ -108,6 +108,6 @@ IServiceProvider container = services.BuildServiceProvider();
 container.UseMicrosoftDependencyResolver();
 ```
 
-### Use the Locator
+### Use the AppLocator
 
-Now, when registering or resolving services using Locator.Current, or via ReactiveUI, they will be directed to the Microsoft DI container.
+Now, when registering or resolving services using AppLocator.Current, or via ReactiveUI, they will be directed to the Microsoft DI container.

--- a/src/Splat.Microsoft.Extensions.Logging/MicrosoftExtensionsLoggingExtensions.cs
+++ b/src/Splat.Microsoft.Extensions.Logging/MicrosoftExtensionsLoggingExtensions.cs
@@ -27,7 +27,7 @@ public static class MicrosoftExtensionsLoggingExtensions
     /// </param>
     /// <example>
     /// <code>
-    /// Locator.CurrentMutable.UseMicrosoftExtensionsLoggingWithWrappingFullLogger();
+    /// AppLocator.CurrentMutable.UseMicrosoftExtensionsLoggingWithWrappingFullLogger();
     /// </code>
     /// </example>
     public static void UseMicrosoftExtensionsLoggingWithWrappingFullLogger(

--- a/src/Splat.NLog/MutableDependencyResolverExtensions.cs
+++ b/src/Splat.NLog/MutableDependencyResolverExtensions.cs
@@ -21,7 +21,7 @@ public static class MutableDependencyResolverExtensions
     /// </param>
     /// <example>
     /// <code>
-    /// Locator.CurrentMutable.UseNLogWithWrappingFullLogger();
+    /// AppLocator.CurrentMutable.UseNLogWithWrappingFullLogger();
     /// </code>
     /// </example>
     public static void UseNLogWithWrappingFullLogger(this IMutableDependencyResolver instance)

--- a/src/Splat.Ninject/README.md
+++ b/src/Splat.Ninject/README.md
@@ -22,4 +22,4 @@ container.UseNinjectDependencyResolver();
 
 ### Use the Locator
 
-Now, when registering or resolving services using Locator.Current, or via ReactiveUI, they will be directed to the Ninject DI container.
+Now, when registering or resolving services using AppLocator.Current, or via ReactiveUI, they will be directed to the Ninject DI container.

--- a/src/Splat.Serilog/MutableDependencyResolverExtensions.cs
+++ b/src/Splat.Serilog/MutableDependencyResolverExtensions.cs
@@ -19,7 +19,7 @@ public static class MutableDependencyResolverExtensions
     /// <param name="instance">An instance of Mutable Dependency Resolver.</param>
     /// <example>
     /// <code>
-    /// Locator.CurrentMutable.UseSerilogWithWrappingFullLogger();
+    /// AppLocator.CurrentMutable.UseSerilogWithWrappingFullLogger();
     /// </code>
     /// </example>
     public static void UseSerilogFullLogger(this IMutableDependencyResolver instance)
@@ -43,7 +43,7 @@ public static class MutableDependencyResolverExtensions
     /// <param name="actualLogger">The serilog logger to register.</param>
     /// <example>
     /// <code>
-    /// Locator.CurrentMutable.UseSerilogWithWrappingFullLogger();
+    /// AppLocator.CurrentMutable.UseSerilogWithWrappingFullLogger();
     /// </code>
     /// </example>
     public static void UseSerilogFullLogger(this IMutableDependencyResolver instance, global::Serilog.ILogger actualLogger)

--- a/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
+++ b/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
@@ -82,7 +82,7 @@ public class SimpleInjectorDependencyResolver : IDependencyResolver
     public void Register(Func<object?> factory, Type? serviceType, string? contract = null)
     {
         // The function does nothing because there should be no registration called on this object.
-        // Anyway, Locator.SetLocator performs some unnecessary registrations.
+        // Anyway, AppLocator.SetLocator performs some unnecessary registrations.
     }
 
     /// <inheritdoc />

--- a/src/Splat/ApplicationPerformanceMonitoring/EnableFeatureUsageTrackingExtensions.cs
+++ b/src/Splat/ApplicationPerformanceMonitoring/EnableFeatureUsageTrackingExtensions.cs
@@ -21,7 +21,7 @@ public static class EnableFeatureUsageTrackingExtensions
         this IEnableFeatureUsageTracking instance,
         string featureName)
     {
-        var featureUsageTrackingSession = Locator.Current.GetService<IFeatureUsageTrackingManager>();
+        var featureUsageTrackingSession = AppLocator.Current.GetService<IFeatureUsageTrackingManager>();
         return featureUsageTrackingSession switch
         {
             null => throw new InvalidOperationException("Feature Usage Tracking Manager is null. This should never happen, your dependency resolver is broken"),


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

Update

**What is the new behavior?**
<!-- If this is a feature change -->

Replaces all references to Locator.Current and Locator.CurrentMutable with AppLocator.Current and AppLocator.CurrentMutable in documentation, code comments, and usage examples for consistency. Also updates related references in extension methods, dependency resolver adapters, and logging implementations. 

Removes unused package references from Splat.Drawing.csproj.

**What might this PR break?**

Duplicate references removed

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

