### PR TITLE
chore(renovate): keep legacy 4.x System.* packages off the v10 monorepo bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,13 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["local>reactiveui/.github:renovate"]
+    "extends": ["local>reactiveui/.github:renovate"],
+    "packageRules": [
+        {
+            "description": "Legacy System.* compatibility packages are pinned to their 4.x line for the net4*/netstandard targets. Cap Renovate below 5.0.0 so the .NET monorepo v10 updates do not bump these and break those targets. The modern 10.x System.* entries (in the Otherwise/modern groups) are unaffected because this rule only matches versions currently on 4.x.",
+            "matchManagers": ["nuget"],
+            "matchPackageNames": ["/^System\\./"],
+            "matchCurrentVersion": "/^4\\./",
+            "allowedVersions": "<5.0.0"
+        }
+    ]
 }


### PR DESCRIPTION
## What

Adds a Renovate `packageRule` that caps `System.*` packages **currently on the 4.x line** below `5.0.0`.

## Why

The `net4*`/`netstandard` targets pin a set of `System.*` compatibility shims to their 4.x versions in `src/Directory.Packages.props`. Renovate's .NET monorepo **v10** update (e.g. #1598) tries to bump them — for example `System.Runtime.Serialization.Formatters` `4.3.0` → `10.0.x` *inside the net4 conditional block* — which breaks those targets.

## How

```json
{
  "matchManagers": ["nuget"],
  "matchPackageNames": ["/^System\\./"],
  "matchCurrentVersion": "/^4\\./",
  "allowedVersions": "<5.0.0"
}
```

`matchCurrentVersion` scopes the rule to entries **already on 4.x**, so the modern 10.x `System.*` entries keep updating normally — only the legacy 4.x pins are held under 5.0.0.