### PR TITLE
fix(di): scope InstanceGenericFirst registration callbacks to their service key

### DIFF
--- a/src/Splat.Core/ServiceLocation/Common/ArrayHelpers.cs
+++ b/src/Splat.Core/ServiceLocation/Common/ArrayHelpers.cs
@@ -233,6 +233,34 @@ internal static class ArrayHelpers
             }
         }
 
+        /// <summary>Removes the first occurrence of <paramref name="value"/>, if present.</summary>
+        /// <param name="value">The value to remove, matched by the default equality comparer.</param>
+        /// <returns><see langword="true"/> if an item was removed; otherwise <see langword="false"/>.</returns>
+        /// <remarks>When the entry drains to empty, an empty snapshot is published so subsequent reads fast-exit.</remarks>
+        public bool Remove(TValue value)
+        {
+            lock (_gate)
+            {
+                if (!_list.Remove(value))
+                {
+                    return false;
+                }
+
+                _version++;
+                var remaining = _list.Count;
+                Volatile.Write(ref _count, remaining);
+
+                if (remaining == 0)
+                {
+                    // Publish an empty snapshot aligned with the new version so readers fast-exit.
+                    _snapshot = [];
+                    _snapshotVersion = _version;
+                }
+
+                return true;
+            }
+        }
+
         /// <summary>Removes all items and publishes an empty snapshot.</summary>
         public void Clear()
         {

--- a/src/Splat.Core/ServiceLocation/InstanceGenericFirst/InstanceGenericFirstDependencyResolver.cs
+++ b/src/Splat.Core/ServiceLocation/InstanceGenericFirst/InstanceGenericFirstDependencyResolver.cs
@@ -48,18 +48,11 @@ namespace Splat;
     Justification = "Generic service-location API; the service type is supplied explicitly by callers, so type inference cannot apply by design.")]
 public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
 {
-    /// <summary>Gate protecting <see cref="_callbackChanged"/> and publication of <see cref="_callbackSnapshot"/>.</summary>
+    /// <summary>Gate protecting <see cref="_callbackRegistry"/> structure and <see cref="_callbackCount"/> updates.</summary>
     /// <remarks>
-    /// Do not lock on the list instance itself; list mutations (including <c>Clear</c>) would make that pattern fragile.
+    /// Held only while mutating the registry dictionary or reading an entry reference; user callbacks always run outside this gate.
     /// </remarks>
     private readonly Lock _callbackGate = new();
-
-    /// <summary>Registered callbacks notified when registrations change.</summary>
-    /// <remarks>
-    /// The list is mutated under <see cref="_callbackGate"/> and a snapshot is published to <see cref="_callbackSnapshot"/>
-    /// for lock-free invocation.
-    /// </remarks>
-    private readonly List<Action> _callbackChanged = [];
 
     /// <summary>Gate protecting <see cref="_disposalActions"/> additions/enumeration/clearing.</summary>
     private readonly Lock _disposalGate = new();
@@ -76,11 +69,23 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
     /// </remarks>
     private ResolverState _state = new();
 
-    /// <summary>Snapshot of callbacks published for lock-free iteration.</summary>
+    /// <summary>Registration-change callbacks keyed by <c>(service type, contract)</c>; <see langword="null"/> until the first subscription.</summary>
     /// <remarks>
-    /// Written under <see cref="_callbackGate"/> and read via Volatile Read.
+    /// <para>
+    /// Lazily created so resolvers that never subscribe (the common case) allocate no callback state.
+    /// The dictionary structure is mutated only under <see cref="_callbackGate"/>; each per-key
+    /// <see cref="ArrayHelpers.Entry{TValue}"/> publishes an immutable snapshot that is invoked lock-free outside the gate.
+    /// </para>
+    /// <para>
+    /// Callbacks are scoped to their <c>(type, contract)</c> key and fire only on registration (not unregistration),
+    /// matching <see cref="ModernDependencyResolver"/> semantics.
+    /// </para>
     /// </remarks>
-    private Action[] _callbackSnapshot = [];
+    private Dictionary<(Type ServiceType, string? Contract), ArrayHelpers.Entry<Action<IDisposable>>>? _callbackRegistry;
+
+    /// <summary>Total number of live registration callbacks; enables a lock-free fast exit from <see cref="NotifyCallbackChanged"/> when zero.</summary>
+    /// <remarks>Written under <see cref="_callbackGate"/> via <see cref="Volatile.Write(ref int, int)"/>; read lock-free on the registration hot path.</remarks>
+    private int _callbackCount;
 
     /// <summary>Disposal flag: 0 = not disposed, 1 = disposed.</summary>
     private int _disposed;
@@ -340,7 +345,7 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
         var registry = ServiceTypeRegistryCache.Get(_state);
         registry.Register(TypeCache<T>.Type, () => factory()!);
 
-        NotifyCallbackChanged();
+        NotifyCallbackChanged(TypeCache<T>.Type, null);
     }
 
     /// <inheritdoc />
@@ -364,7 +369,7 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
         var registry = ServiceTypeRegistryCache.Get(_state);
         registry.Register(TypeCache<T>.Type, () => factory()!, contract);
 
-        NotifyCallbackChanged();
+        NotifyCallbackChanged(TypeCache<T>.Type, contract);
     }
 
     /// <inheritdoc />
@@ -381,7 +386,7 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
         registry.Register(serviceType, factory);
         registry.TrackNonGenericRegistration(serviceType);
 
-        NotifyCallbackChanged();
+        NotifyCallbackChanged(serviceType, null);
     }
 
     /// <inheritdoc />
@@ -404,7 +409,7 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
         registry.Register(serviceType, factory, contract);
         registry.TrackNonGenericRegistration(serviceType, contract);
 
-        NotifyCallbackChanged();
+        NotifyCallbackChanged(serviceType, contract);
     }
 
     /// <inheritdoc />
@@ -421,7 +426,7 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
         var registry = ServiceTypeRegistryCache.Get(_state);
         registry.Register(TypeCache<TService>.Type, static () => new TImplementation());
 
-        NotifyCallbackChanged();
+        NotifyCallbackChanged(TypeCache<TService>.Type, null);
     }
 
     /// <inheritdoc />
@@ -444,7 +449,7 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
         var registry = ServiceTypeRegistryCache.Get(_state);
         registry.Register(TypeCache<TService>.Type, static () => new TImplementation(), contract);
 
-        NotifyCallbackChanged();
+        NotifyCallbackChanged(TypeCache<TService>.Type, contract);
     }
 
     /// <inheritdoc />
@@ -462,7 +467,7 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
         var registry = ServiceTypeRegistryCache.Get(_state);
         registry.Register(TypeCache<T>.Type, () => value!);
 
-        NotifyCallbackChanged();
+        NotifyCallbackChanged(TypeCache<T>.Type, null);
     }
 
     /// <inheritdoc />
@@ -486,7 +491,7 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
         var registry = ServiceTypeRegistryCache.Get(_state);
         registry.Register(TypeCache<T>.Type, () => value!, contract);
 
-        NotifyCallbackChanged();
+        NotifyCallbackChanged(TypeCache<T>.Type, contract);
     }
 
     /// <inheritdoc />
@@ -529,7 +534,7 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
             return value;
         });
 
-        NotifyCallbackChanged();
+        NotifyCallbackChanged(TypeCache<T>.Type, null);
     }
 
     /// <inheritdoc />
@@ -583,7 +588,7 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
             },
             contract);
 
-        NotifyCallbackChanged();
+        NotifyCallbackChanged(TypeCache<T>.Type, contract);
     }
 
     /// <inheritdoc />
@@ -596,8 +601,6 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
 
         var registry = ServiceTypeRegistryCache.Get(_state);
         registry.UnregisterCurrent(TypeCache<T>.Type);
-
-        NotifyCallbackChanged();
     }
 
     /// <inheritdoc />
