### PR TITLE
Refactor CompositeDisposable for thread safety and performance

### DIFF
--- a/src/Splat.Core/Disposables/CompositeDisposable.cs
+++ b/src/Splat.Core/Disposables/CompositeDisposable.cs
@@ -22,8 +22,11 @@ internal sealed class CompositeDisposable : IDisposable
     // Default initial capacity of the _disposables list in case
     // The number of items is not known upfront
     private const int DefaultCapacity = 16;
-
+#if NET9_0_OR_GREATER
+    private readonly Lock _lock = new();
+#else
     private readonly object _lock = new();
+#endif
     private List<IDisposable>? _disposables;
     private volatile bool _disposed;
 


### PR DESCRIPTION
<!-- Please be sure to read the [Contribute](https://github.com/reactiveui/reactiveui#contribute) section of the README -->

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->

update

**What is the new behavior?**
<!-- If this is a feature change -->

Improves thread safety by introducing a lock for disposal and making _disposed volatile. Optimizes disposal and initialization using Span and CollectionsMarshal for .NET 8+, and refines XML documentation for constructors and methods. Removes unused _count field and updates internal logic for managing disposables.

**What might this PR break?**

none

**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Other information**:

