### PR TITLE
build: cross-platform targeting for non-Windows builds + pinned Android platform versions

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -49,7 +49,7 @@
     <SplatCoreTargets>$(SplatModernTargets)</SplatCoreTargets>
     <SplatCoreTargets Condition=" '$(SplatLegacyTargets)' != '' ">$(SplatCoreTargets);$(SplatLegacyTargets)</SplatCoreTargets>
 
-    <SplatAndroidTargets>net9.0-android;net10.0-android</SplatAndroidTargets>
+    <SplatAndroidTargets>net9.0-android35.0;net10.0-android36.0</SplatAndroidTargets>
     <SplatWindowsTargets>net8.0-windows10.0.17763.0;net9.0-windows10.0.17763.0;net10.0-windows10.0.17763.0;net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</SplatWindowsTargets>
     <SplatAppleTargets>net9.0-ios;net9.0-macos;net9.0-maccatalyst;net9.0-tvos;net10.0-ios;net10.0-macos;net10.0-maccatalyst;net10.0-tvos</SplatAppleTargets>
     <SplatUiFinalTargetFrameworks>$(SplatCoreTargets);$(SplatAndroidTargets);$(SplatWindowsTargets)</SplatUiFinalTargetFrameworks>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -37,12 +37,14 @@
     <!-- Include PDB in the built .nupkg -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <NoWarn>$(NoWarn);IDE1006</NoWarn>
+    <!-- Enable building the .NET Framework targets on non-Windows platforms (reference-only compile). -->
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
   </PropertyGroup>
 
   <PropertyGroup>
     <SplatModernTargets>net8.0;net9.0;net10.0</SplatModernTargets>
 
-    <SplatLegacyTargets Condition="$([MSBuild]::IsOsPlatform('Windows'))">net462;net472;net481</SplatLegacyTargets>
+    <SplatLegacyTargets>net462;net472;net481</SplatLegacyTargets>
 
     <SplatCoreTargets>$(SplatModernTargets)</SplatCoreTargets>
     <SplatCoreTargets Condition=" '$(SplatLegacyTargets)' != '' ">$(SplatCoreTargets);$(SplatLegacyTargets)</SplatCoreTargets>
@@ -50,15 +52,12 @@
     <SplatAndroidTargets>net9.0-android;net10.0-android</SplatAndroidTargets>
     <SplatWindowsTargets>net8.0-windows10.0.17763.0;net9.0-windows10.0.17763.0;net10.0-windows10.0.17763.0;net8.0-windows10.0.19041.0;net9.0-windows10.0.19041.0;net10.0-windows10.0.19041.0</SplatWindowsTargets>
     <SplatAppleTargets>net9.0-ios;net9.0-macos;net9.0-maccatalyst;net9.0-tvos;net10.0-ios;net10.0-macos;net10.0-maccatalyst;net10.0-tvos</SplatAppleTargets>
-    <SplatUiFinalTargetFrameworks>$(SplatCoreTargets);$(SplatAndroidTargets)</SplatUiFinalTargetFrameworks>
+    <SplatUiFinalTargetFrameworks>$(SplatCoreTargets);$(SplatAndroidTargets);$(SplatWindowsTargets)</SplatUiFinalTargetFrameworks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('OSX'))">
+  <!-- Apple TFMs: only buildable on Windows or macOS. -->
+  <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('Windows')) or $([MSBuild]::IsOsPlatform('OSX'))">
     <SplatUiFinalTargetFrameworks>$(SplatUiFinalTargetFrameworks);$(SplatAppleTargets)</SplatUiFinalTargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-    <SplatUiFinalTargetFrameworks>$(SplatUiFinalTargetFrameworks);$(SplatWindowsTargets);$(SplatAppleTargets)</SplatUiFinalTargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(IsTestProject) != 'true'">

--- a/src/Splat.Drawing/Splat.Drawing.csproj
+++ b/src/Splat.Drawing/Splat.Drawing.csproj
@@ -8,13 +8,12 @@
     <Nullable>enable</Nullable>
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
-  <PropertyGroup Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-    <EnableWindowsTargeting>true</EnableWindowsTargeting>
-  </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net8.0')) or $(TargetFramework.StartsWith('net9.0')) or $(TargetFramework.StartsWith('net10.0'))">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
-  <PropertyGroup Condition="($(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4'))) and $([MSBuild]::IsOsPlatform('Windows'))">
+  <!-- WPF/WinForms reference packs are restored on any platform via EnableWindowsTargeting, so the desktop TFMs
+       reference-compile on Linux/macOS as well as Windows. -->
+  <PropertyGroup Condition="$(TargetFramework.Contains('-windows')) or $(TargetFramework.StartsWith('net4'))">
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>

--- a/src/Splat.Drawing/Splat.Drawing.csproj
+++ b/src/Splat.Drawing/Splat.Drawing.csproj
@@ -50,7 +50,7 @@
   <ItemGroup Condition="$(TargetFramework.EndsWith('0-macos'))">
     <Compile Include="Platforms\Cocoa\**\*.cs"/>
   </ItemGroup>
-  <ItemGroup Condition=" $(TargetFramework.EndsWith('0-android'))">
+  <ItemGroup Condition=" $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
     <Compile Include="Platforms\Android\**\*.cs"/>
     <Compile Include="Platforms\TypeForwardedSystemDrawing.cs"/>
     <Compile Include="Resources\**\*.cs"/>


### PR DESCRIPTION
## What

Two build/targeting fixes so the full Splat target matrix restores and reference-compiles on non-Windows machines.

### 1. Compile .NET Framework and Windows targets on non-Windows
- Set `EnableWindowsTargeting=true` so the WPF/WinForms/.NET Framework reference packs restore on any OS.
- Removed the `IsOsPlatform('Windows')` guards around the legacy (`net462`/`net472`/`net481`) and Windows desktop TFMs, and around `UseWPF`/`UseWindowsForms` in `Splat.Drawing`, so those desktop TFMs reference-compile on Linux/macOS as well as Windows.
- Apple TFMs stay gated to Windows or macOS (they can't reference-compile on Linux).

### 2. Pin Android target platform versions
- `net9.0-android`/`net10.0-android` were bare (no platform version). When `Splat.Drawing` is consumed via a cross-repo `ProjectReference`, the platform version is not resolved during restore, producing `NU1012` ("Platform version is not present for one or more target frameworks"). Pinned to `net9.0-android35.0;net10.0-android36.0`.
- Updated `Splat.Drawing`'s Android `<ItemGroup>` condition from `EndsWith('0-android')` (which no longer matches the versioned TFM) to the version-agnostic `$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'`, so the Android `PlatformBitmapLoader` is still compiled in.

## Why

ReactiveUI temporarily project-references the local Splat / Splat.Drawing while the dead `System.Reactive` dependency is removed. These changes let that full target matrix build on non-Windows CI and dev machines.