@@ -616,8 +619,6 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
 
         var registry = ServiceTypeRegistryCache.Get(_state);
         registry.UnregisterCurrent(TypeCache<T>.Type, contract);
-
-        NotifyCallbackChanged();
     }
 
     /// <inheritdoc />
@@ -628,8 +629,6 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
         serviceType ??= NullServiceType.CachedType;
         var registry = ServiceTypeRegistryCache.Get(_state);
         registry.UnregisterCurrent(serviceType);
-
-        NotifyCallbackChanged();
     }
 
     /// <inheritdoc />
@@ -647,8 +646,6 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
 
         var registry = ServiceTypeRegistryCache.Get(_state);
         registry.UnregisterCurrent(serviceType, contract);
-
-        NotifyCallbackChanged();
     }
 
     /// <inheritdoc />
@@ -661,8 +658,6 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
 
         var registry = ServiceTypeRegistryCache.Get(_state);
         registry.UnregisterAll(TypeCache<T>.Type);
-
-        NotifyCallbackChanged();
     }
 
     /// <inheritdoc />
@@ -681,8 +676,6 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
 
         var registry = ServiceTypeRegistryCache.Get(_state);
         registry.UnregisterAll(TypeCache<T>.Type, contract);
-
-        NotifyCallbackChanged();
     }
 
     /// <inheritdoc />
@@ -693,8 +686,6 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
         serviceType ??= NullServiceType.CachedType;
         var registry = ServiceTypeRegistryCache.Get(_state);
         registry.UnregisterAll(serviceType);
-
-        NotifyCallbackChanged();
     }
 
     /// <inheritdoc />
@@ -712,8 +703,6 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
 
         var registry = ServiceTypeRegistryCache.Get(_state);
         registry.UnregisterAll(serviceType, contract);
-
-        NotifyCallbackChanged();
     }
 
     /// <inheritdoc />
@@ -726,17 +715,7 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
         ArgumentExceptionHelper.ThrowIfNull(callback);
         ObjectDisposedExceptionHelper.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
 
-        // Wrap to normalize callback signature; the wrapper is what we store/remove.
-        Action callbackWrapper = () => callback(EmptyDisposable.Instance);
-
-        AddCallback(callbackWrapper);
-        RefreshCallbackSnapshot();
-
-        var disp = new ActionDisposable(() =>
-        {
-            RemoveCallback(callbackWrapper);
-            RefreshCallbackSnapshot();
-        });
+        var disp = AddCallback(TypeCache<T>.Type, contract, callback);
 
         // Invoke callback once per existing registration (matches ModernDependencyResolver behavior).
         // Use counts to avoid invoking factories (especially lazy singletons).
@@ -766,16 +745,7 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
         ArgumentExceptionHelper.ThrowIfNull(callback);
         ObjectDisposedExceptionHelper.ThrowIf(Volatile.Read(ref _disposed) != 0, this);
 
-        Action callbackWrapper = () => callback(EmptyDisposable.Instance);
-
-        AddCallback(callbackWrapper);
-        RefreshCallbackSnapshot();
-
-        var disp = new ActionDisposable(() =>
-        {
-            RemoveCallback(callbackWrapper);
-            RefreshCallbackSnapshot();
-        });
+        var disp = AddCallback(serviceType, contract, callback);
 
         var registry = ServiceTypeRegistryCache.Get(_state);
         var count = registry.GetCount(serviceType, contract);
@@ -803,7 +773,7 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
 
         // Snapshot callbacks and disposal actions under their respective gates.
         // Run user code outside locks.
-        var callbacks = Volatile.Read(ref _callbackSnapshot);
+        var callbacks = DrainCallbacks();
 
         Action[]? disposalActionsSnapshot;
         lock (_disposalGate)
