### PR TITLE
Remove dead System.Reactive package reference from Splat.Core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,391 @@
+# AGENTS.md
+
+This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+
+## Build & Test Commands
+
+This project uses **Microsoft Testing Platform (MTP)** with the **TUnit** testing framework. Test commands differ significantly from traditional VSTest.
+
+See: https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test?tabs=dotnet-test-with-mtp
+
+### Prerequisites
+
+```powershell
+# Check .NET installation
+dotnet --info
+
+# Restore NuGet packages
+dotnet restore Splat.slnx
+```
+
+**Note**: This repository uses **SLNX** (XML-based solution format) instead of the legacy SLN format.
+
+### Build Commands
+
+**CRITICAL:** The working folder must be `./src` folder. These commands won't function properly without the correct working folder.
+
+```powershell
+# Build the solution
+dotnet build Splat.slnx -c Release
+
+# Build with warnings as errors (includes StyleCop violations)
+dotnet build Splat.slnx -c Release -warnaserror
+
+# Clean the solution
+dotnet clean Splat.slnx
+```
+
+### Test Commands (Microsoft Testing Platform)
+
+**CRITICAL:** This repository uses MTP configured in `global.json`. All TUnit-specific arguments must be passed after `--`:
+
+The working folder must be `./src` folder. These commands won't function properly without the correct working folder.
+
+**IMPORTANT:**
+- Do NOT use `--no-build` flag when running tests. Always build before testing to ensure all code changes (including test changes) are compiled. Using `--no-build` can cause tests to run against stale binaries and produce misleading results.
+- Use `--output Detailed` to see Console.WriteLine output from tests. This must be placed BEFORE any `--` separator:
+  ```powershell
+  dotnet test --output Detailed -- --treenode-filter "..."
+  ```
+
+```powershell
+# Run all tests in the solution
+dotnet test --solution Splat.slnx -c Release
+
+# Run all tests in a specific project
+dotnet test --project tests/Splat.Tests/Splat.Tests.csproj -c Release
+
+# Run a single test method using treenode-filter
+# Syntax: /{AssemblyName}/{Namespace}/{ClassName}/{TestMethodName}
+dotnet test --project tests/Splat.Tests/Splat.Tests.csproj -- --treenode-filter "/*/*/*/MyTestMethod"
+
+# Run all tests in a specific class
+dotnet test --project tests/Splat.Tests/Splat.Tests.csproj -- --treenode-filter "/*/*/MyClassName/*"
+
+# Run tests in a specific namespace
+dotnet test --project tests/Splat.Tests/Splat.Tests.csproj -- --treenode-filter "/*/MyNamespace/*/*"
+
+# Filter by test property (e.g., Category)
+dotnet test --solution Splat.slnx -- --treenode-filter "/*/*/*/*[Category=Integration]"
+
+# Run tests with code coverage (Microsoft Code Coverage)
+dotnet test --solution Splat.slnx -- --coverage --coverage-output-format cobertura
+
+# Run tests with detailed output
+dotnet test --solution Splat.slnx -- --output Detailed
+
+# List all available tests without running them
+dotnet test --project tests/Splat.Tests/Splat.Tests.csproj -- --list-tests
+
+# Fail fast (stop on first failure)
+dotnet test --solution Splat.slnx -- --fail-fast
+
+# Control parallel test execution
+dotnet test --solution Splat.slnx -- --maximum-parallel-tests 4
+
+# Generate TRX report
+dotnet test --solution Splat.slnx -- --report-trx
+
+# Disable logo for cleaner output
+dotnet test --project tests/Splat.Tests/Splat.Tests.csproj -- --disable-logo
+
+# Combine options: coverage + TRX report + detailed output
+dotnet test --solution Splat.slnx -- --coverage --coverage-output-format cobertura --report-trx --output Detailed
+```
+
+**Alternative: Using `dotnet run` for single project**
+```powershell
+# Run tests using dotnet run (easier for passing flags)
+dotnet run --project tests/Splat.Tests/Splat.Tests.csproj -c Release -- --treenode-filter "/*/*/*/MyTest"
+
+# Disable logo for cleaner output
+dotnet run --project tests/Splat.Tests/Splat.Tests.csproj -- --disable-logo --treenode-filter "/*/*/*/Test1"
+```
+
+### TUnit Treenode-Filter Syntax
+
+The `--treenode-filter` follows the pattern: `/{AssemblyName}/{Namespace}/{ClassName}/{TestMethodName}`
+
+**Examples:**
+- Single test: `--treenode-filter "/*/*/*/MyTestMethod"`
+- All tests in class: `--treenode-filter "/*/*/MyClassName/*"`
+- All tests in namespace: `--treenode-filter "/*/MyNamespace/*/*"`
+- Filter by property: `--treenode-filter "/*/*/*/*[Category=Integration]"`
+- Multiple wildcards: `--treenode-filter "/*/*/MyTests*/*"`
+
+**Note:** Use single asterisks (`*`) to match segments. Double asterisks (`/**`) are not supported in treenode-filter.
+
+### Key TUnit Command-Line Flags
+
+- `--treenode-filter` - Filter tests by path pattern or properties (syntax: `/{Assembly}/{Namespace}/{Class}/{Method}`)
+- `--list-tests` - Display available tests without running
+- `--fail-fast` - Stop after first failure
+- `--maximum-parallel-tests` - Limit concurrent execution (default: processor count)
+- `--coverage` - Enable Microsoft Code Coverage
+- `--coverage-output-format` - Set coverage format (cobertura, xml, coverage)
+- `--report-trx` - Generate TRX format reports
+- `--output` - Control verbosity (Normal or Detailed)
+- `--no-progress` - Suppress progress reporting
+- `--disable-logo` - Remove TUnit logo display
+- `--diagnostic` - Enable diagnostic logging (Trace level)
+- `--timeout` - Set global test timeout
+- `--reflection` - Enable reflection mode instead of source generation
+
+See https://tunit.dev/docs/reference/command-line-flags for complete TUnit flag reference.
+
+### Key Configuration Files
+
+- `global.json` - Specifies `"Microsoft.Testing.Platform"` as the test runner
+- `testconfig.json` - Configures test execution (`"parallel": true`) and code coverage (Cobertura format)
+- `Directory.Build.props` - Enables `TestingPlatformDotnetTestSupport` for test projects
+- `.github/COPILOT_INSTRUCTIONS.md` - Comprehensive development guidelines
+
+## Architecture Overview
+
+### Core Framework Structure
+
+Splat is a cross-platform utility library providing abstractions for common functionality that should work everywhere but often doesn't. It solves the problem of writing cross-platform mobile and desktop code riddled with `#ifdefs`.
+
+**Core Library (`Splat/`)**
+- `ServiceLocation/` - Simple, flexible service location/dependency injection
+- `AppLocator` - Main service locator for registering and retrieving services
+- `PlatformModeDetector/` - Detect unit test runners and design mode
+- Core abstractions and utilities
+
+**Specialized Libraries**
+- `Splat.Builder/` - AOT-friendly configuration with `AppBuilder` and `IModule` pattern
+- `Splat.Core/` - Core interfaces and abstractions
+- `Splat.Logging/` - Cross-platform logging abstraction with `ILogger` interface
+- `Splat.Drawing/` - Cross-platform image loading/saving and color/geometry primitives
+
+**Dependency Injection Adapters (`Splat.*/`)**
+- `Splat.Autofac/` - Autofac container integration
+- `Splat.DryIoc/` - DryIoc container integration
+- `Splat.Microsoft.Extensions.DependencyInjection/` - Microsoft.Extensions.DependencyInjection integration
+- `Splat.Ninject/` - Ninject container integration
+- `Splat.SimpleInjector/` - SimpleInjector container integration
+- `Splat.Prism/` - Prism framework integration
+
+**Logging Adapters (`Splat.*/`)**
+- `Splat.Serilog/` - Serilog logger integration
+- `Splat.NLog/` - NLog logger integration
+- `Splat.Log4Net/` - Log4Net logger integration
+- `Splat.Microsoft.Extensions.Logging/` - Microsoft.Extensions.Logging integration
+
+**Application Performance Monitoring (`Splat.*/`)**
+- `Splat.AppCenter/` - Microsoft App Center APM integration
+- `Splat.ApplicationInsights/` - Azure Application Insights integration
+- `Splat.Exceptionless/` - Exceptionless integration
+- `Splat.Raygun/` - Raygun integration
+
+### Key Architectural Patterns
+
+**Service Location**
+- `AppLocator.Current` - Retrieve registered services
+- `AppLocator.CurrentMutable` - Register new services at runtime
+- `RegisterLazySingleton` - Register singletons that are created on first access
+- `RegisterConstant` - Register singleton instances
+- `Register` - Register factory functions for transient instances
+
+**Logging**
+- `IEnableLogger` - Tag interface for classes that want logging support
+- `this.Log().Info()` / `this.Log().Warn()` - Extension methods for logging
+- `LogHost.Default` - Static logger for static methods
+- Platform-specific adapters forward to chosen logging framework
+
+**Cross-Platform Drawing**
+- `IBitmap` - Platform-agnostic bitmap interface
+- `ToNative()` / `FromNative()` - Convert between Splat and platform types
+- `BitmapLoader.Current` - Load/save images from streams, resources, or files
+- `SplatColor` - Cross-platform color abstraction
+- `PointF`, `SizeF`, `RectangleF` - Cross-platform geometry primitives
+
+**AppBuilder and IModule (AOT-Friendly)**
+- `IModule` - Define reusable service registration modules
+- `AppBuilder` - Compose modules and apply to resolver
+- `UseCurrentSplatLocator()` - Target current `AppLocator.CurrentMutable`
+- AOT-safe configuration without reflection
+
+### Multi-Platform Target Framework Strategy
+
+The project uses granular target framework definitions in `Directory.Build.props`:
+
+- `SplatModernTargets` - net8.0, net9.0, net10.0 (modern cross-platform)
+- `SplatLegacyTargets` - net462, net472, net481 (Windows-only legacy .NET Framework)
+- `SplatCoreTargets` - Combines modern + legacy targets for core libraries
+- `SplatWindowsTargets` - net8.0/9.0/10.0-windows10.0.17763.0 and windows10.0.19041.0
+- `SplatAndroidTargets` - net9.0-android, net10.0-android
+- `SplatAppleTargets` - iOS, tvOS, macOS, Mac Catalyst
+- `SplatUiFinalTargetFrameworks` - OS-aware composition for UI projects
+
+**OS-Aware Builds:** The build system automatically selects appropriate target frameworks based on the host OS:
+- **Linux**: Builds .NET 8/9/10 and Android targets
+- **Windows**: Builds all targets including .NET Framework, Core, Android, Windows, and Apple
+- **macOS**: Builds .NET 8/9/10, Android, and Apple targets
+
+### Zero-Reflection and AOT (Ahead-of-Time) Compilation Priority
+
+**CRITICAL: Prefer Zero-Reflection Solutions First**
+
+When implementing new features, follow this priority order:
+
+1. **Zero-reflection solutions** - Design APIs that don't require reflection at all
+2. **Source generators** - Use Roslyn source generators to generate code at compile-time
+3. **Compile-time code generation** - Use tools like T4 templates or build-time code generation
+4. **Strongly-typed expressions** - Use expression trees that can be analyzed without runtime reflection
+5. **Reflection with AOT attributes** - Only as a last resort, and always with proper `DynamicallyAccessedMembers` attributes
+
+**Examples of Preferred Approaches:**
+
+**Good: Zero-Reflection with Explicit Registration**
+```csharp
+// Users explicitly register their services - no reflection needed
+AppLocator.CurrentMutable.Register<IMyService>(() => new MyService());
+```
+
+**Good: Source Generator Pattern**
+```csharp
+// Use source generators to generate registration code at compile-time
+// See: Splat.DI.SourceGenerator package
+[RegisterService(typeof(IMyService))]
+public partial class MyService : IMyService
+{
+    // Generator creates registration code automatically
+}
+```
+
+**Good: Expression-Based with Static Analysis**
+```csharp
+// Expression trees can be analyzed without runtime reflection
+public void RegisterService<T>(Expression<Func<T>> factory)
+{
+    // Analyze expression at compile-time or with source generators
+}
+```
+
+**Avoid: Runtime Reflection (unless properly attributed)**
+```csharp
+// Only use reflection when absolutely necessary and with proper attributes
+#if NET6_0_OR_GREATER
+private static void RegisterFromType(
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
+    Type serviceType)
+#else
+private static void RegisterFromType(Type serviceType)
+#endif
+{
+    var instance = Activator.CreateInstance(serviceType);
+}
+```
+
+### AOT Compatibility Requirements
+
+All code targeting net8.0+ should be AOT-compatible:
+
+**Key AOT Patterns:**
+- **Always prefer zero-reflection solutions** - design APIs that work without reflection
+- **Use source generators** for code that would traditionally require reflection
+- Prefer `DynamicallyAccessedMembersAttribute` over `UnconditionalSuppressMessage`
+- Use specific `DynamicallyAccessedMemberTypes` values rather than `All` when possible
+- `AppBuilder` and `IModule` pattern for AOT-safe dependency injection configuration
+- Avoid reflection in hot paths
+- Document any reflection usage and why it's necessary
+- See `tests/Splat.Aot.Tests/` for AOT test examples
+
+**Source Generator References:**
+- Splat.DI.SourceGenerator: https://github.com/reactivemarbles/Splat.DI.SourceGenerator
+- .NET Source Generators: https://learn.microsoft.com/dotnet/csharp/roslyn-sdk/source-generators-overview
+
+See `.github/COPILOT_INSTRUCTIONS.md` for comprehensive AOT patterns and examples.
+
+## Code Style & Quality Requirements
+
+**CRITICAL:** All code must comply with ReactiveUI contribution guidelines: https://www.reactiveui.net/contribute/index.html
+
+### Style Enforcement
+
+- EditorConfig rules (`.editorconfig`) - comprehensive C# formatting and naming conventions
+- StyleCop Analyzers - builds fail on violations
+- Roslynator Analyzers - additional code quality rules
+- Analysis level: latest with enhanced .NET analyzers
+- `WarningsAsErrors`: nullable
+- **All public APIs require XML documentation comments** (including protected methods of public classes)
+
+### C# Style Rules
+
+- **Braces:** Allman style (each brace on new line)
+- **Indentation:** 4 spaces, no tabs
+- **Fields:** `_camelCase` for private/internal, `readonly` where possible, `static readonly` (not `readonly static`)
+- **Visibility:** Always explicit (e.g., `private string _foo` not `string _foo`), visibility first modifier
+- **Namespaces:** File-scoped preferred, imports outside namespace, sorted (system then third-party)
+- **Types:** Use keywords (`int`, `string`) not BCL types (`Int32`, `String`)
+- **Modern C#:** Use nullable reference types, pattern matching, switch expressions, records, init setters, target-typed new, collection expressions, file-scoped namespaces, primary constructors
+- **Avoid `this.`** unless necessary
+- **Use `nameof()`** instead of string literals
+- **Use `var`** when it improves readability or aids refactoring
+
+See `.github/COPILOT_INSTRUCTIONS.md` for complete style guide.
+
+## Testing Guidelines
+
+- Unit tests use **TUnit** framework with **Microsoft Testing Platform**
+- Test projects detected via naming convention (project name contains `Tests`)
+- Coverage configured in `testconfig.json` (Cobertura format, skip auto-properties)
+- Parallel test execution enabled (`"parallel": true` in testconfig.json)
+- Always write unit tests for new features or bug fixes
+- Follow existing test patterns in `tests/Splat.Tests/`
+- For AOT scenarios, reference patterns in `tests/Splat.Aot.Tests/`
+- Platform-specific test runners available for Android and UWP
+
+## Common Tasks
+
+### Adding a New Feature
+
+1. **Design for zero-reflection first** - avoid reflection if at all possible
+2. **Consider source generators** - use compile-time code generation when needed
+3. Create failing tests first
+4. Implement minimal functionality
+5. Ensure AOT compatibility
+6. Update documentation if needed
+7. Add XML documentation to all public APIs
+8. Prefer to create new methods than changing the signature of existing ones when changing APIs
+9. Run formatting validation before committing
+
+### Fixing Bugs
+
+1. Create reproduction test
+2. Fix with minimal changes
+3. Verify AOT compatibility
+4. Ensure no regression in existing tests
+
+### Adding a New Logging or DI Adapter
+
+1. Create new project following naming convention (e.g., `Splat.NewContainer`)
+2. Implement adapter interface (`IMutableDependencyResolver` for DI, logger factory for logging)
+3. **Prefer zero-reflection implementations** - design adapters to work without runtime reflection
+4. Create corresponding test project (e.g., `Splat.NewContainer.Tests`)
+5. Add extension methods for registration (e.g., `UseNewContainer()`)
+6. Update README.md with new adapter information
+7. Ensure adapter works with `AppBuilder` pattern for AOT scenarios
+
+## What to Avoid
+
+- **Runtime reflection** - prefer zero-reflection solutions or source generators
+- **Implicit service discovery** - explicit registration is better for AOT
+- **Heavy reflection** without proper AOT suppression attributes (if reflection is absolutely necessary)
+- **Platform-specific code** in core Splat library (use platform extensions instead)
+- **Breaking changes** to public APIs without proper versioning
+- **Large dependencies** in core libraries (keep Splat lightweight)
+- **Implicit service registrations** that might surprise users or break AOT
+
+## Important Notes
+
+- **Zero-Reflection First:** Always design for zero-reflection solutions before considering alternatives
+- **Source Generators:** Leverage source generators for compile-time code generation instead of runtime reflection
+- **No shallow clones:** Repository requires full clone for git version information used by Nerdbank.GitVersioning
+- **Required .NET SDKs:** .NET 8.0, 9.0, and 10.0 (all three required for full build)
+- **SLNX Format:** Uses modern XML-based solution format instead of legacy SLN
+- **Comprehensive Instructions:** `.github/COPILOT_INSTRUCTIONS.md` contains detailed development guidelines
+- **Code Formatting:** Always run `dotnet format whitespace` and `dotnet format style` before committing
+
+**Philosophy:** Splat provides "leaky abstractions" that solve cross-platform problems while always allowing access to native platform types via `ToNative()` and `FromNative()`. Keep abstractions minimal and focused on solving real cross-platform pain points. **Prefer zero-reflection solutions and source generators over runtime reflection.** When in doubt, prefer simplicity over feature completeness, explicit registration over implicit discovery, and always consider the AOT implications of your changes.

