### PR TITLE
Add AOT/trimming attributes to DI and detector

### DIFF
--- a/src/Splat.Autofac/AutofacDependencyResolver.cs
+++ b/src/Splat.Autofac/AutofacDependencyResolver.cs
@@ -106,6 +106,9 @@ public class AutofacDependencyResolver : IDependencyResolver
     }
 
     /// <inheritdoc />
+#if NET6_0_OR_GREATER
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "The non-generic Autofac API builds IEnumerable<T> for a runtime Type; generic GetServices<T>() is the AOT-safe path.")]
+#endif
     public virtual IEnumerable<object> GetServices(Type? serviceType)
     {
         var isNull = serviceType is null;
@@ -136,6 +139,9 @@ public class AutofacDependencyResolver : IDependencyResolver
     }
 
     /// <inheritdoc />
+#if NET6_0_OR_GREATER
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "The non-generic Autofac API builds IEnumerable<T> for a runtime Type; generic GetServices<T>(string?) is the AOT-safe path.")]
+#endif
     public virtual IEnumerable<object> GetServices(Type? serviceType, string? contract)
     {
         var isNull = serviceType is null;

--- a/src/Splat.Drawing/DefaultPlatformModeDetector.cs
+++ b/src/Splat.Drawing/DefaultPlatformModeDetector.cs
@@ -34,6 +34,10 @@ public class DefaultPlatformModeDetector : IPlatformModeDetector
 #endif
 
     /// <inheritdoc />
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("Uses Activator.CreateInstance and reflection which require dynamic code generation")]
+    [RequiresUnreferencedCode("Uses Type.GetType and Activator.CreateInstance which may be trimmed")]
+#endif
     public bool? InDesignMode()
     {
 #if NETFX_CORE

--- a/src/Splat.Drawing/IPlatformModeDetector.cs
+++ b/src/Splat.Drawing/IPlatformModeDetector.cs
@@ -22,5 +22,9 @@ public interface IPlatformModeDetector
     /// Gets a value indicating whether the current library or application is running in a GUI design mode tool.
     /// </summary>
     /// <returns>If we are currently running in design mode.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("Uses Activator.CreateInstance and reflection which require dynamic code generation")]
+    [RequiresUnreferencedCode("Uses Type.GetType and Activator.CreateInstance which may be trimmed")]
+#endif
     bool? InDesignMode();
 }

--- a/src/Splat.Drawing/PlatformModeDetector.cs
+++ b/src/Splat.Drawing/PlatformModeDetector.cs
@@ -45,6 +45,10 @@ public static class PlatformModeDetector
     /// Gets a value indicating whether we are currently running from within a GUI design editor.
     /// </summary>
     /// <returns>If we are currently running from design mode.</returns>
+#if NET6_0_OR_GREATER
+    [RequiresDynamicCode("Uses Activator.CreateInstance and reflection which require dynamic code generation")]
+    [RequiresUnreferencedCode("Uses Type.GetType and Activator.CreateInstance which may be trimmed")]
+#endif
     public static bool InDesignMode()
     {
         if (_cachedInDesignModeResult.HasValue)

--- a/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
+++ b/src/Splat.Microsoft.Extensions.DependencyInjection/MicrosoftDependencyResolver.cs
@@ -149,6 +149,9 @@ public class MicrosoftDependencyResolver : IDependencyResolver, IAsyncDisposable
     }
 
     /// <inheritdoc />
+#if NET7_0_OR_GREATER
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "The non-generic Microsoft DI API requires runtime IEnumerable<T> native code; generic GetServices<T>() is the AOT-safe path.")]
+#endif
     public virtual IEnumerable<object> GetServices(Type? serviceType)
     {
         if (ServiceProvider is null)
@@ -175,6 +178,9 @@ public class MicrosoftDependencyResolver : IDependencyResolver, IAsyncDisposable
     }
 
     /// <inheritdoc />
