### PR TITLE
feat(applicationinsights): add v3 package

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,7 +855,8 @@ The table below shows the support across various APM packages
 
 | Product | Package | NuGet | Maturity Level | Error Reporting | Feature Usage Tracking | View Tracking |
 |----|----|----|----|----|----|----|
-| Application Insights | [Splat.ApplicationInsights][SplatApplicationInsightsNuGet] | [![SplatApplicationInsightsBadge]][SplatApplicationInsightsNuGet] | Alpha | TODO | Native | Native |
+| Application Insights v2 | [Splat.ApplicationInsights][SplatApplicationInsightsNuGet] | [![SplatApplicationInsightsBadge]][SplatApplicationInsightsNuGet] | Alpha | TODO | Native | Native |
+| Application Insights v3 | [Splat.ApplicationInsightsV3][SplatApplicationInsightsV3NuGet] | [![SplatApplicationInsightsV3Badge]][SplatApplicationInsightsV3NuGet] | Alpha | TODO | Native | Custom event named `PageView` |
 | Exceptionless | [Splat.Exceptionless][SplatExceptionlessNuGet] | [![SplatExceptionlessBadge]][SplatExceptionlessNuGet] | Alpha | TODO | Native | By Convention |
 | New Relic | N\A | N\A | Not Started | TODO | TODO | TODO
 | OpenTrace | N\A | N\A | Not Started |TODO | TODO | TODO
@@ -863,6 +864,8 @@ The table below shows the support across various APM packages
 
 [SplatApplicationInsightsNuGet]: https://www.nuget.org/packages/Splat.ApplicationInsights/
 [SplatApplicationInsightsBadge]: https://img.shields.io/nuget/v/Splat.ApplicationInsights.svg
+[SplatApplicationInsightsV3NuGet]: https://www.nuget.org/packages/Splat.ApplicationInsightsV3/
+[SplatApplicationInsightsV3Badge]: https://img.shields.io/nuget/v/Splat.ApplicationInsightsV3.svg
 [SplatExceptionlessNuGet]: https://www.nuget.org/packages/Splat.Exceptionless/
 [SplatExceptionlessBadge]: https://img.shields.io/nuget/v/Splat.Exceptionless.svg
 [SplatRaygunNuGet]: https://www.nuget.org/packages/Splat.Raygun/
@@ -959,15 +962,23 @@ as subfeatures.
 
 TODO
 
-#### Configuring Application Insights
+#### Configuring Application Insights v2
 
-First configure Application Insights. For guidance see https://docs.microsoft.com/en-us/azure/azure-monitor/app/worker-service
+First configure Application Insights v2. For guidance see https://docs.microsoft.com/en-us/azure/azure-monitor/app/worker-service
 
 ```cs
 using Splat.ApplicationInsights;
 
 // then in your service locator initialisation
 Locator.CurrentMutable.UseApplicationInsightsApm();
+```
+
+#### Configuring Application Insights v3
+
+The `Splat.ApplicationInsightsV3` package targets the Application Insights v3 SDK. Application Insights v3 removed native `TrackPageView` support, so Splat records view navigation as custom events named `PageView` with the view name in the `Name` property.
+
+```cs
+using Splat.ApplicationInsightsV3;
 ```
 
 #### Configuring Exceptionless

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.ApplicationInsights" Version="2.23.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageVersion Include="OpenTelemetry.Api" Version="1.17.0" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.301" />
     <PackageVersion Include="Mindscape.Raygun4Net.NetCore" Version="11.2.6" />
     <PackageVersion Include="MinVer" Version="7.0.0" />