--- a/src/Benchmarks/src/Splat.Benchmarks.csproj
+++ b/src/Benchmarks/src/Splat.Benchmarks.csproj
@@ -8,7 +8,6 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="BenchmarkDotNet" />
-		<PackageReference Include="System.Reactive" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\Splat\Splat.csproj" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -81,10 +81,7 @@
 
     <PackageReference Include="TUnit"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Verify.TUnit"/>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
-    <PackageReference Include="Microsoft.Reactive.Testing" />
-    <PackageReference Include="PublicApiGenerator" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' != 'true'">

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -26,12 +26,10 @@
     <PackageVersion Include="SimpleInjector" Version="5.5.2" />
     <PackageVersion Include="stylecop.analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="System.Net.Http" Version="4.3.4" />
-    <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageVersion Include="TUnit" Version="1.45.8" />
     <PackageVersion Include="Verify.TUnit" Version="31.16.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.1.0" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.7.0" />
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.2.3" />
     <PackageVersion Include="PublicApiGenerator" Version="11.5.4" />
@@ -93,9 +91,5 @@
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net46'))">
     <PackageVersion Include="System.ValueTuple" Version="4.6.2" />
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netstandard'))">
-    <PackageVersion Include="System.Diagnostics.Contracts" Version="4.3.0" />
-    <PackageVersion Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -438,11 +438,11 @@ public class AutofacDependencyResolver : IDependencyResolver
             }
 
             // Register to both the application-wide container and internal lifetime