@@ -817,19 +787,12 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
         {
             try
             {
-                callbacks[i]();
+                callbacks[i](EmptyDisposable.Instance);
             }
             catch
             {
                 // Suppress exceptions during disposal.
             }
-        }
-
-        // Clear callbacks under the correct gate (race fix vs. original).
-        lock (_callbackGate)
-        {
-            _callbackChanged.Clear();
-            Volatile.Write(ref _callbackSnapshot, []);
         }
 
         // Execute disposal actions for constants and lazy singletons (exceptions suppressed).
@@ -1062,60 +1025,123 @@ public sealed class InstanceGenericFirstDependencyResolver : IDependencyResolver
         _state.MarkHasRegistrations();
     }
 
-    /// <summary>Adds a callback to the registration-change callback list.</summary>
+    /// <summary>Registers a callback under the supplied <c>(service type, contract)</c> key and returns a disposable that removes it.</summary>
+    /// <param name="serviceType">The service type the callback is scoped to.</param>
+    /// <param name="contract">The optional contract the callback is scoped to.</param>
     /// <param name="callback">The callback to add.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
-    private void AddCallback(Action callback)
+    /// <returns>A disposable that unsubscribes the callback when disposed.</returns>
+    private ActionDisposable AddCallback(Type serviceType, string? contract, Action<IDisposable> callback)
     {
-        ArgumentExceptionHelper.ThrowIfNull(callback);
+        var key = (serviceType, contract);
+
         lock (_callbackGate)
         {
-            _callbackChanged.Add(callback);
+            _callbackRegistry ??= [];
+            if (!_callbackRegistry.TryGetValue(key, out var entry))
+            {
+                entry = new();
+                _callbackRegistry[key] = entry;
+            }
+
+            entry.Add(callback);
+            Volatile.Write(ref _callbackCount, _callbackCount + 1);
+        }
+
+        return new ActionDisposable(() => RemoveCallback(key, callback));
+    }
+
+    /// <summary>Atomically detaches and returns every registered callback for one-shot teardown invocation.</summary>
+    /// <returns>A flattened snapshot of all registered callbacks; an empty array when none are subscribed.</returns>
+    private Action<IDisposable>[] DrainCallbacks()
+    {
+        lock (_callbackGate)
+        {
+            try
+            {
+                if (_callbackRegistry is null || _callbackCount == 0)
+                {
+                    return [];
+                }
+
+                // Flatten every key's callbacks into a single list so each is invoked exactly once on teardown.
+                var flattened = new List<Action<IDisposable>>(_callbackCount);
+                foreach (var entry in _callbackRegistry.Values)
+                {
+                    entry.CopyItemsTo(flattened);
+                }
+
+                return [.. flattened];
+            }
+            finally
+            {
+                _callbackRegistry = null;
+                Volatile.Write(ref _callbackCount, 0);
+            }
         }
     }
 
-    /// <summary>Removes a callback from the registration-change callback list.</summary>
+    /// <summary>Removes a previously registered callback for the supplied key.</summary>
+    /// <param name="key">The <c>(service type, contract)</c> key the callback was registered under.</param>
     /// <param name="callback">The callback to remove.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="callback"/> is <see langword="null"/>.</exception>
-    private void RemoveCallback(Action callback)
-    {
-        ArgumentExceptionHelper.ThrowIfNull(callback);
-        lock (_callbackGate)
-        {
-            _callbackChanged.Remove(callback);
-        }
-    }
-
-    /// <summary>Publishes a fresh snapshot of callbacks for lock-free invocation.</summary>
-    /// <remarks>
-    /// This allocates a new array containing the current callback list.
-    /// The array is then published via <see cref="Volatile.Write{T}(ref T, T)"/>.
-    /// </remarks>
-    private void RefreshCallbackSnapshot()
+    private void RemoveCallback((Type ServiceType, string? Contract) key, Action<IDisposable> callback)
     {
         lock (_callbackGate)
         {
-            Volatile.Write(ref _callbackSnapshot, [.. _callbackChanged]);
+            if (_callbackRegistry is null || !_callbackRegistry.TryGetValue(key, out var entry))
+            {
+                return;
+            }
+
+            if (!entry.Remove(callback))
+            {
+                return;
+            }
+
+            Volatile.Write(ref _callbackCount, _callbackCount - 1);
+
+            if (entry.Count == 0)
+            {
+                _callbackRegistry.Remove(key);
+            }
         }
     }
 
