### PR TITLE
fix: remove always-false conditions flagged by SonarCloud

### DIFF
--- a/src/Splat.Logging/MemoizingMRUCache.cs
+++ b/src/Splat.Logging/MemoizingMRUCache.cs
@@ -250,7 +250,7 @@ public sealed class MemoizingMRUCache<TParam, TVal>
     [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Aggregates exceptions when requested.")]
     public void InvalidateAll(bool aggregateReleaseExceptions)
     {
-        Dictionary<TParam, (LinkedListNode<TParam> node, TVal value)>? oldEntries = null;
+        Dictionary<TParam, (LinkedListNode<TParam> node, TVal value)> oldEntries;
 
         lock (_gate)
         {
@@ -265,7 +265,7 @@ public sealed class MemoizingMRUCache<TParam, TVal>
             _entries = new(_comparer);
         }
 
-        if (_releaseFunction is null || oldEntries is null)
+        if (_releaseFunction is null)
         {
             return;
         }

--- a/src/Splat.Ninject/NinjectDependencyResolver.cs
+++ b/src/Splat.Ninject/NinjectDependencyResolver.cs
@@ -358,7 +358,7 @@ public class NinjectDependencyResolver(IKernel kernel) : IDependencyResolver
 
         var bindings = kernel.GetBindings(serviceType).ToArray();
 
-        if (bindings is null || bindings.Length < 1)
+        if (bindings.Length < 1)
         {
             return;
         }
@@ -380,7 +380,7 @@ public class NinjectDependencyResolver(IKernel kernel) : IDependencyResolver
 
         var bindings = kernel.GetBindings(serviceType).ToArray();
 
-        if (bindings is null || bindings.Length < 1)
+        if (bindings.Length < 1)
         {
             return;
         }
@@ -410,7 +410,7 @@ public class NinjectDependencyResolver(IKernel kernel) : IDependencyResolver
 
         var bindings = kernel.GetBindings(serviceType).ToArray();
 
-        if (bindings is null || bindings.Length < 1)
+        if (bindings.Length < 1)
         {
             return;
         }
@@ -435,7 +435,7 @@ public class NinjectDependencyResolver(IKernel kernel) : IDependencyResolver
 
         var bindings = kernel.GetBindings(serviceType).ToArray();
 
-        if (bindings is null || bindings.Length < 1)
+        if (bindings.Length < 1)
         {
             return;
         }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / code-smell cleanup (no behavioural change).

## What is the new behavior?

Removes redundant conditions that SonarCloud reports as always evaluating to `False`:

- **`Splat.Logging/MemoizingMRUCache.cs`** (`InvalidateAll`) — `oldEntries` is guaranteed to be assigned on the only path that leaves the lock without returning, so `oldEntries is null` was always false. The local is now declared non-nullable (which also satisfies nullable flow analysis) and the dead disjunct is gone, leaving the meaningful `_releaseFunction is null` guard.
- **`Splat.Ninject/NinjectDependencyResolver.cs`** (`UnregisterCurrent`/`UnregisterAll`, 4 sites) — `kernel.GetBindings(serviceType).ToArray()` never returns null, so `bindings is null` was always false. The guards now check only `bindings.Length < 1`.

## What is the current behavior?

The code carried redundant `x is null` checks that the analyzer flagged as always-false (`MemoizingMRUCache.cs` L268; `NinjectDependencyResolver.cs` L361, L383, L413, L438) — five Major "Code Smell" maintainability issues.

## What might this PR break?

None. Every removed sub-condition was provably unreachable, so behaviour is identical. Public API is unchanged.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [ ] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

No tests added — the changes are behaviour-preserving removals of dead conditions. Existing suites pass (Ninject 83, MemoizingMRUCache 27/27) and both projects build clean under `-warnaserror`.