-            _builder.RegisterType<TImplementation>()
+            _builder.Register(static _ => new TImplementation())
                 .As<TService>()
                 .AsImplementedInterfaces();
             _internalLifetimeScope = _internalLifetimeScope.BeginLifetimeScope(internalBuilder =>
-                internalBuilder.RegisterType<TImplementation>()
+                internalBuilder.Register(static _ => new TImplementation())
                     .As<TService>()
                     .AsImplementedInterfaces());
         }
@@ -463,16 +463,16 @@ public class AutofacDependencyResolver : IDependencyResolver
 
             if (string.IsNullOrWhiteSpace(contract))
             {
-               Register<TService, TImplementation>();
+                Register<TService, TImplementation>();
             }
             else
             {
                 // Register to both the application-wide container and internal lifetime
-                _builder.RegisterType<TImplementation>()
+                _builder.Register(static _ => new TImplementation())
                     .Named<TService>(contract!)
                     .AsImplementedInterfaces();
                 _internalLifetimeScope = _internalLifetimeScope.BeginLifetimeScope(internalBuilder =>
-                    internalBuilder.RegisterType<TImplementation>()
+                    internalBuilder.Register(static _ => new TImplementation())
                         .Named<TService>(contract!)
                         .AsImplementedInterfaces());
             }