-    /// <summary>Invokes the current callback snapshot to signal that registrations have changed.</summary>
+    /// <summary>Notifies callbacks scoped to the registered <c>(service type, contract)</c> key that a registration changed.</summary>
+    /// <param name="serviceType">The service type that was just registered.</param>
+    /// <param name="contract">The contract that was just registered, if any.</param>
     /// <remarks>
-    /// Suppresses exceptions thrown by callbacks. If the resolver is disposed, no callbacks are invoked.
+    /// Returns immediately (lock-free) when the resolver is disposed or no callbacks are subscribed.
+    /// Otherwise the matching key's immutable snapshot is invoked outside the gate; callback exceptions are suppressed.
     /// </remarks>
-    private void NotifyCallbackChanged()
+    private void NotifyCallbackChanged(Type serviceType, string? contract)
     {
         if (Volatile.Read(ref _disposed) != 0)
         {
             return;
         }
 
-        var callbacks = Volatile.Read(ref _callbackSnapshot);
-        for (var i = 0; i < callbacks.Length; i++)
+        // Fast path: the overwhelmingly common case has no subscribers, so avoid the gate and the dictionary lookup entirely.
+        if (Volatile.Read(ref _callbackCount) == 0)
+        {
+            return;
+        }
+
+        Action<IDisposable>[] snapshot;
+        lock (_callbackGate)
+        {
+            if (_callbackRegistry is null || !_callbackRegistry.TryGetValue((serviceType, contract), out var entry))
+            {
+                return;
+            }
+
+            snapshot = entry.GetSnapshot();
+        }
+
+        for (var i = 0; i < snapshot.Length; i++)
         {
             try
             {
-                callbacks[i]();
+                snapshot[i](EmptyDisposable.Instance);
             }
             catch
             {

--- a/src/tests/Splat.Tests/ServiceLocation/InstanceGenericFirst/InstanceGenericFirstDependencyResolverTests.cs
+++ b/src/tests/Splat.Tests/ServiceLocation/InstanceGenericFirst/InstanceGenericFirstDependencyResolverTests.cs
@@ -14,6 +14,83 @@ namespace Splat.Tests.ServiceLocation;
 [InheritsTests]
 public sealed class InstanceGenericFirstDependencyResolverTests : BaseDependencyResolverTests<InstanceGenericFirstDependencyResolver>
 {
+    /// <summary>
+    /// Tests that a generic registration callback fires only for registrations of its own service type,
+    /// not for unrelated ones (issue #1589 callback-scoping regression).
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ServiceRegistrationCallback_Generic_OnlyFiresForMatchingServiceType()
+    {
+        var resolver = new InstanceGenericFirstDependencyResolver();
+        var totalInvocations = 0;
+        var matchingInvocations = 0;
+
+        using var subscription = resolver.ServiceRegistrationCallback<ViewModelOne>(_ =>
+        {
+            totalInvocations++;
+            matchingInvocations += resolver.HasRegistration<ViewModelOne>() ? 1 : 0;
+        });
+
+        // An unrelated registration must not trigger the ViewModelOne callback.
+        resolver.RegisterConstant(new ViewModelTwo());
+        await Assert.That(totalInvocations).IsEqualTo(0);
+
+        // The matching registration must trigger it exactly once, while the service is resolvable.
+        resolver.RegisterConstant(new ViewModelOne());
+        using (Assert.Multiple())
+        {
+            await Assert.That(totalInvocations).IsEqualTo(1);
+            await Assert.That(matchingInvocations).IsEqualTo(1);
+        }
+    }
+
+    /// <summary>Tests that registration callbacks do not fire on unregistration, matching ModernDependencyResolver.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ServiceRegistrationCallback_Generic_DoesNotFireOnUnregister()
+    {
+        var resolver = new InstanceGenericFirstDependencyResolver();
+        resolver.RegisterConstant(new ViewModelOne());
+
+        var invocations = 0;
+        using var subscription = resolver.ServiceRegistrationCallback<ViewModelOne>(_ => invocations++);
+
+        // The single existing registration is replayed once on subscribe; nothing else should fire.
+        var baseline = invocations;
+
+        resolver.UnregisterCurrent<ViewModelOne>();
+        resolver.UnregisterAll<ViewModelOne>();
+
+        await Assert.That(invocations).IsEqualTo(baseline);
+    }
+
+    /// <summary>
+    /// Tests that a nested generic lookup for a not-yet-registered type during another resolution does not
+    /// permanently flag that type as unresolvable (issue #1589 nested-resolution regression).
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task GetService_Generic_WhenMissingDuringNestedResolution_ResolvesAfterLaterRegistration()
+    {
+        var resolver = new InstanceGenericFirstDependencyResolver();
+        resolver.RegisterLazySingleton(() => new NestedResolutionProbe<ViewModelOne>(resolver));
+
+        var probe = resolver.GetService<NestedResolutionProbe<ViewModelOne>>();
+
+        await Assert.That(probe).IsNotNull();
+        await Assert.That(probe!.Service).IsNull();
+
+        var service = new ViewModelOne();
+        resolver.RegisterConstant(service);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.HasRegistration<ViewModelOne>()).IsTrue();
+            await Assert.That(resolver.GetService<ViewModelOne>()).IsSameReferenceAs(service);
+        }
+    }
+
     /// <summary>Test constructor with configure parameter registers services.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]

--- a/src/tests/Splat.Tests/ServiceLocation/ModernDependencyResolverTests.cs
+++ b/src/tests/Splat.Tests/ServiceLocation/ModernDependencyResolverTests.cs
@@ -28,6 +28,80 @@ public sealed class ModernDependencyResolverTests : BaseDependencyResolverTests<
             .Throws<ArgumentNullException>();
     }
 
+    /// <summary>
+    /// Tests that a generic registration callback fires only for registrations of its own service type.
+    /// Serves as the parity baseline for the <c>InstanceGenericFirstDependencyResolver</c> fix (issue #1589).
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ServiceRegistrationCallback_Generic_OnlyFiresForMatchingServiceType()
+    {
+        var resolver = new ModernDependencyResolver();
+        var totalInvocations = 0;
+        var matchingInvocations = 0;
+
+        using var subscription = resolver.ServiceRegistrationCallback<ViewModelOne>(_ =>
+        {
+            totalInvocations++;
+            matchingInvocations += resolver.HasRegistration<ViewModelOne>() ? 1 : 0;
+        });
+
+        resolver.RegisterConstant(new ViewModelTwo());
+        await Assert.That(totalInvocations).IsEqualTo(0);
+
+        resolver.RegisterConstant(new ViewModelOne());
+        using (Assert.Multiple())
+        {
+            await Assert.That(totalInvocations).IsEqualTo(1);
+            await Assert.That(matchingInvocations).IsEqualTo(1);
+        }
+    }
+
+    /// <summary>Tests that registration callbacks do not fire on unregistration.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ServiceRegistrationCallback_Generic_DoesNotFireOnUnregister()
+    {
+        var resolver = new ModernDependencyResolver();
+        resolver.RegisterConstant(new ViewModelOne());
+
+        var invocations = 0;
+        using var subscription = resolver.ServiceRegistrationCallback<ViewModelOne>(_ => invocations++);
+
+        var baseline = invocations;
+
+        resolver.UnregisterCurrent<ViewModelOne>();
+        resolver.UnregisterAll<ViewModelOne>();
+
+        await Assert.That(invocations).IsEqualTo(baseline);
+    }
+
+    /// <summary>
+    /// Tests that a nested generic lookup for a not-yet-registered type during another resolution does not
+    /// permanently flag that type as unresolvable.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task GetService_Generic_WhenMissingDuringNestedResolution_ResolvesAfterLaterRegistration()
+    {
+        var resolver = new ModernDependencyResolver();
+        resolver.RegisterLazySingleton(() => new NestedResolutionProbe<ViewModelOne>(resolver));
+
+        var probe = resolver.GetService<NestedResolutionProbe<ViewModelOne>>();
+
+        await Assert.That(probe).IsNotNull();
+        await Assert.That(probe!.Service).IsNull();
+
+        var service = new ViewModelOne();
+        resolver.RegisterConstant(service);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.HasRegistration<ViewModelOne>()).IsTrue();
+            await Assert.That(resolver.GetService<ViewModelOne>()).IsSameReferenceAs(service);
+        }
+    }
+
     /// <summary>Test ServiceRegistrationCallback invoked once per existing registration.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]