+#if NET7_0_OR_GREATER
+    [UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "The non-generic Microsoft DI API requires runtime IEnumerable<T> native code; generic GetServices<T>(string?) is the AOT-safe path.")]
+#endif
     public virtual IEnumerable<object> GetServices(Type? serviceType, string? contract)
     {
         if (ServiceProvider is null)

--- a/src/Splat.Prism/SplatContainerExtension.cs
+++ b/src/Splat.Prism/SplatContainerExtension.cs
@@ -63,6 +63,7 @@ public class SplatContainerExtension : IContainerExtension<IDependencyResolver>,
     public IContainerRegistry RegisterManySingleton(Type type, params Type[] serviceTypes) => throw new NotSupportedException();
 
     /// <inheritdoc/>
+    [UnconditionalSuppressMessage("Trimming", "IL2067:RequiresUnreferencedCode", Justification = "Prism exposes Type-based registration; factory overloads are the trim-safe path.")]
     public IContainerRegistry Register(Type from, Type to)
     {
         _types[(from, null)] = to;
@@ -85,6 +86,7 @@ public class SplatContainerExtension : IContainerExtension<IDependencyResolver>,
     }
 
     /// <inheritdoc/>
+    [UnconditionalSuppressMessage("Trimming", "IL2067:RequiresUnreferencedCode", Justification = "Prism exposes Type-based registration; factory overloads are the trim-safe path.")]
     public IContainerRegistry Register(Type from, Type to, string name)
     {
         _types[(from, name)] = to;
@@ -107,6 +109,7 @@ public class SplatContainerExtension : IContainerExtension<IDependencyResolver>,
     }
 
     /// <inheritdoc/>
+    [UnconditionalSuppressMessage("Trimming", "IL2067:RequiresUnreferencedCode", Justification = "Prism exposes Type-based registration; factory overloads are the trim-safe path.")]
     public IContainerRegistry RegisterMany(Type type, params Type[] serviceTypes)
     {
         if (serviceTypes is null)
@@ -158,6 +161,7 @@ public class SplatContainerExtension : IContainerExtension<IDependencyResolver>,
     }
 
     /// <inheritdoc/>
+    [UnconditionalSuppressMessage("Trimming", "IL2067:RequiresUnreferencedCode", Justification = "Prism exposes Type-based registration; factory overloads are the trim-safe path.")]
     public IContainerRegistry RegisterSingleton(Type from, Type to)
     {
         _types[(from, null)] = to;
@@ -195,6 +199,7 @@ public class SplatContainerExtension : IContainerExtension<IDependencyResolver>,
     }
 
     /// <inheritdoc/>
+    [UnconditionalSuppressMessage("Trimming", "IL2067:RequiresUnreferencedCode", Justification = "Prism exposes Type-based registration; factory overloads are the trim-safe path.")]
     public IContainerRegistry RegisterSingleton(Type from, Type to, string name)
     {
         _types[(from, name)] = to;
@@ -213,6 +218,7 @@ public class SplatContainerExtension : IContainerExtension<IDependencyResolver>,
 
     /// <inheritdoc/>
     [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1316:Tuple element names should use correct casing", Justification = "Existing API")]
+    [UnconditionalSuppressMessage("Trimming", "IL2067:RequiresUnreferencedCode", Justification = "Prism exposes Type-based resolution; resolver/factory overloads are the trim-safe path.")]
     public object Resolve(Type type, params (Type Type, object Instance)[] parameters) =>
         (_types.TryGetValue((type, null), out var resolvedType)
             ? Activator.CreateInstance(resolvedType, parameters.Select(x => x.Instance)) ?? throw new InvalidOperationException("Could not create type")
@@ -223,6 +229,7 @@ public class SplatContainerExtension : IContainerExtension<IDependencyResolver>,
 
     /// <inheritdoc/>
     [SuppressMessage("StyleCop.CSharp.NamingRules", "SA1316:Tuple element names should use correct casing", Justification = "Existing API")]
+    [UnconditionalSuppressMessage("Trimming", "IL2067:RequiresUnreferencedCode", Justification = "Prism exposes Type-based resolution; resolver/factory overloads are the trim-safe path.")]
     public object Resolve(Type type, string name, params (Type Type, object Instance)[] parameters) =>
         (!_types.TryGetValue((type, name), out var resolvedType)
             ? resolvedType switch

--- a/src/tests/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.DotNet10_0.verified.txt
+++ b/src/tests/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.DotNet10_0.verified.txt
@@ -36,6 +36,9 @@ namespace Splat
     public class DefaultPlatformModeDetector : Splat.IPlatformModeDetector
     {
         public DefaultPlatformModeDetector() { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Uses Activator.CreateInstance and reflection which require dynamic code generatio" +
+            "n")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses Type.GetType and Activator.CreateInstance which may be trimmed")]
         public bool? InDesignMode() { }
     }
     public interface IBitmap : System.IDisposable
@@ -52,6 +55,9 @@ namespace Splat
     }
     public interface IPlatformModeDetector
     {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Uses Activator.CreateInstance and reflection which require dynamic code generatio" +
+            "n")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses Type.GetType and Activator.CreateInstance which may be trimmed")]
         bool? InDesignMode();
     }
     public enum KnownColor
@@ -241,6 +247,9 @@ namespace Splat
     }
     public static class PlatformModeDetector
     {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Uses Activator.CreateInstance and reflection which require dynamic code generatio" +
+            "n")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses Type.GetType and Activator.CreateInstance which may be trimmed")]
         public static bool InDesignMode() { }
         public static void OverrideModeDetector(Splat.IPlatformModeDetector modeDetector) { }
     }

--- a/src/tests/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.DotNet8_0.verified.txt
+++ b/src/tests/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.DotNet8_0.verified.txt
@@ -36,6 +36,9 @@ namespace Splat
     public class DefaultPlatformModeDetector : Splat.IPlatformModeDetector
     {
         public DefaultPlatformModeDetector() { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Uses Activator.CreateInstance and reflection which require dynamic code generatio" +
+            "n")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses Type.GetType and Activator.CreateInstance which may be trimmed")]
         public bool? InDesignMode() { }
     }
     public interface IBitmap : System.IDisposable
@@ -52,6 +55,9 @@ namespace Splat
     }
     public interface IPlatformModeDetector
     {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Uses Activator.CreateInstance and reflection which require dynamic code generatio" +
+            "n")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses Type.GetType and Activator.CreateInstance which may be trimmed")]
         bool? InDesignMode();
     }
     public enum KnownColor