--- a/src/Splat.ApplicationInsightsV3/ApplicationInsightsFeatureUsageSessionCore.cs
+++ b/src/Splat.ApplicationInsightsV3/ApplicationInsightsFeatureUsageSessionCore.cs
@@ -1,0 +1,75 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.ApplicationInsights;
+
+namespace Splat.ApplicationInsightsV3;
+
+/// <summary>Owns the mutable work of an Application Insights v3 feature usage session.</summary>
+internal sealed class ApplicationInsightsFeatureUsageSessionCore
+{
+    /// <summary>The event name emitted when a session starts.</summary>
+    private const string FeatureUsageStartEventName = "Feature Usage Start";
+
+    /// <summary>The event name emitted when a session ends.</summary>
+    private const string FeatureUsageEndEventName = "Feature Usage End";
+
+    /// <summary>The Application Insights client that receives feature telemetry.</summary>
+    private readonly TelemetryClient _telemetryClient;
+
+    /// <summary>Initializes a new instance of the <see cref="ApplicationInsightsFeatureUsageSessionCore"/> class.</summary>
+    /// <param name="featureName">The Splat feature name.</param>
+    /// <param name="parentReference">The parent feature reference, or <see cref="Guid.Empty"/> for a root session.</param>
+    /// <param name="telemetryClient">The client that receives telemetry.</param>
+    internal ApplicationInsightsFeatureUsageSessionCore(
+        string featureName,
+        Guid parentReference,
+        TelemetryClient telemetryClient)
+    {
+        FeatureName = featureName;
+        FeatureReference = Guid.NewGuid();
+        ParentReference = parentReference;
+        _telemetryClient = telemetryClient;
+
+        TrackEvent(FeatureUsageStartEventName);
+    }
+
+    /// <summary>Gets the current feature session reference.</summary>
+    internal Guid FeatureReference { get; }
+
+    /// <summary>Gets the parent feature session reference.</summary>
+    internal Guid ParentReference { get; }
+
+    /// <summary>Gets the current feature name.</summary>
+    internal string FeatureName { get; }
+
+    /// <summary>Creates a child feature usage session.</summary>
+    /// <param name="description">The child feature name.</param>
+    /// <returns>The child feature usage session core.</returns>
+    internal ApplicationInsightsFeatureUsageSessionCore CreateSubFeature(string description) =>
+        new(description, FeatureReference, _telemetryClient);
+
+    /// <summary>Tracks the end of this feature usage session.</summary>
+    internal void TrackEnd() => TrackEvent(FeatureUsageEndEventName);
+
+    /// <summary>Tracks an exception that occurred during this feature usage session.</summary>
+    /// <param name="exception">The exception captured during the session.</param>
+    internal void TrackException(Exception exception) =>
+        _telemetryClient.TrackException(
+            ApplicationInsightsTelemetryFactory.CreateExceptionTelemetry(
+                exception,
+                FeatureName,
+                FeatureReference,
+                ParentReference));
+
+    /// <summary>Tracks a feature usage event for this session.</summary>
+    /// <param name="eventName">The Application Insights event name.</param>
+    private void TrackEvent(string eventName) =>
+        _telemetryClient.TrackEvent(
+            ApplicationInsightsTelemetryFactory.CreateFeatureUsageEvent(
+                eventName,
+                FeatureName,
+                FeatureReference,
+                ParentReference));
+}

--- a/src/Splat.ApplicationInsightsV3/ApplicationInsightsFeatureUsageTrackingSession.cs
+++ b/src/Splat.ApplicationInsightsV3/ApplicationInsightsFeatureUsageTrackingSession.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for full license information.
 
 using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.DataContracts;
 
 using Splat.ApplicationPerformanceMonitoring;
 
@@ -64,8 +63,11 @@ public sealed class ApplicationInsightsFeatureUsageTrackingSession : IFeatureUsa
     /// <inheritdoc />
     public void OnException(Exception exception)
     {
-        var telemetry = new ExceptionTelemetry(exception);
-        PrepareEventData(telemetry);
+        var telemetry = ApplicationInsightsTelemetryFactory.CreateExceptionTelemetry(
+            exception,
+            FeatureName,
+            FeatureReference,
+            ParentReference);
 
         _telemetryClient.TrackException(telemetry);
     }
@@ -74,26 +76,12 @@ public sealed class ApplicationInsightsFeatureUsageTrackingSession : IFeatureUsa
     /// <param name="eventName">The Application Insights event name.</param>
     private void TrackEvent(string eventName)
     {
-        var eventTelemetry = new EventTelemetry(eventName);
-        PrepareEventData(eventTelemetry);
+        var eventTelemetry = ApplicationInsightsTelemetryFactory.CreateFeatureUsageEvent(
+            eventName,
+            FeatureName,
+            FeatureReference,
+            ParentReference);
 
         _telemetryClient.TrackEvent(eventTelemetry);
-    }
-
-    /// <summary>Adds the session metadata shared by events and exceptions.</summary>
-    /// <typeparam name="TTelemetry">The telemetry shape that carries custom properties.</typeparam>
-    /// <param name="eventTelemetry">The telemetry item being populated.</param>
-    private void PrepareEventData<TTelemetry>(TTelemetry eventTelemetry)
-        where TTelemetry : ISupportProperties
-    {
-        eventTelemetry.Properties.Add("Name", FeatureName);
-        eventTelemetry.Properties.Add("Reference", FeatureReference.ToString());
-
-        if (ParentReference == Guid.Empty)
-        {
-            return;
-        }
-
-        eventTelemetry.Properties.Add("ParentReference", ParentReference.ToString());
     }
 }

--- a/src/Splat.ApplicationInsightsV3/ApplicationInsightsFeatureUsageTrackingSession.cs
+++ b/src/Splat.ApplicationInsightsV3/ApplicationInsightsFeatureUsageTrackingSession.cs
@@ -2,8 +2,6 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using Microsoft.ApplicationInsights;
-
 using Splat.ApplicationPerformanceMonitoring;
 
 namespace Splat.ApplicationInsightsV3;
@@ -11,77 +9,39 @@ namespace Splat.ApplicationInsightsV3;
 /// <summary>Tracks feature usage events and exceptions with the Application Insights v3 client.</summary>
 public sealed class ApplicationInsightsFeatureUsageTrackingSession : IFeatureUsageTrackingSession<Guid>
 {
-    /// <summary>The client used for all feature usage telemetry.</summary>
-    private readonly TelemetryClient _telemetryClient;
+    /// <summary>The session state and telemetry sender.</summary>
+    private readonly ApplicationInsightsFeatureUsageSessionCore _session;
 
     /// <summary>Initializes a new instance of the <see cref="ApplicationInsightsFeatureUsageTrackingSession"/> class.</summary>
     /// <param name="featureName">The feature name stored with each telemetry item.</param>
     /// <param name="telemetryClient">The client that receives telemetry.</param>
     public ApplicationInsightsFeatureUsageTrackingSession(
         string featureName,
-        TelemetryClient telemetryClient)
-        : this(featureName, Guid.Empty, telemetryClient)
+        Microsoft.ApplicationInsights.TelemetryClient telemetryClient)
+        : this(new ApplicationInsightsFeatureUsageSessionCore(featureName, Guid.Empty, telemetryClient))
     {
     }
 
     /// <summary>Initializes a new instance of the <see cref="ApplicationInsightsFeatureUsageTrackingSession"/> class.</summary>
