### PR TITLE
Compile .NET Framework and Windows targets on non-Windows

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -37,12 +37,14 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <NoWarn>$(NoWarn);IDE1006</NoWarn>
+    <!-- Enable building the .NET Framework targets on non-Windows platforms (reference-only compile). -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup>
     <SplatModernTargets>net8.0;net9.0;net10.0</SplatModernTargets>
 
-    <SplatLegacyTargets Condition="$([MSBuild]::IsOsPlatform('Windows'))">net462;net472;net481</SplatLegacyTargets>
+    <SplatLegacyTargets>net462;net472;net481</SplatLegacyTargets>
 
     <SplatCoreTargets>$(SplatModernTargets)</SplatCoreTargets>
     <SplatCoreTargets Condition=" '$(SplatLegacyTargets)' != '' ">$(SplatCoreTargets);$(SplatLegacyTargets)</SplatCoreTargets>
@@ -50,15 +52,12 @@
     <SplatAndroidTargets>net9.0-android;net10.0-android</SplatAndroidTargets>
     <SplatWindowsTargets>net8.0-windows10.0.17763.0;net9.0-windows10.0.17763.0;net10.0-windows10.0.17763.0;net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</SplatWindowsTargets>
     <SplatAppleTargets>net9.0-ios;net9.0-macos;net9.0-maccatalyst;net9.0-tvos;net10.0-ios;net10.0-macos;net10.0-maccatalyst;net10.0-tvos</SplatAppleTargets>
-    <SplatUiFinalTargetFrameworks>$(SplatCoreTargets);$(SplatAndroidTargets)</SplatUiFinalTargetFrameworks>
+    <SplatUiFinalTargetFrameworks>$(SplatCoreTargets);$(SplatAndroidTargets);$(SplatWindowsTargets)</SplatUiFinalTargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('OSX'))">
+  <!-- Apple TFMs: only buildable on Windows or macOS. -->
+  <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('Windows')) or $([MSBuild]::IsOsPlatform('OSX'))">
     <SplatUiFinalTargetFrameworks>$(SplatUiFinalTargetFrameworks);$(SplatAppleTargets)</SplatUiFinalTargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-    <SplatUiFinalTargetFrameworks>$(SplatUiFinalTargetFrameworks);$(SplatWindowsTargets);$(SplatAppleTargets)</SplatUiFinalTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(IsTestProject) != 'true'">

--- a/src/Splat.Drawing/Splat.Drawing.csproj
+++ b/src/Splat.Drawing/Splat.Drawing.csproj
@@ -8,13 +8,12 @@
     <Nullable>enable</Nullable>
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
-  <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
-  </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0')) or $(TargetFramework.StartsWith('net10.0'))">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
-  <PropertyGroup Condition="($(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4'))) and $([MSBuild]::IsOsPlatform('Windows'))">
+  <!-- WPF/WinForms reference packs are restored on any platform via EnableWindowsTargeting, so the desktop TFMs
+       reference-compile on Linux/macOS as well as Windows. -->
+  <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4'))">
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>


### PR DESCRIPTION
## What

Makes the full target set buildable on Linux/macOS, not just Windows.

- Set `EnableWindowsTargeting=true` and drop the Windows-only condition on the `net462`/`net472`/`net481` legacy targets so they are always part of the build.
- Always include the `net8/9/10`-windows TFMs in the UI projects' target set (`SplatUiFinalTargetFrameworks`).
- Drop the `IsOsPlatform('Windows')` gate on Splat.Drawing's `UseWPF`/`UseWindowsForms` (and its redundant local `EnableWindowsTargeting`) so the WPF/WinForms reference packs are restored and the desktop TFMs reference-compile everywhere.
- Apple TFMs remain gated to Windows/macOS — they cannot build on Linux.

`System.ValueTuple` for net462 is already handled by the existing per-project references, so no change was needed there.

## Why

Lets the full multi-TFM build (legacy + Windows desktop targets) run on Linux/macOS CI and dev machines, not just Windows.

## Testing (Linux)

- `Splat` + `Splat.Core` + `Splat.Builder` + `Splat.Logging` build across `net8.0;net9.0;net10.0;net462;net472;net481`.
- `Splat.Drawing` builds for `net462` and `net8.0-windows10.0.19041.0`.
- Full test suite via MTP: **12,825 passed, 0 failed, 3 skipped**.