--- a/src/Splat.Core/Disposables/ActionDisposable.cs
+++ b/src/Splat.Core/Disposables/ActionDisposable.cs
@@ -27,7 +27,7 @@ internal sealed class ActionDisposable : IDisposable
     /// </summary>
     /// <remarks>This property can be used when an IDisposable implementation is required but no cleanup is
     /// necessary. The returned object is safe to dispose multiple times.</remarks>
-    public static IDisposable Empty => new ActionDisposable(() => { });
+    public static IDisposable Empty { get; } = new ActionDisposable(() => { });
 
     /// <inheritdoc />
     public void Dispose() => Interlocked.Exchange(ref _block, () => { })();

--- a/src/Splat.Core/ServiceLocation/ModernDependencyResolver.cs
+++ b/src/Splat.Core/ServiceLocation/ModernDependencyResolver.cs
@@ -534,7 +534,7 @@ public class ModernDependencyResolver : IDependencyResolver
 
         if (Volatile.Read(ref _snapshot) is null)
         {
-            return new ActionDisposable(() => { });
+            return ActionDisposable.Empty;
         }
 
         var pair = GetKey(serviceType, contract);
@@ -543,7 +543,7 @@ public class ModernDependencyResolver : IDependencyResolver
         {
             if (Volatile.Read(ref _snapshot) is null)
             {
-                return new ActionDisposable(() => { });
+                return ActionDisposable.Empty;
             }
 
             if (!_callbackRegistry.TryGetValue(pair, out var list))
@@ -592,7 +592,7 @@ public class ModernDependencyResolver : IDependencyResolver
 
         if (Volatile.Read(ref _snapshot) is null)
         {
-            return new ActionDisposable(() => { });
+            return ActionDisposable.Empty;
         }
 
         var pair = GetKey(typeof(T), contract);
@@ -601,7 +601,7 @@ public class ModernDependencyResolver : IDependencyResolver
         {
             if (Volatile.Read(ref _snapshot) is null)
             {
-                return new ActionDisposable(() => { });
+                return ActionDisposable.Empty;
             }
 
             if (!_callbackRegistry.TryGetValue(pair, out var list))

--- a/src/Splat.Core/ServiceLocation/NullServiceType.cs
+++ b/src/Splat.Core/ServiceLocation/NullServiceType.cs
@@ -15,7 +15,7 @@ public class NullServiceType(Func<object?> factory)
     /// <summary>
     /// Gets the cached <see cref="Type"/> instance representing the <see cref="NullServiceType"/> type.
     /// </summary>
-    /// <remarks>This field can be used to avoid repeated calls to <see cref="Type.GetType"/> or <see
+    /// <remarks>This field can be used to avoid repeated calls to <see cref="Type.GetType(string)"/> or <see
     /// langword="typeof"/> for <see cref="NullServiceType"/>. It is intended for scenarios where a reference to the
     /// <see cref="NullServiceType"/> type is needed multiple times.</remarks>
     public static readonly Type CachedType = typeof(NullServiceType);

--- a/src/Splat.Core/Splat.Core.csproj
+++ b/src/Splat.Core/Splat.Core.csproj
@@ -10,9 +10,6 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0')) or $(TargetFramework.StartsWith('net10.0'))">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Reactive" />
-  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Splat" />

--- a/src/Splat.Core/Splat.Core.csproj
+++ b/src/Splat.Core/Splat.Core.csproj
@@ -10,6 +10,9 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0')) or $(TargetFramework.StartsWith('net10.0'))">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net46'))">
+    <PackageReference Include="System.ValueTuple" />
+  </ItemGroup>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Splat" />