--- a/src/tests/Splat.Tests/ServiceLocation/NestedResolutionProbe.cs
+++ b/src/tests/Splat.Tests/ServiceLocation/NestedResolutionProbe.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Splat.Tests.ServiceLocation;
+
+/// <summary>Captures the result of a nested generic service lookup performed during its own construction.</summary>
+/// <typeparam name="T">The nested service type to resolve.</typeparam>
+/// <param name="resolver">The resolver used to perform the nested lookup.</param>
+internal sealed class NestedResolutionProbe<T>(IDependencyResolver resolver)
+{
+    /// <summary>Gets the service resolved by a nested generic lookup performed during construction.</summary>
+    public T? Service { get; } = resolver.GetService<T>();
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

`InstanceGenericFirstDependencyResolver` now scopes registration callbacks the same way `ModernDependencyResolver` does:

- **Scoped callbacks.** Callbacks are keyed by `(service type, contract)` in a lazily allocated `Dictionary<(Type, string?), ArrayHelpers.Entry<Action<IDisposable>>>`, and only the matching key is invoked when a registration changes. `ServiceRegistrationCallback<T>` no longer fires for unrelated registrations.
- **Register-only notifications.** Callbacks fire on `Register*` paths only, not on `Unregister*`, matching `ModernDependencyResolver`.
- **Allocation/perf friendly.**
  - The registry stays `null` until the first subscription, so resolvers that never use callbacks allocate no callback state.
  - A volatile callback count gives a lock-free, zero-allocation fast exit from the notification path when nothing is subscribed (the common case).
  - Each key reuses the existing lock-free `ArrayHelpers.Entry` snapshot primitive, so callbacks are invoked outside the gate with no per-notification allocation. The per-subscription wrapper closure the old code allocated is gone.

## What is the current behavior?

Closes #1589.

`InstanceGenericFirstDependencyResolver` stored registration callbacks in a single global list and fired *every* callback on *every* registration and unregistration, dropping the `(service type, contract)` scope. As a result `ServiceRegistrationCallback<T>` ran for unrelated registrations and could trigger nested `GetService<T>` lookups before `T` was actually registered — a behavioural regression from `ModernDependencyResolver` when it became the Splat 19 default.

## What might this PR break?

None. Behaviour is brought in line with `ModernDependencyResolver`; callbacks that previously relied on the over-firing (global, fire-on-unregister) behaviour were observing a bug. Public API is unchanged.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Regression tests were added to both the `InstanceGenericFirst` and `Modern` resolver suites:

- `ServiceRegistrationCallback_Generic_OnlyFiresForMatchingServiceType` — an unrelated registration does not fire a `ViewModelOne` callback; the matching one fires exactly once while the service is resolvable.
- `ServiceRegistrationCallback_Generic_DoesNotFireOnUnregister` — unregistration does not invoke callbacks.
- `GetService_Generic_WhenMissingDuringNestedResolution_ResolvesAfterLaterRegistration` — a nested lookup for a not-yet-registered type does not permanently flag it as unresolvable.

Both resolver suites pass locally (InstanceGenericFirst 80/80, Modern 85/85) and the solution builds clean under `-warnaserror`.