@@ -241,6 +247,9 @@ namespace Splat
     }
     public static class PlatformModeDetector
     {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Uses Activator.CreateInstance and reflection which require dynamic code generatio" +
+            "n")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses Type.GetType and Activator.CreateInstance which may be trimmed")]
         public static bool InDesignMode() { }
         public static void OverrideModeDetector(Splat.IPlatformModeDetector modeDetector) { }
     }

--- a/src/tests/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.DotNet9_0.verified.txt
+++ b/src/tests/Splat.Drawing.Tests/API/ApiApprovalTests.SplatUIProject.DotNet9_0.verified.txt
@@ -36,6 +36,9 @@ namespace Splat
     public class DefaultPlatformModeDetector : Splat.IPlatformModeDetector
     {
         public DefaultPlatformModeDetector() { }
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Uses Activator.CreateInstance and reflection which require dynamic code generatio" +
+            "n")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses Type.GetType and Activator.CreateInstance which may be trimmed")]
         public bool? InDesignMode() { }
     }
     public interface IBitmap : System.IDisposable
@@ -52,6 +55,9 @@ namespace Splat
     }
     public interface IPlatformModeDetector
     {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Uses Activator.CreateInstance and reflection which require dynamic code generatio" +
+            "n")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses Type.GetType and Activator.CreateInstance which may be trimmed")]
         bool? InDesignMode();
     }
     public enum KnownColor
@@ -241,6 +247,9 @@ namespace Splat
     }
     public static class PlatformModeDetector
     {
+        [System.Diagnostics.CodeAnalysis.RequiresDynamicCode("Uses Activator.CreateInstance and reflection which require dynamic code generatio" +
+            "n")]
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("Uses Type.GetType and Activator.CreateInstance which may be trimmed")]
         public static bool InDesignMode() { }
         public static void OverrideModeDetector(Splat.IPlatformModeDetector modeDetector) { }
     }


### PR DESCRIPTION
<!-- Please be sure to read our [Contribute guide](https://www.reactiveui.net/contribute/index.html) before opening a PR. -->

## What kind of change does this PR introduce?
<!-- Bug fix, feature, docs update, refactor, ci, ... -->
update

## What is the current behavior?
<!-- You can also link to an open issue here. Use "Closes #123" to auto-close on merge. -->

## What is the new behavior?
<!-- If this is a feature change -->

Apply AOT and trimming annotations across the codebase: 
- add UnconditionalSuppressMessage for non-generic GetServices overloads in Autofac and Microsoft.Extensions DI (guarded by NET6_0_OR_GREATER / NET7_0_OR_GREATER), 
- add RequiresDynamicCode and RequiresUnreferencedCode to IPlatformModeDetector.InDesignMode, DefaultPlatformModeDetector.InDesignMode and PlatformModeDetector.InDesignMode, 
- add trimming suppressions to Prism type-based registration/resolution APIs.

Updated API approval test files to reflect the new attributes. 
These changes document and suppress AOT/trimming warnings and point consumers toward the trim/AOT-safe generic/factory overloads.

## What might this PR break?

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information