--- a/src/Splat.Drawing/DefaultPlatformModeDetector.cs
+++ b/src/Splat.Drawing/DefaultPlatformModeDetector.cs
@@ -29,6 +29,7 @@ public class DefaultPlatformModeDetector : IPlatformModeDetector
     private const string WinFormsDesignerPropertiesType = "Windows.ApplicationModel.DesignMode, Windows, ContentType=WindowsRuntime";
     private const string WinFormsDesignerPropertiesDesignModeMethod = "DesignModeEnabled";
 
+    private static readonly string[] _designEnvironments = ["BLEND.EXE", "XDESPROC.EXE"];
     private static bool? _cachedInDesignModeResult;
 #endif
 
@@ -72,7 +73,6 @@ public class DefaultPlatformModeDetector : IPlatformModeDetector
         }
         else
         {
-            var designEnvironments = new[] { "BLEND.EXE", "XDESPROC.EXE" };
 #if NETFRAMEWORK || TIZEN
             var entry = Assembly.GetEntryAssembly()?.Location;
 #else
@@ -82,7 +82,7 @@ public class DefaultPlatformModeDetector : IPlatformModeDetector
             {
                 var exeName = new FileInfo(entry).Name;
 
-                foreach (var designEnv in designEnvironments)
+                foreach (var designEnv in _designEnvironments)
                 {
 #if NETFRAMEWORK || TIZEN
                     if (designEnv.IndexOf(exeName, StringComparison.InvariantCultureIgnoreCase) != -1)

--- a/src/Splat.Drawing/Platforms/Android/Bitmaps/PlatformBitmapLoaderHelpers.cs
+++ b/src/Splat.Drawing/Platforms/Android/Bitmaps/PlatformBitmapLoaderHelpers.cs
@@ -100,8 +100,7 @@ internal static class PlatformBitmapLoaderHelpers
     /// <returns>Whether the termination is correct.</returns>
     internal static bool HasCorrectStreamEnd(Stream sourceStream)
     {
-        // 0-based and go back 2.
-        sourceStream.Position = sourceStream.Length - 3;
+        sourceStream.Position = sourceStream.Length - 2;
         return sourceStream.ReadByte() == 0xFF
                && sourceStream.ReadByte() == 0xD9;
     }

--- a/src/Splat.Drawing/Splat.Drawing.csproj
+++ b/src/Splat.Drawing/Splat.Drawing.csproj
@@ -14,7 +14,7 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0')) or $(TargetFramework.StartsWith('net10.0'))">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
-  <PropertyGroup Condition="($(TargetFramework.EndsWith('-windows10.0.17763.0')) or $(TargetFramework.StartsWith('net4'))) and $([MSBuild]::IsOsPlatform('Windows'))">
+  <PropertyGroup Condition="($(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4'))) and $([MSBuild]::IsOsPlatform('Windows'))">
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/src/Splat.Exceptionless/Splat.Exceptionless.csproj
+++ b/src/Splat.Exceptionless/Splat.Exceptionless.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Exceptionless" />
-    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Collections.Immutable" Condition="!$(TargetFramework.StartsWith('net10.0'))" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Splat\Splat.csproj" />

--- a/src/Splat.Logging/MemoizingMRUCache.cs
+++ b/src/Splat.Logging/MemoizingMRUCache.cs
@@ -174,6 +174,7 @@ public sealed class MemoizingMRUCache<TParam, TVal>
 
         // Insert under the gate (double-check in case another thread filled it).
         TVal? evictedToRelease = default;
+        var hasEvictedToRelease = false;
         List<TVal>? evictedBatch = null;
 
         lock (_gate)
@@ -191,7 +192,7 @@ public sealed class MemoizingMRUCache<TParam, TVal>
             // Maintain size under lock, but do not invoke release under lock.
             if (_entries.Count > _maxCacheSize)
             {
-                EvictToSize_NoThrow(ref evictedToRelease, ref evictedBatch);
+                EvictToSize_NoThrow(ref evictedToRelease, ref hasEvictedToRelease, ref evictedBatch);
             }
         }
 
@@ -205,7 +206,7 @@ public sealed class MemoizingMRUCache<TParam, TVal>
                     _releaseFunction(evictedBatch[i]);
                 }
             }