-    /// <param name="featureName">The feature name stored with each telemetry item.</param>
-    /// <param name="parentReference">The parent feature reference, or <see cref="Guid.Empty"/> for root sessions.</param>
-    /// <param name="telemetryClient">The client that receives telemetry.</param>
-    internal ApplicationInsightsFeatureUsageTrackingSession(
-        string featureName,
-        Guid parentReference,
-        TelemetryClient telemetryClient)
-    {
-        _telemetryClient = telemetryClient;
-        FeatureName = featureName;
-        FeatureReference = Guid.NewGuid();
-        ParentReference = parentReference;
-
-        TrackEvent("Feature Usage Start");
-    }
+    /// <param name="session">The session state and telemetry sender.</param>
+    private ApplicationInsightsFeatureUsageTrackingSession(ApplicationInsightsFeatureUsageSessionCore session) => _session = session;
 
     /// <inheritdoc />
-    public Guid FeatureReference { get; }
+    public Guid FeatureReference => _session.FeatureReference;
 
     /// <inheritdoc />
-    public Guid ParentReference { get; }
+    public Guid ParentReference => _session.ParentReference;
 
     /// <inheritdoc />
-    public string FeatureName { get; }
+    public string FeatureName => _session.FeatureName;
 
     /// <inheritdoc />
-    public void Dispose() => TrackEvent("Feature Usage End");
+    public void Dispose() => _session.TrackEnd();
 
     /// <inheritdoc />
     public IFeatureUsageTrackingSession SubFeature(string description) =>
-        new ApplicationInsightsFeatureUsageTrackingSession(
-            description,
-            FeatureReference,
-            _telemetryClient);
+        new ApplicationInsightsFeatureUsageTrackingSession(_session.CreateSubFeature(description));
 
     /// <inheritdoc />
-    public void OnException(Exception exception)
-    {
-        var telemetry = ApplicationInsightsTelemetryFactory.CreateExceptionTelemetry(
-            exception,
-            FeatureName,
-            FeatureReference,
-            ParentReference);
-
-        _telemetryClient.TrackException(telemetry);
-    }
-
-    /// <summary>Sends a feature usage event with the current session metadata.</summary>
-    /// <param name="eventName">The Application Insights event name.</param>
-    private void TrackEvent(string eventName)
-    {
-        var eventTelemetry = ApplicationInsightsTelemetryFactory.CreateFeatureUsageEvent(
-            eventName,
-            FeatureName,
-            FeatureReference,
-            ParentReference);
-
-        _telemetryClient.TrackEvent(eventTelemetry);
-    }
+    public void OnException(Exception exception) => _session.TrackException(exception);
 }