-            else if (!EqualityComparer<TVal>.Default.Equals(evictedToRelease!, default!))
+            else if (hasEvictedToRelease)
             {
                 _releaseFunction(evictedToRelease!);
             }
@@ -365,11 +366,12 @@ public sealed class MemoizingMRUCache<TParam, TVal>
     /// </summary>
     /// <param name="value">The value that was evicted.</param>
     /// <param name="singleEvicted">Single-value slot.</param>
+    /// <param name="hasSingleEvicted">Whether the single-value slot contains a value.</param>
     /// <param name="batchEvicted">Batch list for multiple evictions.</param>
 #if NET8_0_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-    private static void RecordEvictedValueNoThrow(TVal value, ref TVal? singleEvicted, ref List<TVal>? batchEvicted)
+    private static void RecordEvictedValueNoThrow(TVal value, ref TVal? singleEvicted, ref bool hasSingleEvicted, ref List<TVal>? batchEvicted)
     {
         if (batchEvicted is not null)
         {
@@ -378,15 +380,17 @@ public sealed class MemoizingMRUCache<TParam, TVal>
         }
 
         // First eviction goes to the single slot.
-        if (EqualityComparer<TVal>.Default.Equals(singleEvicted!, default!))
+        if (!hasSingleEvicted)
         {
             singleEvicted = value;
+            hasSingleEvicted = true;
             return;
         }
 
         // Second eviction upgrades to a list.
         batchEvicted = new(capacity: 4) { singleEvicted!, value };
         singleEvicted = default;
+        hasSingleEvicted = false;
     }
 
     /// <summary>
@@ -412,6 +416,7 @@ public sealed class MemoizingMRUCache<TParam, TVal>
     /// Evicts least-recently-used entries until the cache size is within <see cref="_maxCacheSize"/>.
     /// </summary>
     /// <param name="singleEvicted">Receives a single evicted value when exactly one eviction occurs.</param>
+    /// <param name="hasSingleEvicted">Receives whether a single evicted value was recorded.</param>
     /// <param name="batchEvicted">Receives evicted values when multiple evictions occur.</param>
     /// <remarks>
     /// Caller must hold <c>lock(_gate)</c>. This method does not invoke the release callback.
@@ -419,7 +424,7 @@ public sealed class MemoizingMRUCache<TParam, TVal>
 #if NET8_0_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
-    private void EvictToSize_NoThrow(ref TVal? singleEvicted, ref List<TVal>? batchEvicted)
+    private void EvictToSize_NoThrow(ref TVal? singleEvicted, ref bool hasSingleEvicted, ref List<TVal>? batchEvicted)
     {
         while (_entries.Count > _maxCacheSize)
         {
@@ -435,10 +440,10 @@ public sealed class MemoizingMRUCache<TParam, TVal>
             ref var entry = ref CollectionsMarshal.GetValueRefOrNullRef(_entries, key);
             if (!Unsafe.IsNullRef(ref entry))
             {
-                RecordEvictedValueNoThrow(entry.value, ref singleEvicted, ref batchEvicted);
+                RecordEvictedValueNoThrow(entry.value, ref singleEvicted, ref hasSingleEvicted, ref batchEvicted);
             }
 #else
-            RecordEvictedValueNoThrow(_entries[key].value, ref singleEvicted, ref batchEvicted);
+            RecordEvictedValueNoThrow(_entries[key].value, ref singleEvicted, ref hasSingleEvicted, ref batchEvicted);
 #endif
 
             _ = _entries.Remove(key);

--- a/src/Splat.Logging/Splat.Logging.csproj
+++ b/src/Splat.Logging/Splat.Logging.csproj
@@ -6,8 +6,8 @@
     <Nullable>enable</Nullable>
     <Authors>.NET Foundation and Contributors</Authors>
     <Description>A library to make things cross-platform that should be, providing Builder and Dependency Injection abstractions and implementations. AOT compatible for .NET 8+</Description>
-      </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0'))">
+  </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0')) or $(TargetFramework.StartsWith('net10.0'))">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 

--- a/src/Splat.Logging/WrappingFullLogger.cs
+++ b/src/Splat.Logging/WrappingFullLogger.cs
@@ -4,7 +4,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using System.Globalization;
-using System.Reflection;
 
 namespace Splat;
 
@@ -20,7 +19,6 @@ namespace Splat;
 public class WrappingFullLogger : AllocationFreeLoggerBase, IFullLogger
 {
     private readonly ILogger _inner;
-    private readonly MethodInfo _stringFormat = typeof(string).GetMethod("Format", [typeof(IFormatProvider), typeof(string), typeof(object[])]) ?? throw new InvalidOperationException("Cannot find the Format method which is required.");
 
     /// <summary>
     /// Initializes a new instance of the <see cref="WrappingFullLogger"/> class.
@@ -554,12 +552,8 @@ public class WrappingFullLogger : AllocationFreeLoggerBase, IFullLogger
         }
     }
 
-    private string InvokeStringFormat(IFormatProvider formatProvider, string message, object[] args)
+    private static string InvokeStringFormat(IFormatProvider formatProvider, string message, object[] args)
     {
-        var sfArgs = new object?[3];
-        sfArgs[0] = formatProvider;
-        sfArgs[1] = message;
-        sfArgs[2] = args;
-        return (string?)_stringFormat.Invoke(null, sfArgs) ?? "(null)";
+        return string.Format(formatProvider, message, args);
     }
 }

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
@@ -107,12 +107,46 @@ public class MicrosoftDependencyResolver : IDependencyResolver, IAsyncDisposable
     }
 
     /// <inheritdoc />