--- a/src/Splat.ApplicationInsightsV3/ApplicationInsightsFeatureUsageTrackingSession.cs
+++ b/src/Splat.ApplicationInsightsV3/ApplicationInsightsFeatureUsageTrackingSession.cs
@@ -1,0 +1,99 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+
+using Splat.ApplicationPerformanceMonitoring;
+
+namespace Splat.ApplicationInsightsV3;
+
+/// <summary>Tracks feature usage events and exceptions with the Application Insights v3 client.</summary>
+public sealed class ApplicationInsightsFeatureUsageTrackingSession : IFeatureUsageTrackingSession<Guid>
+{
+    /// <summary>The client used for all feature usage telemetry.</summary>
+    private readonly TelemetryClient _telemetryClient;
+
+    /// <summary>Initializes a new instance of the <see cref="ApplicationInsightsFeatureUsageTrackingSession"/> class.</summary>
+    /// <param name="featureName">The feature name stored with each telemetry item.</param>
+    /// <param name="telemetryClient">The client that receives telemetry.</param>
+    public ApplicationInsightsFeatureUsageTrackingSession(
+        string featureName,
+        TelemetryClient telemetryClient)
+        : this(featureName, Guid.Empty, telemetryClient)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="ApplicationInsightsFeatureUsageTrackingSession"/> class.</summary>
+    /// <param name="featureName">The feature name stored with each telemetry item.</param>
+    /// <param name="parentReference">The parent feature reference, or <see cref="Guid.Empty"/> for root sessions.</param>
+    /// <param name="telemetryClient">The client that receives telemetry.</param>
+    internal ApplicationInsightsFeatureUsageTrackingSession(
+        string featureName,
+        Guid parentReference,
+        TelemetryClient telemetryClient)
+    {
+        _telemetryClient = telemetryClient;
+        FeatureName = featureName;
+        FeatureReference = Guid.NewGuid();
+        ParentReference = parentReference;
+
+        TrackEvent("Feature Usage Start");
+    }
+
+    /// <inheritdoc />
+    public Guid FeatureReference { get; }
+
+    /// <inheritdoc />
+    public Guid ParentReference { get; }
+
+    /// <inheritdoc />
+    public string FeatureName { get; }
+
+    /// <inheritdoc />
+    public void Dispose() => TrackEvent("Feature Usage End");
+
+    /// <inheritdoc />
+    public IFeatureUsageTrackingSession SubFeature(string description) =>
+        new ApplicationInsightsFeatureUsageTrackingSession(
+            description,
+            FeatureReference,
+            _telemetryClient);
+
+    /// <inheritdoc />
+    public void OnException(Exception exception)
+    {
+        var telemetry = new ExceptionTelemetry(exception);
+        PrepareEventData(telemetry);
+
+        _telemetryClient.TrackException(telemetry);
+    }
+
+    /// <summary>Sends a feature usage event with the current session metadata.</summary>
+    /// <param name="eventName">The Application Insights event name.</param>
+    private void TrackEvent(string eventName)
+    {
+        var eventTelemetry = new EventTelemetry(eventName);
+        PrepareEventData(eventTelemetry);
+
+        _telemetryClient.TrackEvent(eventTelemetry);
+    }
+
+    /// <summary>Adds the session metadata shared by events and exceptions.</summary>
+    /// <typeparam name="TTelemetry">The telemetry shape that carries custom properties.</typeparam>
+    /// <param name="eventTelemetry">The telemetry item being populated.</param>
+    private void PrepareEventData<TTelemetry>(TTelemetry eventTelemetry)
+        where TTelemetry : ISupportProperties
+    {
+        eventTelemetry.Properties.Add("Name", FeatureName);
+        eventTelemetry.Properties.Add("Reference", FeatureReference.ToString());
+
+        if (ParentReference == Guid.Empty)
+        {
+            return;
+        }
+
+        eventTelemetry.Properties.Add("ParentReference", ParentReference.ToString());
+    }
+}

--- a/src/Splat.ApplicationInsightsV3/ApplicationInsightsTelemetryFactory.cs
+++ b/src/Splat.ApplicationInsightsV3/ApplicationInsightsTelemetryFactory.cs
@@ -1,0 +1,94 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.ApplicationInsights.DataContracts;
+
+namespace Splat.ApplicationInsightsV3;
+
+/// <summary>Creates Application Insights v3 telemetry shapes used by the Splat APM adapters.</summary>
+internal static class ApplicationInsightsTelemetryFactory
+{
+    /// <summary>The common property name for view and feature names.</summary>
+    private const string NamePropertyName = "Name";
+
+    /// <summary>The property name for the current feature reference.</summary>
+    private const string ReferencePropertyName = "Reference";
+
+    /// <summary>The property name for the parent feature reference.</summary>
+    private const string ParentReferencePropertyName = "ParentReference";
+
+    /// <summary>The custom event name used for view tracking in Application Insights v3.</summary>
+    private const string PageViewEventName = "PageView";
+
+    /// <summary>Creates the custom event used for view navigation in Application Insights v3.</summary>
+    /// <param name="name">The view name recorded in event properties.</param>
+    /// <returns>The event telemetry to send.</returns>
+    internal static EventTelemetry CreateViewNavigationEvent(string name)
+    {
+        var eventTelemetry = new EventTelemetry(PageViewEventName);
+        eventTelemetry.Properties.Add(NamePropertyName, name);
+
+        return eventTelemetry;
+    }
+
+    /// <summary>Creates a feature usage event with Splat feature metadata.</summary>
+    /// <param name="eventName">The Application Insights event name.</param>
+    /// <param name="featureName">The Splat feature name.</param>
+    /// <param name="featureReference">The feature session reference.</param>
+    /// <param name="parentReference">The parent feature reference, or <see cref="Guid.Empty"/> for root sessions.</param>
+    /// <returns>The event telemetry to send.</returns>
+    internal static EventTelemetry CreateFeatureUsageEvent(
+        string eventName,
+        string featureName,
+        Guid featureReference,
+        Guid parentReference)
+    {
+        var eventTelemetry = new EventTelemetry(eventName);
+        AddFeatureProperties(eventTelemetry, featureName, featureReference, parentReference);
+
+        return eventTelemetry;
+    }
+
+    /// <summary>Creates exception telemetry with Splat feature metadata.</summary>
+    /// <param name="exception">The exception captured during the feature session.</param>
+    /// <param name="featureName">The Splat feature name.</param>
+    /// <param name="featureReference">The feature session reference.</param>
+    /// <param name="parentReference">The parent feature reference, or <see cref="Guid.Empty"/> for root sessions.</param>
+    /// <returns>The exception telemetry to send.</returns>
+    internal static ExceptionTelemetry CreateExceptionTelemetry(
+        Exception exception,
+        string featureName,
+        Guid featureReference,
+        Guid parentReference)
+    {
+        var telemetry = new ExceptionTelemetry(exception);
+        AddFeatureProperties(telemetry, featureName, featureReference, parentReference);
+
+        return telemetry;
+    }
+
+    /// <summary>Adds the metadata shared by feature usage events and exceptions.</summary>
+    /// <typeparam name="TTelemetry">The telemetry shape that carries custom properties.</typeparam>
+    /// <param name="telemetry">The telemetry item being populated.</param>
+    /// <param name="featureName">The Splat feature name.</param>
+    /// <param name="featureReference">The feature session reference.</param>
+    /// <param name="parentReference">The parent feature reference, or <see cref="Guid.Empty"/> for root sessions.</param>
+    private static void AddFeatureProperties<TTelemetry>(
+        TTelemetry telemetry,
+        string featureName,
+        Guid featureReference,
+        Guid parentReference)
+        where TTelemetry : ISupportProperties
+    {
+        telemetry.Properties.Add(NamePropertyName, featureName);
+        telemetry.Properties.Add(ReferencePropertyName, featureReference.ToString());
+
+        if (parentReference == Guid.Empty)
+        {
+            return;
+        }
+
+        telemetry.Properties.Add(ParentReferencePropertyName, parentReference.ToString());
+    }
+}

--- a/src/Splat.ApplicationInsightsV3/ApplicationInsightsViewTracking.cs
+++ b/src/Splat.ApplicationInsightsV3/ApplicationInsightsViewTracking.cs
@@ -16,5 +16,5 @@ public sealed class ApplicationInsightsViewTracking(TelemetryClient telemetryCli
     /// <summary>Tracks a view navigation as a custom <c>PageView</c> event.</summary>
     /// <param name="name">The view name recorded in the event properties.</param>
     public void OnViewNavigation(string name) =>
-        telemetryClient.TrackEvent("PageView", new Dictionary<string, string> { ["Name"] = name });
+        telemetryClient.TrackEvent(ApplicationInsightsTelemetryFactory.CreateViewNavigationEvent(name));
 }

--- a/src/Splat.ApplicationInsightsV3/ApplicationInsightsViewTracking.cs
+++ b/src/Splat.ApplicationInsightsV3/ApplicationInsightsViewTracking.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.ApplicationInsights;
+
+using Splat.ApplicationPerformanceMonitoring;
+
+namespace Splat.ApplicationInsightsV3;
+
+/// <summary>Records view navigation with the Application Insights v3 client.</summary>
+/// <remarks>Application Insights v3 removed native page-view telemetry; navigation is emitted as a custom event named <c>PageView</c>.</remarks>
+/// <param name="telemetryClient">The client that receives telemetry.</param>
+public sealed class ApplicationInsightsViewTracking(TelemetryClient telemetryClient) : IViewTracking
+{
+    /// <summary>Tracks a view navigation as a custom <c>PageView</c> event.</summary>
+    /// <param name="name">The view name recorded in the event properties.</param>
+    public void OnViewNavigation(string name) =>
+        telemetryClient.TrackEvent("PageView", new Dictionary<string, string> { ["Name"] = name });
+}

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net10.0/PublicAPI.Shipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net10.0/PublicAPI.Shipped.txt
@@ -1,1 +1,12 @@
 #nullable enable
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,12 @@
+#nullable enable
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,12 +1,1 @@
 #nullable enable
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net11.0/PublicAPI.Shipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net11.0/PublicAPI.Shipped.txt
@@ -1,1 +1,12 @@
 #nullable enable
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,12 @@
+#nullable enable
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net11.0/PublicAPI.Unshipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net11.0/PublicAPI.Unshipped.txt
@@ -1,12 +1,1 @@
 #nullable enable
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -1,1 +1,12 @@
 #nullable enable
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,0 +1,12 @@
+#nullable enable
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,12 +1,1 @@
 #nullable enable
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net472/PublicAPI.Shipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net472/PublicAPI.Shipped.txt
@@ -1,1 +1,12 @@
 #nullable enable
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,0 +1,12 @@
+#nullable enable
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net472/PublicAPI.Unshipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net472/PublicAPI.Unshipped.txt
@@ -1,12 +1,1 @@
 #nullable enable
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net481/PublicAPI.Shipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net481/PublicAPI.Shipped.txt
@@ -1,1 +1,12 @@
 #nullable enable
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,0 +1,12 @@
+#nullable enable
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net481/PublicAPI.Unshipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net481/PublicAPI.Unshipped.txt
@@ -1,12 +1,1 @@
 #nullable enable
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -1,1 +1,12 @@
 #nullable enable
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,12 @@
+#nullable enable
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,12 +1,1 @@
 #nullable enable
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net9.0/PublicAPI.Shipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net9.0/PublicAPI.Shipped.txt
@@ -1,1 +1,12 @@
 #nullable enable
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,12 @@
+#nullable enable
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
+Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
+Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Splat.ApplicationInsightsV3/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,12 +1,1 @@
 #nullable enable
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ApplicationInsightsFeatureUsageTrackingSession(string! featureName, Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.Dispose() -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureName.get -> string!
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.FeatureReference.get -> System.Guid
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.OnException(System.Exception! exception) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.ParentReference.get -> System.Guid
-Splat.ApplicationInsightsV3.ApplicationInsightsFeatureUsageTrackingSession.SubFeature(string! description) -> Splat.ApplicationPerformanceMonitoring.IFeatureUsageTrackingSession!
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.ApplicationInsightsViewTracking(Microsoft.ApplicationInsights.TelemetryClient! telemetryClient) -> void
-Splat.ApplicationInsightsV3.ApplicationInsightsViewTracking.OnViewNavigation(string! name) -> void

--- a/src/Splat.ApplicationInsightsV3/Splat.ApplicationInsightsV3.csproj
+++ b/src/Splat.ApplicationInsightsV3/Splat.ApplicationInsightsV3.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(SplatCoreTargets)</TargetFrameworks>
+    <AssemblyName>Splat.ApplicationInsightsV3</AssemblyName>
+    <RootNamespace>Splat</RootNamespace>
+    <Authors>.NET Foundation and Contributors</Authors>
+    <Description>Application Insights v3 integrations for Splat</Description>
+    <PackageId>Splat.ApplicationInsightsV3</PackageId>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights" VersionOverride="3.1.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Splat\Splat.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Splat.ApplicationInsightsV3/Splat.ApplicationInsightsV3.csproj
+++ b/src/Splat.ApplicationInsightsV3/Splat.ApplicationInsightsV3.csproj
@@ -8,6 +8,9 @@
     <PackageId>Splat.ApplicationInsightsV3</PackageId>
   </PropertyGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="Splat.ApplicationInsightsV3.Tests" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights" VersionOverride="3.1.2" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Splat.slnx
+++ b/src/Splat.slnx
@@ -29,6 +29,7 @@
   </Folder>
   <Folder Name="/Other/">
     <Project Path="Splat.ApplicationInsights/Splat.ApplicationInsights.csproj" />
+    <Project Path="Splat.ApplicationInsightsV3/Splat.ApplicationInsightsV3.csproj" />
     <Project Path="Splat.Exceptionless/Splat.Exceptionless.csproj" />
     <Project Path="Splat.Raygun/Splat.Raygun.csproj" />
   </Folder>
@@ -57,6 +58,7 @@
   </Folder>
   <Folder Name="/test/PerformanceMonitoring/">
     <Project Path="tests/Splat.ApplicationInsights.Tests/Splat.ApplicationInsights.Tests.csproj" />
+    <Project Path="tests/Splat.ApplicationInsightsV3.Tests/Splat.ApplicationInsightsV3.Tests.csproj" />
     <Project Path="tests/Splat.Raygun.Tests/Splat.Raygun.Tests.csproj" />
   </Folder>
   <Folder Name="/_Solution Items/">

--- a/src/tests/Splat.ApplicationInsightsV3.Tests/ApplicationInsightsFeatureUsageTrackingSessionTests.cs
+++ b/src/tests/Splat.ApplicationInsightsV3.Tests/ApplicationInsightsFeatureUsageTrackingSessionTests.cs
@@ -1,0 +1,102 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
+
+using Splat.ApplicationInsightsV3;
+
+namespace Splat.Tests.ApplicationPerformanceMonitoring;
+
+/// <summary>Tests the Application Insights v3 feature usage adapter.</summary>
+public static class ApplicationInsightsFeatureUsageTrackingSessionTests
+{
+    /// <inheritdoc />
+    [InheritsTests]
+    public sealed class ConstructorTests : BaseFeatureUsageTrackingTests.BaseConstructorTests<ApplicationInsightsFeatureUsageTrackingSession>
+    {
+        /// <inheritdoc />
+        protected override ApplicationInsightsFeatureUsageTrackingSession GetFeatureUsageTrackingSession(string featureName)
+        {
+            var telemetryConfiguration = new TelemetryConfiguration
+            {
+                ConnectionString = $"InstrumentationKey={Guid.NewGuid()}",
+                DisableTelemetry = true,
+            };
+            var telemetryClient = new TelemetryClient(telemetryConfiguration);
+
+            return new(featureName, telemetryClient);
+        }
+    }
+
+    /// <inheritdoc />
+    [InheritsTests]
+    public sealed class SubFeatureMethodTests : BaseFeatureUsageTrackingTests.BaseSubFeatureMethodTests<ApplicationInsightsFeatureUsageTrackingSession>
+    {
+        /// <inheritdoc />
+        protected override ApplicationInsightsFeatureUsageTrackingSession GetFeatureUsageTrackingSession(string featureName)
+        {
+            var telemetryConfiguration = new TelemetryConfiguration
+            {
+                ConnectionString = $"InstrumentationKey={Guid.NewGuid()}",
+                DisableTelemetry = true,
+            };
+            var telemetryClient = new TelemetryClient(telemetryConfiguration);
+
+            return new(featureName, telemetryClient);
+        }
+    }
+
+    /// <summary>Verifies the v3 feature usage call paths.</summary>
+    public sealed class TelemetryEmissionTests
+    {
+        /// <summary>Verifies that constructing a session is accepted by the v3 SDK.</summary>
+        /// <returns>A task representing the asynchronous test.</returns>
+        [Test]
+        public async Task Constructor_WithFeatureName_DoesNotThrow()
+        {
+            var client = CreateClient();
+            var featureName = Guid.NewGuid().ToString();
+
+            await Assert.That(() => new ApplicationInsightsFeatureUsageTrackingSession(featureName, client).Dispose()).ThrowsNothing();
+        }
+
+        /// <summary>Verifies that disposing a session is accepted by the v3 SDK.</summary>
+        /// <returns>A task representing the asynchronous test.</returns>
+        [Test]
+        public async Task Dispose_WithStartedSession_DoesNotThrow()
+        {
+            var client = CreateClient();
+            var session = new ApplicationInsightsFeatureUsageTrackingSession(Guid.NewGuid().ToString(), client);
+
+            await Assert.That(session.Dispose).ThrowsNothing();
+        }
+
+        /// <summary>Verifies that exception tracking is accepted by the v3 SDK.</summary>
+        /// <returns>A task representing the asynchronous test.</returns>
+        [Test]
+        public async Task OnException_WithException_DoesNotThrow()
+        {
+            var client = CreateClient();
+            var featureName = Guid.NewGuid().ToString();
+            using var session = new ApplicationInsightsFeatureUsageTrackingSession(featureName, client);
+            var exception = new InvalidOperationException("boom");
+
+            await Assert.That(() => session.OnException(exception)).ThrowsNothing();
+        }
+
+        /// <summary>Creates a disabled v3 client with the required connection string.</summary>
+        /// <returns>The configured telemetry client.</returns>
+        private static TelemetryClient CreateClient()
+        {
+            var telemetryConfiguration = new TelemetryConfiguration
+            {
+                ConnectionString = $"InstrumentationKey={Guid.NewGuid()}",
+                DisableTelemetry = true,
+            };
+
+            return new(telemetryConfiguration);
+        }
+    }
+}

--- a/src/tests/Splat.ApplicationInsightsV3.Tests/ApplicationInsightsTelemetryFactoryTests.cs
+++ b/src/tests/Splat.ApplicationInsightsV3.Tests/ApplicationInsightsTelemetryFactoryTests.cs
@@ -1,0 +1,103 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Splat.ApplicationInsightsV3;
+
+namespace Splat.Tests.ApplicationPerformanceMonitoring;
+
+/// <summary>Tests the shared Application Insights v3 telemetry factory.</summary>
+public sealed class ApplicationInsightsTelemetryFactoryTests
+{
+    /// <summary>The common property name for view and feature names.</summary>
+    private const string NamePropertyName = "Name";
+
+    /// <summary>The property name for the current feature reference.</summary>
+    private const string ReferencePropertyName = "Reference";
+
+    /// <summary>The property name for the parent feature reference.</summary>
+    private const string ParentReferencePropertyName = "ParentReference";
+
+    /// <summary>The feature name shared by root and exception telemetry tests.</summary>
+    private const string SearchFeatureName = "Search";
+
+    /// <summary>Verifies that view navigation telemetry uses the documented custom PageView event shape.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CreateViewNavigationEvent_WithName_ReturnsPageViewEvent()
+    {
+        var telemetry = ApplicationInsightsTelemetryFactory.CreateViewNavigationEvent("Home");
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(telemetry.Name).IsEqualTo("PageView");
+            await Assert.That(telemetry.Properties[NamePropertyName]).IsEqualTo("Home");
+        }
+    }
+
+    /// <summary>Verifies that root feature events include feature metadata without a parent reference.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CreateFeatureUsageEvent_WithRootFeature_ReturnsEventWithoutParentReference()
+    {
+        var featureReference = Guid.NewGuid();
+
+        var telemetry = ApplicationInsightsTelemetryFactory.CreateFeatureUsageEvent(
+            "Feature Usage Start",
+            SearchFeatureName,
+            featureReference,
+            Guid.Empty);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(telemetry.Name).IsEqualTo("Feature Usage Start");
+            await Assert.That(telemetry.Properties[NamePropertyName]).IsEqualTo(SearchFeatureName);
+            await Assert.That(telemetry.Properties[ReferencePropertyName]).IsEqualTo(featureReference.ToString());
+            await Assert.That(telemetry.Properties.ContainsKey(ParentReferencePropertyName)).IsFalse();
+        }
+    }
+
+    /// <summary>Verifies that child feature events include the parent feature reference.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CreateFeatureUsageEvent_WithChildFeature_ReturnsEventWithParentReference()
+    {
+        var featureReference = Guid.NewGuid();
+        var parentReference = Guid.NewGuid();
+
+        var telemetry = ApplicationInsightsTelemetryFactory.CreateFeatureUsageEvent(
+            "Feature Usage End",
+            "Filter",
+            featureReference,
+            parentReference);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(telemetry.Properties[NamePropertyName]).IsEqualTo("Filter");
+            await Assert.That(telemetry.Properties[ReferencePropertyName]).IsEqualTo(featureReference.ToString());
+            await Assert.That(telemetry.Properties[ParentReferencePropertyName]).IsEqualTo(parentReference.ToString());
+        }
+    }
+
+    /// <summary>Verifies that exception telemetry carries the exception and feature metadata.</summary>
+    /// <returns>A task representing the asynchronous test.</returns>
+    [Test]
+    public async Task CreateExceptionTelemetry_WithException_ReturnsExceptionTelemetryWithFeatureMetadata()
+    {
+        var exception = new InvalidOperationException("boom");
+        var featureReference = Guid.NewGuid();
+
+        var telemetry = ApplicationInsightsTelemetryFactory.CreateExceptionTelemetry(
+            exception,
+            SearchFeatureName,
+            featureReference,
+            Guid.Empty);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(telemetry.Exception).IsSameReferenceAs(exception);
+            await Assert.That(telemetry.Properties[NamePropertyName]).IsEqualTo(SearchFeatureName);
+            await Assert.That(telemetry.Properties[ReferencePropertyName]).IsEqualTo(featureReference.ToString());
+        }
+    }
+}