-    public virtual object? GetService(Type? serviceType) =>
-        GetServices(serviceType).LastOrDefault();
+    public virtual object? GetService(Type? serviceType)
+    {
+        if (ServiceProvider is null)
+        {
+            throw new InvalidOperationException("The ServiceProvider is null.");
+        }
+
+        var isNull = serviceType is null;
+        serviceType ??= NullServiceType.CachedType;
+
+        var service = ServiceProvider.GetService(serviceType);
+        return isNull && service is NullServiceType nullServiceType
+            ? nullServiceType.Factory()
+            : service;
+    }
 
     /// <inheritdoc />
-    public virtual object? GetService(Type? serviceType, string? contract) =>
-        GetServices(serviceType, contract).LastOrDefault();
+    public virtual object? GetService(Type? serviceType, string? contract)
+    {
+        if (contract is null)
+        {
+            return GetService(serviceType);
+        }
+
+        if (ServiceProvider is null)
+        {
+            throw new InvalidOperationException("The ServiceProvider is null.");
+        }
+
+        var isNull = serviceType is null;
+        serviceType ??= NullServiceType.CachedType;
+
+        var service = ServiceProvider is IKeyedServiceProvider serviceProvider
+            ? serviceProvider.GetKeyedService(serviceType, contract)
+            : null;
+
+        return isNull && service is NullServiceType nullServiceType
+            ? nullServiceType.Factory()
+            : service;
+    }
 
     /// <inheritdoc />
     public virtual IEnumerable<object> GetServices(Type? serviceType)
@@ -405,18 +439,46 @@ public class MicrosoftDependencyResolver : IDependencyResolver, IAsyncDisposable
     }
 
     /// <inheritdoc/>
-    public T? GetService<T>() => (T?)GetService(typeof(T));
+    public T? GetService<T>() => ServiceProvider is null
+        ? throw new InvalidOperationException("The ServiceProvider is null.")
+        : ServiceProvider.GetService<T>();
 
     /// <inheritdoc/>
-    public T? GetService<T>(string? contract) =>
-        (T?)GetService(typeof(T), contract);
+    public T? GetService<T>(string? contract)
+    {
+        if (contract is null)
+        {
+            return GetService<T>();
+        }
+
+        return ServiceProvider switch
+        {
+            null => throw new InvalidOperationException("The ServiceProvider is null."),
+            IKeyedServiceProvider keyedServiceProvider => keyedServiceProvider.GetKeyedService<T>(contract),
+            _ => default
+        };
+    }
 
     /// <inheritdoc/>
-    public IEnumerable<T> GetServices<T>() => GetServices(typeof(T)).Cast<T>();
+    public IEnumerable<T> GetServices<T>() => ServiceProvider is null
+        ? throw new InvalidOperationException("The ServiceProvider is null.")
+        : ServiceProvider.GetServices<T>();
 
     /// <inheritdoc/>
-    public IEnumerable<T> GetServices<T>(string? contract) =>
-        GetServices(typeof(T), contract).Cast<T>();
+    public IEnumerable<T> GetServices<T>(string? contract)
+    {
+        if (contract is null)
+        {
+            return GetServices<T>();
+        }
+
+        return ServiceProvider switch
+        {
+            null => throw new InvalidOperationException("The ServiceProvider is null."),
+            IKeyedServiceProvider keyedServiceProvider => keyedServiceProvider.GetKeyedServices<T>(contract),
+            _ => []
+        };
+    }
 
     /// <inheritdoc/>
     public bool HasRegistration<T>() => HasRegistration(typeof(T));
@@ -467,7 +529,7 @@ public class MicrosoftDependencyResolver : IDependencyResolver, IAsyncDisposable
 
         lock (_syncLock)
         {
-            _serviceCollection?.AddTransient<TService, TImplementation>();
+            _serviceCollection?.AddTransient<TService>(static _ => new TImplementation());
 
             // required so that it gets rebuilt if not injected externally.
             DisposeServiceProvider(_serviceProvider);
@@ -493,7 +555,7 @@ public class MicrosoftDependencyResolver : IDependencyResolver, IAsyncDisposable
 
         lock (_syncLock)
         {
-            _serviceCollection?.AddKeyedTransient<TService, TImplementation>(contract);
+            _serviceCollection?.AddKeyedTransient<TService>(contract, static (_, _) => new TImplementation());
 
             // required so that it gets rebuilt if not injected externally.
             DisposeServiceProvider(_serviceProvider);

--- a/src/Splat.Microsoft.Extensions.Logging/Splat.Microsoft.Extensions.Logging.csproj
+++ b/src/Splat.Microsoft.Extensions.Logging/Splat.Microsoft.Extensions.Logging.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" />
-    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Collections.Immutable" Condition="!$(TargetFramework.StartsWith('net10.0'))" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Splat.Logging\Splat.Logging.csproj" />

--- a/src/Splat.Serilog/Splat.Serilog.csproj
+++ b/src/Splat.Serilog/Splat.Serilog.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Serilog" />
-    <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="System.Collections.Immutable" Condition="!$(TargetFramework.StartsWith('net10.0'))" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Splat.Logging\Splat.Logging.csproj" />

--- a/src/tests/Splat.Drawing.Tests/API/ApiApprovalTests.cs
+++ b/src/tests/Splat.Drawing.Tests/API/ApiApprovalTests.cs
@@ -19,7 +19,7 @@ public class ApiApprovalTests
     /// <returns>The task.</returns>
     [Test]
     public Task SplatUIProject() =>
-#if WINDOWS
+#if WINDOWS && !SPLAT_DUPLICATE_WINDOWS_API_APPROVAL_TARGET
         typeof(IPlatformModeDetector).Assembly.CheckApproval(["Splat"]);
 #else
         Task.CompletedTask;

--- a/src/tests/Splat.Drawing.Tests/PlatformBitmapLoaderHelpersTests.cs
+++ b/src/tests/Splat.Drawing.Tests/PlatformBitmapLoaderHelpersTests.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 ReactiveUI. All rights reserved.
+// Licensed to ReactiveUI under one or more agreements.
+// ReactiveUI licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+#if ANDROID
+namespace Splat.Tests.Drawing;
+
+/// <summary>
+/// Tests for Android bitmap loader helpers.
+/// </summary>
+public class PlatformBitmapLoaderHelpersTests
+{
+    /// <summary>
+    /// Checks that two-byte image terminators are accepted.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task HasCorrectStreamEnd_ReturnsTrue_ForTwoByteTerminator()
+    {
+        using var stream = new MemoryStream([0xFF, 0xD9]);
+
+        await Assert.That(PlatformBitmapLoaderHelpers.HasCorrectStreamEnd(stream)).IsTrue();
+    }
+
+    /// <summary>
+    /// Checks that three-byte streams inspect the last two bytes.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task HasCorrectStreamEnd_ReturnsTrue_WhenLastTwoBytesAreTerminator()
+    {
+        using var stream = new MemoryStream([0x00, 0xFF, 0xD9]);
+
+        await Assert.That(PlatformBitmapLoaderHelpers.HasCorrectStreamEnd(stream)).IsTrue();
+    }
+}
+#endif

--- a/src/tests/Splat.Drawing.Tests/Splat.Drawing.Tests.csproj
+++ b/src/tests/Splat.Drawing.Tests/Splat.Drawing.Tests.csproj
@@ -12,9 +12,13 @@
     <TargetFrameworks>$(SplatWindowsTargets)</TargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="($(TargetFramework.EndsWith('-windows10.0.17763.0')) or $(TargetFramework.StartsWith('net4'))) and $([MSBuild]::IsOsPlatform('Windows'))">
+  <PropertyGroup Condition="($(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4'))) and $([MSBuild]::IsOsPlatform('Windows'))">
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.EndsWith('0-windows10.0.19041.0'))">
+    <DefineConstants>$(DefineConstants);SPLAT_DUPLICATE_WINDOWS_API_APPROVAL_TARGET</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tests/Splat.Logging.Tests/MemoizingMRUCacheTests.cs
+++ b/src/tests/Splat.Logging.Tests/MemoizingMRUCacheTests.cs
@@ -96,6 +96,29 @@ public class MemoizingMRUCacheTests
     }
 
     /// <summary>