--- a/src/tests/Splat.ApplicationInsightsV3.Tests/ApplicationInsightsViewTrackingTests.cs
+++ b/src/tests/Splat.ApplicationInsightsV3.Tests/ApplicationInsightsViewTrackingTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
+
+using Splat.ApplicationInsightsV3;
+
+namespace Splat.Tests.ApplicationPerformanceMonitoring;
+
+/// <summary>Tests the Application Insights v3 view tracking adapter.</summary>
+public static class ApplicationInsightsViewTrackingTests
+{
+    /// <inheritdoc />
+    [InheritsTests]
+    public sealed class ConstructorMethod : BaseViewTrackingTests.ConstructorMethod<ApplicationInsightsViewTracking>
+    {
+        /// <inheritdoc />
+        protected override ApplicationInsightsViewTracking GetViewTracking()
+        {
+            var telemetryConfiguration = new TelemetryConfiguration
+            {
+                ConnectionString = $"InstrumentationKey={Guid.NewGuid()}",
+                DisableTelemetry = true,
+            };
+            var telemetryClient = new TelemetryClient(telemetryConfiguration);
+
+            return new(telemetryClient);
+        }
+    }
+
+    /// <summary>Verifies the v3 view tracking call path.</summary>
+    public sealed class NavigationTests
+    {
+        /// <summary>Verifies that navigating by name is accepted by the v3 SDK.</summary>
+        /// <returns>A task representing the asynchronous test.</returns>
+        [Test]
+        public async Task OnViewNavigation_WithName_DoesNotThrow()
+        {
+            var client = CreateClient();
+            var viewTracking = new ApplicationInsightsViewTracking(client);
+
+            await Assert.That(() => viewTracking.OnViewNavigation("Home")).ThrowsNothing();
+        }
+
+        /// <summary>Creates a disabled v3 client with the required connection string.</summary>
+        /// <returns>The configured telemetry client.</returns>
+        private static TelemetryClient CreateClient()
+        {
+            var telemetryConfiguration = new TelemetryConfiguration
+            {
+                ConnectionString = $"InstrumentationKey={Guid.NewGuid()}",
+                DisableTelemetry = true,
+            };
+
+            return new(telemetryConfiguration);
+        }
+    }
+}

--- a/src/tests/Splat.ApplicationInsightsV3.Tests/Splat.ApplicationInsightsV3.Tests.csproj
+++ b/src/tests/Splat.ApplicationInsightsV3.Tests/Splat.ApplicationInsightsV3.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(SplatModernTargets)</TargetFrameworks>
+
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Splat.Tests\ApplicationPerformanceMonitoring\BaseFeatureUsageTrackingTests.cs" Link="BaseTests\BaseFeatureUsageTrackingTests.cs" />
+    <Compile Include="..\Splat.Tests\ApplicationPerformanceMonitoring\BaseViewTrackingTests.cs" Link="BaseTests\BaseViewTrackingTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights" VersionOverride="3.1.2" />
+    <ProjectReference Include="..\..\Splat.ApplicationInsightsV3\Splat.ApplicationInsightsV3.csproj" />
+    <ProjectReference Include="..\Splat.Common.Test\Splat.Common.Test.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## What kind of change does this PR introduce?

feat

## What is the new behavior?

- Consumers can choose `Splat.ApplicationInsights` for the Application Insights v2 SDK or `Splat.ApplicationInsightsV3` for the Application Insights v3 SDK.
- Existing consumers keep native page-view telemetry by staying on `Splat.ApplicationInsights`; that package remains on the v2 SDK.
- New v3 consumers reference `Splat.ApplicationInsightsV3` and use the v3-prefixed namespace:

```csharp
using Splat.ApplicationInsightsV3;
```

- `ApplicationInsightsViewTracking` in the v3 package records view navigation as custom events named `PageView` with the view name in the `Name` property.
- `ApplicationInsightsFeatureUsageTrackingSession` is available in the v3 package for feature start/end events and exception tracking through the existing Splat APM contracts.

## What is the current behavior?

- `Splat.ApplicationInsights` is the only Application Insights package and is pinned to the v2 SDK.
- Moving that package directly to v3 would remove native `TrackPageView` support from consumers because Application Insights v3 removed that API.
- Related to #1505.

## What might this PR break?

None. The v3 support is opt-in through a new package, and the existing v2 package remains unchanged.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

- `Splat.ApplicationInsightsV3` uses `Microsoft.ApplicationInsights` 3.1.2.
- `OpenTelemetry.Api` is pinned to 1.17.0 to avoid vulnerable transitive versions from the v3 SDK dependency graph.
- The v3 public API entries are in shipped baselines for all target frameworks.
- Verified locally with `dotnet build Splat.slnx -c Release`, `dotnet test --solution Splat.slnx -c Release`, and the v3 test project after moving the new APIs to shipped.