+    /// Test that cache eviction releases default values.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Cache_EvictsDefaultValues_WhenMaxSizeReached()
+    {
+        List<int> released = [];
+        var instance = new MemoizingMRUCache<string, int>(
+            (_, _) => 0,
+            1,
+            released.Add);
+
+        _ = instance.Get("key1");
+        _ = instance.Get("key2");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(released).Count().IsEqualTo(1);
+            await Assert.That(released[0]).IsEqualTo(0);
+        }
+    }
+
+    /// <summary>
     /// Test that InvalidateAll with aggregateReleaseExceptions handles exceptions.
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>

--- a/src/tests/Splat.Tests/DisposableTests.cs
+++ b/src/tests/Splat.Tests/DisposableTests.cs
@@ -7,6 +7,8 @@ namespace Splat.Tests;
 
 public class DisposableTests
 {
+    private static readonly int[] _expectedDisposeOrder = [1, 2, 3];
+
     /// <summary>
     /// Test BooleanDisposable initial state.
     /// </summary>
@@ -541,7 +543,7 @@ public class DisposableTests
         compositeDisposable.Dispose();
 
         // Assert
-        await Assert.That(disposeOrder).IsEquivalentTo(new[] { 1, 2, 3 });
+        await Assert.That(disposeOrder).IsEquivalentTo(_expectedDisposeOrder);
     }
 
     /// <summary>

--- a/src/tests/Splat.Tests/Splat.Tests.csproj
+++ b/src/tests/Splat.Tests/Splat.Tests.csproj
@@ -6,6 +6,10 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="PublicApiGenerator" />
+    <PackageReference Include="Verify.TUnit" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\Splat.Core\Splat.Core.csproj" />
     <ProjectReference Include="..\..\Splat\Splat.csproj" />
     <ProjectReference Include="..\Splat.Common.Test\Splat.Common.Test.csproj" />


### PR DESCRIPTION
## What
Removes the `System.Reactive` `PackageReference` from `Splat.Core`.

## Why
It's dead weight. Nothing in `Splat.Core` — or anywhere in the Splat source tree — references a `System.Reactive` type: there are no `using System.Reactive` directives and no usage of `IScheduler` / `IObservable` / `Subject` / `Observable` / `Unit`.

Because `Splat.Core` is the base package, this single reference transitively forces `System.Reactive` onto **every** downstream consumer (`Splat`, `Splat.Builder`, `Splat.Logging`, and in turn ReactiveUI and the rest of the ecosystem) — including those actively trying to drop it. Removing it has no effect on Splat's behavior and lets consumers shed the unwanted transitive dependency.

## Verification
- `grep -r "using System.Reactive"` across the Splat source: no matches.
- `grep -r "System.Reactive|IScheduler|IObservable|Subject|Observable.|Unit"` in `Splat.Core`: no matches.

## Other
- Add AGENTS.md with build/test guidance and TUnit usage. 
- Make multiple AOT-friendly changes: replace runtime type/MethodInfo usage with static factory lambdas (Autofac, Microsoft DI registrations), remove reflection-based string.Format usage in WrappingFullLogger, and add ActionDisposable.Empty with modern callers. 
- Fix MemoizingMRUCache eviction logic (add has-evicted flag and adjust helper signatures). 
- Correct Android bitmap end-of-stream check and add PlatformBitmapLoaderHelpersTests. 
- Update various csproj files: adjust target framework conditions, add conditional PackageReference for System.Collections.Immutable and System.ValueTuple, remove some package references/versions, and tweak test project settings (API approval guard and additional test deps). 
- Misc: minor docs/comment and NullServiceType XML comment fix.
