### PR TITLE
fix(simpleinjector): key registrations by contract and stop dropping Register

### DIFF
--- a/src/Splat.SimpleInjector/ContractRegistrations.cs
+++ b/src/Splat.SimpleInjector/ContractRegistrations.cs
@@ -1,0 +1,139 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Splat.SimpleInjector;
+
+/// <summary>Holds the service factories that were registered against a contract, keyed by service type and contract.</summary>
+/// <remarks>
+/// Simple Injector deliberately offers no named or keyed registrations, so a contract cannot be expressed inside the
+/// container itself. Contract registrations are therefore held in this table beside the container and resolved from
+/// it. Keeping them out of the container is what stops two implementations registered under different contracts from
+/// silently overwriting one another, and what keeps a contract registration invisible to a contract-less lookup.
+/// </remarks>
+internal sealed class ContractRegistrations
+{
+    /// <summary>Serializes access to <see cref="_factories"/>.</summary>
+    private readonly Lock _lockObject = new();
+
+    /// <summary>The registered factories, keyed by service type and contract, held in registration order.</summary>
+    private readonly Dictionary<(Type ServiceType, string Contract), List<Func<object?>>> _factories = [];
+
+    /// <summary>Records a factory against the supplied service type and contract.</summary>
+    /// <param name="serviceType">The service type the factory produces.</param>
+    /// <param name="contract">The contract the registration is keyed by.</param>
+    /// <param name="factory">The factory that produces the service.</param>
+    internal void Add(Type serviceType, string contract, Func<object?> factory)
+    {
+        lock (_lockObject)
+        {
+#if NET6_0_OR_GREATER
+            ref var registered = ref System.Runtime.InteropServices.CollectionsMarshal.GetValueRefOrAddDefault(_factories, (serviceType, contract), out _);
+            registered ??= [];
+#else
+            if (!_factories.TryGetValue((serviceType, contract), out var registered))
+            {
+                registered = [];
+                _factories.Add((serviceType, contract), registered);
+            }
+#endif
+
+            registered.Add(factory);
+        }
+    }
+
+    /// <summary>Determines whether anything is registered for the supplied service type and contract.</summary>
+    /// <param name="serviceType">The service type to look for.</param>
+    /// <param name="contract">The contract to look for.</param>
+    /// <returns><see langword="true"/> when at least one factory is registered; otherwise <see langword="false"/>.</returns>
+    internal bool Contains(Type serviceType, string contract)
+    {
+        lock (_lockObject)
+        {
+            return _factories.TryGetValue((serviceType, contract), out var registered) && registered.Count > 0;
+        }
+    }
+
+    /// <summary>Resolves the most recently registered factory for the supplied service type and contract.</summary>
+    /// <param name="serviceType">The service type to resolve.</param>
+    /// <param name="contract">The contract to resolve under.</param>
+    /// <returns>The produced service, or <see langword="null"/> when nothing is registered under that contract.</returns>
+    internal object? ResolveLast(Type serviceType, string contract)
+    {
+        var factories = Snapshot(serviceType, contract);
+
+        return factories.Length == 0 ? null : factories[^1]();
+    }
+
+    /// <summary>Resolves every factory registered for the supplied service type and contract, in registration order.</summary>
+    /// <param name="serviceType">The service type to resolve.</param>
+    /// <param name="contract">The contract to resolve under.</param>
+    /// <returns>The produced services; empty when nothing is registered under that contract.</returns>
+    internal IEnumerable<object> ResolveAll(Type serviceType, string contract)
+    {
+        var factories = Snapshot(serviceType, contract);
+        if (factories.Length == 0)
+        {
+            return [];
+        }
+
+        var services = new List<object>(factories.Length);
+        foreach (var factory in factories)
+        {
+            var service = factory();
+            if (service is not null)
+            {
+                services.Add(service);
+            }
+        }
+
+        return services;
+    }
+
+    /// <summary>Removes every factory registered for the supplied service type and contract.</summary>
+    /// <param name="serviceType">The service type to remove registrations for.</param>
+    /// <param name="contract">The contract to remove registrations for.</param>
+    internal void RemoveAll(Type serviceType, string contract)
+    {
+        lock (_lockObject)
+        {
+            _ = _factories.Remove((serviceType, contract));
+        }
+    }
+
+    /// <summary>Copies every registration held here into <paramref name="destination"/>, preserving registration order.</summary>
+    /// <param name="destination">The table the registrations are copied into.</param>
+    internal void CopyTo(ContractRegistrations destination)
+    {
+        List<(Type ServiceType, string Contract, Func<object?> Factory)> snapshot;
+
+        lock (_lockObject)
+        {
+            snapshot = new(_factories.Count);
+            foreach (var entry in _factories)
+            {
+                foreach (var factory in entry.Value)
+                {
+                    snapshot.Add((entry.Key.ServiceType, entry.Key.Contract, factory));
+                }
+            }
+        }
+
+        foreach (var (serviceType, contract, factory) in snapshot)
+        {
+            destination.Add(serviceType, contract, factory);
+        }
+    }
+
+    /// <summary>Takes a point-in-time copy of the factories for a key so they can be invoked outside the lock.</summary>
+    /// <param name="serviceType">The service type to snapshot.</param>
+    /// <param name="contract">The contract to snapshot.</param>
+    /// <returns>The registered factories, or an empty array when the key is unknown.</returns>
+    private Func<object?>[] Snapshot(Type serviceType, string contract)
+    {
+        lock (_lockObject)
+        {
+            return _factories.TryGetValue((serviceType, contract), out var registered) ? [.. registered] : [];
+        }
+    }
+}

--- a/src/Splat.SimpleInjector/README.md
+++ b/src/Splat.SimpleInjector/README.md
@@ -41,3 +41,27 @@ container.Options.AllowOverridingRegistrations = true;
 container.Register<IViewLocator, MyCustomViewLocator>();
 
 ```
+
+### Contracts
+
+SimpleInjector deliberately has no named or keyed registrations, so Splat keeps contract registrations beside the
+container rather than inside it. A contract registration is only ever returned to a caller asking for the same
+contract, and a contract-less lookup never sees it:
+
+```cs
+AppLocator.CurrentMutable.Register<IViewLocator>(() => new PhoneViewLocator(), "phone");
+AppLocator.CurrentMutable.Register<IViewLocator>(() => new TabletViewLocator(), "tablet");
+
+AppLocator.Current.GetService<IViewLocator>("phone");  // PhoneViewLocator
+AppLocator.Current.GetService<IViewLocator>();         // null - neither contract answers this
+```
+
+Because contract registrations live outside the container, SimpleInjector cannot inject them into a constructor.
+Resolve them through Splat.
+
+### Registering after the container is wired up
+
+Contract-less registrations go straight into the container, so they are injectable by SimpleInjector. SimpleInjector
+locks its container on the first resolution, so register everything - through `SimpleInjectorInitializer` or against
+the container - before resolving anything. A registration attempted after the first resolution fails with
+SimpleInjector's own exception rather than being silently dropped.

--- a/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
+++ b/src/Splat.SimpleInjector/SimpleInjectorDependencyResolver.cs
@@ -12,12 +12,29 @@ namespace Splat.SimpleInjector;
 /// Provides an implementation of the IDependencyResolver interface using a SimpleInjector container for dependency
 /// resolution.
 /// </summary>
-/// <remarks>This resolver adapts a SimpleInjector Container to the IDependencyResolver abstraction, enabling
-/// integration with frameworks or components that expect this interface. Contract-based resolution is not natively
-/// supported by SimpleInjector; contract parameters are ignored and treated as standard resolution requests. Service
-/// unregistration and registration callbacks are not supported, as SimpleInjector does not provide mechanisms for
-/// removing registrations or observing registration events after initial configuration. The resolver manages the
-/// lifetime of the underlying container and disposes it when the resolver is disposed.</remarks>
+/// <remarks>
+/// <para>
+/// This resolver adapts a SimpleInjector Container to the IDependencyResolver abstraction, enabling integration with
+/// frameworks or components that expect this interface.
+/// </para>
+/// <para>
+/// SimpleInjector has no keyed registrations, so a contract cannot be expressed inside the container. Contract
+/// registrations are held beside the container instead and are only ever returned to a caller asking for the same
+/// contract; a contract-less lookup never sees them, and two implementations registered under different contracts
+/// stay distinct.
+/// </para>
+/// <para>
+/// Registration goes straight into the container, so anything registered here is also injectable by SimpleInjector.
+/// SimpleInjector locks its container on the first resolution, so a registration attempted after the first service
+/// has been resolved fails with SimpleInjector's own exception. Register everything up front - through
+/// <see cref="SimpleInjectorInitializer"/> or against the container - before resolving.
+/// </para>
+/// <para>
+/// Service unregistration and registration callbacks are not supported, as SimpleInjector does not provide mechanisms
+/// for removing registrations or observing registration events after initial configuration. The resolver manages the
+/// lifetime of the underlying container and disposes it when the resolver is disposed.
+/// </para>
+/// </remarks>
 [SuppressMessage(
     "StyleSharp",
     "SST2307:A generic method's type parameter appears in no parameter, so no caller can infer it",
@@ -26,6 +43,18 @@ public class SimpleInjectorDependencyResolver : IDependencyResolver
 {
     /// <summary>The underlying SimpleInjector container used for registration and resolution.</summary>
     private readonly Container _container;
+
+    /// <summary>The factories registered against a contract, which SimpleInjector itself cannot express.</summary>
+    private readonly ContractRegistrations _contractFactories = new();
+
+    /// <summary>Serializes access to <see cref="_collectionServiceTypes"/>.</summary>
+    private readonly Lock _lockObject = new();
+
+    /// <summary>The service types this resolver has added factories to the container's collection for.</summary>
+    /// <remarks>SimpleInjector does not report a collection registration from <c>GetCurrentRegistrations</c> until
+    /// the container has been locked, so these are tracked here to keep <see cref="HasRegistration(Type)"/> honest
+    /// before the first resolution.</remarks>
+    private readonly HashSet<Type> _collectionServiceTypes = [];
 
     /// <summary>Initializes a new instance of the <see cref="SimpleInjectorDependencyResolver"/> class.</summary>
     /// <param name="container">The container.</param>
@@ -67,15 +96,25 @@ public class SimpleInjectorDependencyResolver : IDependencyResolver
 
     /// <inheritdoc />
     public object? GetService(Type? serviceType, string? contract) =>
-        GetService(serviceType); // SimpleInjector doesn't natively support contracts, so we treat contract-based calls the same as non-contract
+        contract is null
+            ? GetService(serviceType)
+            : _contractFactories.ResolveLast(serviceType ?? NullServiceType.CachedType, contract);
 
     /// <inheritdoc/>
     public T? GetService<T>() =>
         (T?)GetService(typeof(T)); // SimpleInjector's generic methods require class constraint, so we always use the non-generic version
 
     /// <inheritdoc/>
-    public T? GetService<T>(string? contract) =>
-        (T?)GetService(typeof(T), contract); // SimpleInjector's generic methods require class constraint, so we always use the non-generic version
+    public T? GetService<T>(string? contract)
+    {
+        if (contract is null)
+        {
+            return GetService<T>();
+        }
+
+        var service = _contractFactories.ResolveLast(typeof(T), contract);
+        return service is null ? default : (T?)service;
+    }
 
     /// <inheritdoc />
     public IEnumerable<object> GetServices(Type? serviceType)
@@ -98,7 +137,9 @@ public class SimpleInjectorDependencyResolver : IDependencyResolver
 
     /// <inheritdoc />
     public IEnumerable<object> GetServices(Type? serviceType, string? contract) =>
-        GetServices(serviceType); // SimpleInjector doesn't natively support contracts, so we treat contract-based calls the same as non-contract
+        contract is null
+            ? GetServices(serviceType)
+            : _contractFactories.ResolveAll(serviceType ?? NullServiceType.CachedType, contract);
 
     /// <inheritdoc/>
     /// <remarks>SimpleInjector's generic methods require a class constraint, so the non-generic overload does the work.</remarks>
@@ -125,12 +166,22 @@ public class SimpleInjectorDependencyResolver : IDependencyResolver
     {
         serviceType ??= NullServiceType.CachedType;
 
+        lock (_lockObject)
+        {
+            if (_collectionServiceTypes.Contains(serviceType))
+            {
+                return true;
+            }
+        }
+
         return Array.Exists(_container.GetCurrentRegistrations(), x => x.ServiceType == serviceType);
     }
 
     /// <inheritdoc />
     public bool HasRegistration(Type? serviceType, string? contract) =>
-        HasRegistration(serviceType); // SimpleInjector doesn't natively support contracts, so we treat contract-based calls the same as non-contract
+        contract is null
+            ? HasRegistration(serviceType)
+            : _contractFactories.Contains(serviceType ?? NullServiceType.CachedType, contract);
 
     /// <inheritdoc/>
     public bool HasRegistration<T>() =>
@@ -138,29 +189,65 @@ public class SimpleInjectorDependencyResolver : IDependencyResolver
 
     /// <inheritdoc/>
     public bool HasRegistration<T>(string? contract) =>
-        HasRegistration(typeof(T), contract);
+        contract is null ? HasRegistration<T>() : _contractFactories.Contains(typeof(T), contract);
 
     /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">The container has already resolved a service and can no longer be changed.</exception>
     public void Register(Func<object?> factory, Type? serviceType)
     {
-        // The function does nothing because there should be no registration called on this object.
-        // Anyway, AppLocator.SetLocator performs some unnecessary registrations.
+        ArgumentExceptionHelper.ThrowIfNull(factory);
+
+        var isNull = serviceType is null;
+        serviceType ??= NullServiceType.CachedType;
+
+        AppendToCollection(
+            serviceType,
+            isNull
+                ? () => new NullServiceType(factory)
+                : factory);
     }
 
     /// <inheritdoc />
     public void Register(Func<object?> factory, Type? serviceType, string? contract)
     {
-        // The function does nothing because there should be no registration called on this object.
-        // Anyway, AppLocator.SetLocator performs some unnecessary registrations.
+        if (contract is null)
+        {
+            Register(factory, serviceType);
+            return;
+        }
+
+        ArgumentExceptionHelper.ThrowIfNull(factory);
+
+        var isNull = serviceType is null;
+
+        _contractFactories.Add(
+            serviceType ?? NullServiceType.CachedType,
+            contract,
+            () => isNull ? new NullServiceType(factory) : factory());
     }
 
     /// <inheritdoc/>
-    public void Register<T>(Func<T?> factory) =>
-        Register(() => factory(), typeof(T)); // SimpleInjector's generic methods require class constraint, so we always use the non-generic version
+    public void Register<T>(Func<T?> factory)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(factory);
+
+        // SimpleInjector's generic methods require class constraint, so we always use the non-generic version
+        Register(() => factory(), typeof(T));
+    }
 
     /// <inheritdoc/>
-    public void Register<T>(Func<T?> factory, string? contract) =>
-        Register(() => factory(), typeof(T), contract); // SimpleInjector's generic methods require class constraint, so we always use the non-generic version
+    public void Register<T>(Func<T?> factory, string? contract)
+    {
+        if (contract is null)
+        {
+            Register(factory);
+            return;
+        }
+
+        ArgumentExceptionHelper.ThrowIfNull(factory);
+
+        _contractFactories.Add(typeof(T), contract, () => factory());
+    }
 
     /// <inheritdoc/>
     public void Register<TService, TImplementation>()
@@ -171,8 +258,16 @@ public class SimpleInjectorDependencyResolver : IDependencyResolver
     /// <inheritdoc/>
     public void Register<TService, TImplementation>(string? contract)
         where TService : class
-        where TImplementation : class, TService, new() =>
-        Register(static () => (TService)new TImplementation(), contract);
+        where TImplementation : class, TService, new()
+    {
+        if (contract is null)
+        {
+            Register<TService, TImplementation>();
+            return;
+        }
+
+        _contractFactories.Add(typeof(TService), contract, static () => new TImplementation());
+    }
 
     /// <inheritdoc />
     public void UnregisterCurrent(Type? serviceType) =>
@@ -184,7 +279,7 @@ public class SimpleInjectorDependencyResolver : IDependencyResolver
     public void UnregisterCurrent(Type? serviceType, string? contract) =>
         throw new NotSupportedException(
             "UnregisterCurrent with contract is not supported in the SimpleInjector dependency resolver. "
-            + "SimpleInjector does not support contracts or removing individual registrations after they have been added.");
+            + "SimpleInjector does not support removing individual registrations after they have been added.");
 
     /// <inheritdoc/>
     public void UnregisterCurrent<T>() =>
@@ -204,7 +299,7 @@ public class SimpleInjectorDependencyResolver : IDependencyResolver
     public void UnregisterAll(Type? serviceType, string? contract) =>
         throw new NotSupportedException(
             "UnregisterAll with contract is not supported in the SimpleInjector dependency resolver. "
-            + "SimpleInjector does not support contracts or removing registrations after they have been added.");
+            + "SimpleInjector does not support removing registrations after they have been added.");
 
     /// <inheritdoc/>
     public void UnregisterAll<T>() =>
@@ -224,7 +319,7 @@ public class SimpleInjectorDependencyResolver : IDependencyResolver
     public IDisposable ServiceRegistrationCallback(Type serviceType, string? contract, Action<IDisposable> callback) =>
         throw new NotSupportedException(
             "ServiceRegistrationCallback with contract is not supported in the SimpleInjector dependency resolver. "
-            + "SimpleInjector does not support contracts or service registration callbacks.");
+            + "SimpleInjector does not provide a mechanism for service registration callbacks.");
 
     /// <inheritdoc/>
     public IDisposable ServiceRegistrationCallback<T>(Action<IDisposable> callback) =>
@@ -247,9 +342,15 @@ public class SimpleInjectorDependencyResolver : IDependencyResolver
     public void RegisterConstant<T>(T? value, string? contract)
         where T : class
     {
+        if (contract is null)
+        {
+            RegisterConstant(value);
+            return;
+        }
+
         ArgumentExceptionHelper.ThrowIfNull(value);
 
-        Register(() => value, typeof(T), contract);
+        _contractFactories.Add(typeof(T), contract, () => value);
     }
 
     /// <inheritdoc/>
@@ -265,10 +366,17 @@ public class SimpleInjectorDependencyResolver : IDependencyResolver
     public void RegisterLazySingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(Func<T?> valueFactory, string? contract)
         where T : class
     {
+        if (contract is null)
+        {
+            RegisterLazySingleton(valueFactory);
+            return;
+        }
+
         ArgumentExceptionHelper.ThrowIfNull(valueFactory);
 
         var lazy = new Lazy<T?>(valueFactory, LazyThreadSafetyMode.ExecutionAndPublication);
-        Register(() => lazy.Value, typeof(T), contract);
+
+        _contractFactories.Add(typeof(T), contract, () => lazy.Value);
     }
 
     /// <inheritdoc />
@@ -303,6 +411,28 @@ public class SimpleInjectorDependencyResolver : IDependencyResolver
             }
 
             _container.Collection.Register(typeFactories.Key, registrations);
+
+            lock (_lockObject)
+            {
+                _ = _collectionServiceTypes.Add(typeFactories.Key);
+            }
+        }
+
+        initializer.ContractFactories.CopyTo(_contractFactories);
+    }
+
+    /// <summary>Appends a factory to the container's collection for the supplied service type.</summary>
+    /// <param name="serviceType">The service type the factory produces.</param>
+    /// <param name="factory">The factory that produces the service.</param>
+    private void AppendToCollection(Type serviceType, Func<object?> factory)
+    {
+        _container.Collection.Append(
+            serviceType,
+            new TransientSimpleInjectorRegistration(_container, serviceType, factory));
+
+        lock (_lockObject)
+        {
+            _ = _collectionServiceTypes.Add(serviceType);
         }
     }
 }

--- a/src/Splat.SimpleInjector/SimpleInjectorInitializer.cs
+++ b/src/Splat.SimpleInjector/SimpleInjectorInitializer.cs
@@ -11,10 +11,11 @@ namespace Splat.SimpleInjector;
 /// Injector patterns.
 /// </summary>
 /// <remarks>This class enables registration and resolution of services by type, supporting multiple factories per
-/// service. Contract-based registrations are not supported; contract parameters are ignored. Thread safety is ensured
-/// for all registration and resolution operations. This implementation is suitable for scenarios where lightweight,
-/// in-memory dependency resolution is required without advanced features such as scopes or contract-based
-/// resolution.</remarks>
+/// service. Contract registrations are held separately from the contract-less ones, so a contract registration is only
+/// ever returned to a caller that asks for the same contract and never overwrites the contract-less registration for
+/// the same service type. Thread safety is ensured for all registration and resolution operations. This implementation
+/// is suitable for scenarios where lightweight, in-memory dependency resolution is required without advanced features
+/// such as scopes.</remarks>
 [SuppressMessage(
     "StyleSharp",
     "SST2307:A generic method's type parameter appears in no parameter, so no caller can infer it",
@@ -32,6 +33,11 @@ public class SimpleInjectorInitializer : IDependencyResolver
     public Dictionary<Type, List<Func<object?>>> RegisteredFactories { get; }
         = [];
 
+    /// <summary>Gets the factories that were registered against a contract.</summary>
+    /// <remarks>Simple Injector has no keyed registrations, so these are kept apart from <see cref="RegisteredFactories"/>
+    /// and are handed to the resolver when the container is wired up.</remarks>
+    internal ContractRegistrations ContractFactories { get; } = new();
+
     /// <inheritdoc />
     public object? GetService(Type? serviceType)
     {
@@ -39,14 +45,20 @@ public class SimpleInjectorInitializer : IDependencyResolver
 
         lock (_lockObject)
         {
-            var factories = RegisteredFactories[serviceType];
+            if (!RegisteredFactories.TryGetValue(serviceType, out var factories))
+            {
+                return null;
+            }
+
             return factories.Count == 0 ? null : factories[^1].Invoke()!;
         }
     }
 
     /// <inheritdoc />
     public object? GetService(Type? serviceType, string? contract) =>
-        GetService(serviceType); // SimpleInjectorInitializer doesn't support contracts, so we treat contract-based calls the same as non-contract
+        contract is null
+            ? GetService(serviceType)
+            : ContractFactories.ResolveLast(serviceType ?? NullServiceType.CachedType, contract);
 
     /// <inheritdoc/>
     public T? GetService<T>()
@@ -63,8 +75,16 @@ public class SimpleInjectorInitializer : IDependencyResolver
     }
 
     /// <inheritdoc/>
-    public T? GetService<T>(string? contract) =>
-        GetService<T>(); // SimpleInjectorInitializer doesn't support contracts, so we treat contract-based calls the same as non-contract
+    public T? GetService<T>(string? contract)
+    {
+        if (contract is null)
+        {
+            return GetService<T>();
+        }
+
+        var service = ContractFactories.ResolveLast(typeof(T), contract);
+        return service is null ? default : (T?)service;
+    }
 
     /// <inheritdoc/>
     public IEnumerable<object> GetServices(Type? serviceType)
@@ -73,7 +93,11 @@ public class SimpleInjectorInitializer : IDependencyResolver
 
         lock (_lockObject)
         {
-            var factories = RegisteredFactories[serviceType];
+            if (!RegisteredFactories.TryGetValue(serviceType, out var factories))
+            {
+                return [];
+            }
+
             var services = new List<object>(factories.Count);
             foreach (var factory in factories)
             {
@@ -86,7 +110,9 @@ public class SimpleInjectorInitializer : IDependencyResolver
 
     /// <inheritdoc/>
     public IEnumerable<object> GetServices(Type? serviceType, string? contract) =>
-        GetServices(serviceType); // SimpleInjectorInitializer doesn't support contracts, so we treat contract-based calls the same as non-contract
+        contract is null
+            ? GetServices(serviceType)
+            : ContractFactories.ResolveAll(serviceType ?? NullServiceType.CachedType, contract);
 
     /// <inheritdoc/>
     public IEnumerable<T> GetServices<T>()
@@ -109,8 +135,14 @@ public class SimpleInjectorInitializer : IDependencyResolver
     }
 
     /// <inheritdoc/>
-    public IEnumerable<T> GetServices<T>(string? contract) =>
-        GetServices<T>(); // SimpleInjectorInitializer doesn't support contracts, so we treat contract-based calls the same as non-contract
+    /// <remarks>SimpleInjector's generic methods require a class constraint, so the non-generic overload does the work.</remarks>
+    public IEnumerable<T> GetServices<T>(string? contract)
+    {
+        foreach (var service in GetServices(typeof(T), contract))
+        {
+            yield return (T)service;
+        }
+    }
 
     /// <inheritdoc />
     public bool HasRegistration(Type? serviceType)
@@ -126,7 +158,9 @@ public class SimpleInjectorInitializer : IDependencyResolver
 
     /// <inheritdoc />
     public bool HasRegistration(Type? serviceType, string? contract) =>
-        HasRegistration(serviceType); // SimpleInjectorInitializer doesn't support contracts, so we treat contract-based calls the same as non-contract
+        contract is null
+            ? HasRegistration(serviceType)
+            : ContractFactories.Contains(serviceType ?? NullServiceType.CachedType, contract);
 
     /// <inheritdoc/>
     public bool HasRegistration<T>()
@@ -140,7 +174,7 @@ public class SimpleInjectorInitializer : IDependencyResolver
 
     /// <inheritdoc/>
     public bool HasRegistration<T>(string? contract) =>
-        HasRegistration<T>(); // SimpleInjectorInitializer doesn't support contracts, so we treat contract-based calls the same as non-contract
+        contract is null ? HasRegistration<T>() : ContractFactories.Contains(typeof(T), contract);
 
     /// <inheritdoc />
     public void Register(Func<object?> factory, Type? serviceType)
@@ -169,8 +203,21 @@ public class SimpleInjectorInitializer : IDependencyResolver
     }
 
     /// <inheritdoc />
-    public void Register(Func<object?> factory, Type? serviceType, string? contract) =>
-        Register(factory, serviceType); // SimpleInjectorInitializer doesn't support contracts, so we treat contract-based calls the same as non-contract
+    public void Register(Func<object?> factory, Type? serviceType, string? contract)
+    {
+        if (contract is null)
+        {
+            Register(factory, serviceType);
+            return;
+        }
+
+        var isNull = serviceType is null;
+
+        ContractFactories.Add(
+            serviceType ?? NullServiceType.CachedType,
+            contract,
+            () => isNull ? new NullServiceType(factory) : factory());
+    }
 
     /// <inheritdoc/>
     public void Register<T>(Func<T?> factory)
@@ -195,8 +242,18 @@ public class SimpleInjectorInitializer : IDependencyResolver
     }
 
     /// <inheritdoc/>
-    public void Register<T>(Func<T?> factory, string? contract) =>
-        Register(factory); // SimpleInjectorInitializer doesn't support contracts, so we treat contract-based calls the same as non-contract
+    public void Register<T>(Func<T?> factory, string? contract)
+    {
+        if (contract is null)
+        {
+            Register(factory);
+            return;
+        }
+
+        ArgumentExceptionHelper.ThrowIfNull(factory);
+
+        ContractFactories.Add(typeof(T), contract, () => factory());
+    }
 
     /// <inheritdoc/>
     public void Register<TService, TImplementation>()
@@ -223,8 +280,16 @@ public class SimpleInjectorInitializer : IDependencyResolver
     /// <inheritdoc/>
     public void Register<TService, TImplementation>(string? contract)
         where TService : class
-        where TImplementation : class, TService, new() =>
-        Register<TService, TImplementation>(); // SimpleInjectorInitializer doesn't support contracts, so we treat contract-based calls the same as non-contract
+        where TImplementation : class, TService, new()
+    {
+        if (contract is null)
+        {
+            Register<TService, TImplementation>();
+            return;
+        }
+
+        ContractFactories.Add(typeof(TService), contract, static () => new TImplementation());
+    }
 
     /// <inheritdoc />
     public void UnregisterCurrent(Type? serviceType) => throw new NotSupportedException();
@@ -250,8 +315,16 @@ public class SimpleInjectorInitializer : IDependencyResolver
     }
 
     /// <inheritdoc />
-    public void UnregisterAll(Type? serviceType, string? contract) =>
-        UnregisterAll(serviceType); // SimpleInjectorInitializer doesn't support contracts, so we treat contract-based calls the same as non-contract
+    public void UnregisterAll(Type? serviceType, string? contract)
+    {
+        if (contract is null)
+        {
+            UnregisterAll(serviceType);
+            return;
+        }
+
+        ContractFactories.RemoveAll(serviceType ?? NullServiceType.CachedType, contract);
+    }
 
     /// <inheritdoc/>
     public void UnregisterAll<T>()
@@ -263,8 +336,16 @@ public class SimpleInjectorInitializer : IDependencyResolver
     }
 
     /// <inheritdoc/>
-    public void UnregisterAll<T>(string? contract) =>
-        UnregisterAll<T>(); // SimpleInjectorInitializer doesn't support contracts, so we treat contract-based calls the same as non-contract
+    public void UnregisterAll<T>(string? contract)
+    {
+        if (contract is null)
+        {
+            UnregisterAll<T>();
+            return;
+        }
+
+        ContractFactories.RemoveAll(typeof(T), contract);
+    }
 
     /// <inheritdoc />
     public IDisposable ServiceRegistrationCallback(Type serviceType, Action<IDisposable> callback) => throw new NotSupportedException();
@@ -305,8 +386,18 @@ public class SimpleInjectorInitializer : IDependencyResolver
 
     /// <inheritdoc/>
     public void RegisterConstant<T>(T? value, string? contract)
-        where T : class =>
-        RegisterConstant(value); // SimpleInjectorInitializer doesn't support contracts, so we treat contract-based calls the same as non-contract
+        where T : class
+    {
+        if (contract is null)
+        {
+            RegisterConstant(value);
+            return;
+        }
+
+        ArgumentExceptionHelper.ThrowIfNull(value);
+
+        ContractFactories.Add(typeof(T), contract, () => value);
+    }
 
     /// <inheritdoc/>
     public void RegisterLazySingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(Func<T?> valueFactory)
@@ -335,8 +426,20 @@ public class SimpleInjectorInitializer : IDependencyResolver
 
     /// <inheritdoc/>
     public void RegisterLazySingleton<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>(Func<T?> valueFactory, string? contract)
-        where T : class =>
-        RegisterLazySingleton(valueFactory); // SimpleInjectorInitializer doesn't support contracts, so we treat contract-based calls the same as non-contract
+        where T : class
+    {
+        if (contract is null)
+        {
+            RegisterLazySingleton(valueFactory);
+            return;
+        }
+
+        ArgumentExceptionHelper.ThrowIfNull(valueFactory);
+
+        var lazy = new Lazy<T?>(valueFactory, LazyThreadSafetyMode.ExecutionAndPublication);
+
+        ContractFactories.Add(typeof(T), contract, () => lazy.Value);
+    }
 
     /// <inheritdoc />
     public void Dispose()

--- a/src/tests/Splat.SimpleInjector.Tests/ContractRegistrationTests.cs
+++ b/src/tests/Splat.SimpleInjector.Tests/ContractRegistrationTests.cs
@@ -1,0 +1,671 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using SimpleInjector;
+
+using Splat.Common.Test;
+using Splat.SimpleInjector;
+
+namespace Splat.Simplnjector;
+
+/// <summary>Tests that the SimpleInjector adapter keys registrations by contract instead of dropping the contract.</summary>
+public class ContractRegistrationTests
+{
+    /// <summary>The contract used by tests that register a single named service.</summary>
+    private const string Contract = "contract";
+
+    /// <summary>The first of two contracts used by the tests that prove contracts stay distinct.</summary>
+    private const string LeftContract = "left";
+
+    /// <summary>The second of two contracts used by the tests that prove contracts stay distinct.</summary>
+    private const string RightContract = "right";
+
+    /// <summary>The number of services expected when two are registered under the same contract.</summary>
+    private const int ExpectedContractServiceCount = 2;
+
+    /// <summary>A contract registration on the initializer must not answer a contract-less lookup.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_ContractRegistration_IsInvisibleToContractlessLookup()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+
+        initializer.Register((Func<object?>)(static () => new ViewModelOne()), typeof(IViewModelOne), Contract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(initializer.HasRegistration(typeof(IViewModelOne))).IsFalse();
+            await Assert.That(initializer.GetService(typeof(IViewModelOne))).IsNull();
+            await Assert.That(initializer.GetServices(typeof(IViewModelOne))).IsEmpty();
+        }
+    }
+
+    /// <summary>A contract-less registration on the initializer must not answer a contract lookup.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_ContractlessRegistration_IsInvisibleToContractLookup()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+
+        initializer.Register((Func<object?>)(static () => new ViewModelOne()), typeof(IViewModelOne));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(initializer.HasRegistration(typeof(IViewModelOne), Contract)).IsFalse();
+            await Assert.That(initializer.HasRegistration<IViewModelOne>(Contract)).IsFalse();
+            await Assert.That(initializer.GetService(typeof(IViewModelOne), Contract)).IsNull();
+            await Assert.That(initializer.GetService<IViewModelOne>(Contract)).IsNull();
+            await Assert.That(initializer.GetServices(typeof(IViewModelOne), Contract)).IsEmpty();
+            await Assert.That(initializer.GetServices<IViewModelOne>(Contract)).IsEmpty();
+        }
+    }
+
+    /// <summary>The initializer must keep two implementations registered under different contracts apart.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_DifferentContracts_ResolveDistinctServices()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        var left = new ViewModelOne();
+        var right = new ViewModelOne();
+
+        initializer.Register<IViewModelOne>(() => left, LeftContract);
+        initializer.Register<IViewModelOne>(() => right, RightContract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(initializer.GetService<IViewModelOne>(LeftContract)).IsSameReferenceAs(left);
+            await Assert.That(initializer.GetService<IViewModelOne>(RightContract)).IsSameReferenceAs(right);
+        }
+    }
+
+    /// <summary>The initializer's non-generic Register with a contract should resolve under that contract.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_RegisterByTypeWithContract_ResolvesUnderThatContract()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        var instance = new ViewModelOne();
+
+        initializer.Register((Func<object?>)(() => instance), typeof(IViewModelOne), Contract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(initializer.HasRegistration(typeof(IViewModelOne), Contract)).IsTrue();
+            await Assert.That(initializer.GetService(typeof(IViewModelOne), Contract)).IsSameReferenceAs(instance);
+        }
+    }
+
+    /// <summary>The initializer's generic Register with a contract should resolve under that contract.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_RegisterGenericWithContract_ResolvesUnderThatContract()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        var instance = new ViewModelOne();
+
+        initializer.Register<IViewModelOne>(() => instance, Contract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(initializer.HasRegistration<IViewModelOne>(Contract)).IsTrue();
+            await Assert.That(initializer.GetService<IViewModelOne>(Contract)).IsSameReferenceAs(instance);
+        }
+    }
+
+    /// <summary>The initializer's service/implementation Register with a contract should resolve under that contract.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_RegisterServiceImplementationWithContract_ResolvesUnderThatContract()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+
+        initializer.Register<IViewModelOne, ViewModelOne>(Contract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(initializer.GetService<IViewModelOne>(Contract)).IsTypeOf<ViewModelOne>();
+            await Assert.That(initializer.GetService<IViewModelOne>()).IsNull();
+        }
+    }
+
+    /// <summary>The initializer's RegisterConstant with a contract should resolve the same instance under that contract.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_RegisterConstantWithContract_ResolvesUnderThatContract()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        var instance = new ViewModelOne();
+
+        initializer.RegisterConstant(instance, Contract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(initializer.GetService<ViewModelOne>(Contract)).IsSameReferenceAs(instance);
+            await Assert.That(initializer.GetService<ViewModelOne>()).IsNull();
+        }
+    }
+
+    /// <summary>The initializer's RegisterLazySingleton with a contract should resolve the same instance every time.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_RegisterLazySingletonWithContract_ResolvesSameInstance()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        initializer.RegisterLazySingleton(static () => new ViewModelOne(), Contract);
+
+        var first = initializer.GetService<ViewModelOne>(Contract);
+        var second = initializer.GetService<ViewModelOne>(Contract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(first).IsNotNull();
+            await Assert.That(second).IsSameReferenceAs(first);
+            await Assert.That(initializer.GetService<ViewModelOne>()).IsNull();
+        }
+    }
+
+    /// <summary>The initializer's GetServices with a contract should return every registration made under it, in order.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_GetServicesWithContract_ReturnsEveryContractRegistration()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        var first = new ViewModelOne();
+        var second = new ViewModelOne();
+        initializer.Register<IViewModelOne>(() => first, Contract);
+        initializer.Register<IViewModelOne>(() => second, Contract);
+
+        var services = initializer.GetServices(typeof(IViewModelOne), Contract).ToList();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(services).Count().IsEqualTo(ExpectedContractServiceCount);
+            await Assert.That(services[0]).IsSameReferenceAs(first);
+            await Assert.That(services[1]).IsSameReferenceAs(second);
+        }
+    }
+
+    /// <summary>The initializer's non-generic UnregisterAll with a contract should leave the contract-less registrations alone.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_UnregisterAllByTypeWithContract_LeavesContractlessRegistrations()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        initializer.Register((Func<object?>)(static () => new ViewModelOne()), typeof(IViewModelOne));
+        initializer.Register((Func<object?>)(static () => new ViewModelOne()), typeof(IViewModelOne), Contract);
+
+        initializer.UnregisterAll(typeof(IViewModelOne), Contract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(initializer.HasRegistration(typeof(IViewModelOne), Contract)).IsFalse();
+            await Assert.That(initializer.HasRegistration(typeof(IViewModelOne))).IsTrue();
+        }
+    }
+
+    /// <summary>The initializer's generic UnregisterAll with a contract should remove only that contract's registrations.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_UnregisterAllGenericWithContract_RemovesOnlyThatContract()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        initializer.Register<IViewModelOne, ViewModelOne>(LeftContract);
+        initializer.Register<IViewModelOne, ViewModelOne>(RightContract);
+
+        initializer.UnregisterAll<IViewModelOne>(LeftContract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(initializer.HasRegistration<IViewModelOne>(LeftContract)).IsFalse();
+            await Assert.That(initializer.HasRegistration<IViewModelOne>(RightContract)).IsTrue();
+        }
+    }
+
+    /// <summary>A null contract on the initializer means "no contract" and must register into the contract-less table.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_RegisterWithNullContract_RegistersWithoutContract()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        var instance = new ViewModelOne();
+
+        initializer.Register((Func<object?>)(() => instance), typeof(IViewModelOne), null);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(initializer.HasRegistration(typeof(IViewModelOne), null)).IsTrue();
+            await Assert.That(initializer.GetService(typeof(IViewModelOne), null)).IsSameReferenceAs(instance);
+            await Assert.That(initializer.GetServices(typeof(IViewModelOne), null)).IsNotEmpty();
+        }
+    }
+
+    /// <summary>A contract registration under a null service type should round-trip through the NullServiceType wrapper.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_RegisterByNullTypeWithContract_ResolvesNullServiceTypeWrapper()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        var instance = new ViewModelOne();
+
+        initializer.Register((Func<object?>)(() => instance), (Type?)null, Contract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(initializer.HasRegistration((Type?)null, Contract)).IsTrue();
+            await Assert.That(initializer.GetService((Type?)null, Contract)).IsTypeOf<NullServiceType>();
+            await Assert.That(initializer.GetServices((Type?)null, Contract)).IsNotEmpty();
+        }
+    }
+
+    /// <summary>The initializer's generic UnregisterAll with a null contract should remove the contract-less registrations.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_UnregisterAllGenericWithNullContract_RemovesContractlessRegistrations()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        initializer.Register<IViewModelOne, ViewModelOne>();
+
+        initializer.UnregisterAll<IViewModelOne>(null);
+
+        await Assert.That(initializer.HasRegistration<IViewModelOne>()).IsFalse();
+    }
+
+    /// <summary>The initializer's non-generic UnregisterAll with a contract should remove registrations made under a null service type.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_UnregisterAllByNullTypeWithContract_RemovesContractRegistrations()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        initializer.Register((Func<object?>)(static () => new ViewModelOne()), (Type?)null, Contract);
+
+        initializer.UnregisterAll((Type?)null, Contract);
+
+        await Assert.That(initializer.HasRegistration((Type?)null, Contract)).IsFalse();
+    }
+
+    /// <summary>The initializer's generic reads with a null contract must fall through to the contract-less lookup.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_ReadGenericWithNullContract_DelegatesToContractlessLookup()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        var instance = new ViewModelOne();
+        initializer.Register<IViewModelOne>(() => instance);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(initializer.HasRegistration<IViewModelOne>(null)).IsTrue();
+            await Assert.That(initializer.GetService<IViewModelOne>(null)).IsSameReferenceAs(instance);
+            await Assert.That(initializer.GetServices<IViewModelOne>(null)).IsNotEmpty();
+        }
+    }
+
+    /// <summary>The initializer's generic Register with a null contract must land on the contract-less path.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_RegisterGenericWithNullContract_RegistersWithoutContract()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        var instance = new ViewModelOne();
+
+        initializer.Register<IViewModelOne>(() => instance, null);
+
+        await Assert.That(initializer.GetService<IViewModelOne>()).IsSameReferenceAs(instance);
+    }
+
+    /// <summary>The initializer's service/implementation Register with a null contract must land on the contract-less path.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_RegisterServiceImplementationWithNullContract_RegistersWithoutContract()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+
+        initializer.Register<IViewModelOne, ViewModelOne>(null);
+
+        await Assert.That(initializer.GetService<IViewModelOne>()).IsTypeOf<ViewModelOne>();
+    }
+
+    /// <summary>The initializer's RegisterConstant with a null contract must land on the contract-less path.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_RegisterConstantWithNullContract_RegistersWithoutContract()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        var instance = new ViewModelOne();
+
+        initializer.RegisterConstant(instance, null);
+
+        await Assert.That(initializer.GetService<ViewModelOne>()).IsSameReferenceAs(instance);
+    }
+
+    /// <summary>The initializer's RegisterLazySingleton with a null contract must land on the contract-less path.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_RegisterLazySingletonWithNullContract_RegistersWithoutContract()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+
+        initializer.RegisterLazySingleton(static () => new ViewModelOne(), null);
+
+        var first = initializer.GetService<ViewModelOne>();
+        var second = initializer.GetService<ViewModelOne>();
+
+        await Assert.That(first).IsSameReferenceAs(second);
+    }
+
+    /// <summary>The initializer's non-generic UnregisterAll with a null contract must remove the contract-less registrations.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_UnregisterAllByTypeWithNullContract_RemovesContractlessRegistrations()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        initializer.Register((Func<object?>)(static () => new ViewModelOne()), typeof(IViewModelOne));
+
+        initializer.UnregisterAll(typeof(IViewModelOne), null);
+
+        await Assert.That(initializer.HasRegistration(typeof(IViewModelOne))).IsFalse();
+    }
+
+    /// <summary>The contract registrations staged on the initializer must survive the handover to the resolver.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_InheritsContractRegistrationsFromInitializer()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+        var instance = new ViewModelOne();
+        initializer.Register<IViewModelOne>(() => instance, Contract);
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), initializer);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.HasRegistration<IViewModelOne>(Contract)).IsTrue();
+            await Assert.That(resolver.GetService<IViewModelOne>(Contract)).IsSameReferenceAs(instance);
+        }
+    }
+
+    /// <summary>A contract registration on the resolver must not answer a contract-less lookup.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_ContractRegistration_IsInvisibleToContractlessLookup()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+
+        resolver.Register((Func<object?>)(static () => new ViewModelOne()), typeof(IViewModelOne), Contract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.HasRegistration(typeof(IViewModelOne))).IsFalse();
+            await Assert.That(resolver.GetService(typeof(IViewModelOne))).IsNull();
+        }
+    }
+
+    /// <summary>A registration made straight against the container must not answer a contract lookup.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_ContainerRegistration_IsInvisibleToContractLookup()
+    {
+        var container = new Container();
+        container.RegisterSingleton<IScreen, MockScreen>();
+        using var resolver = new SimpleInjectorDependencyResolver(container, new SimpleInjectorInitializer());
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.HasRegistration(typeof(IScreen), Contract)).IsFalse();
+            await Assert.That(resolver.HasRegistration<IScreen>(Contract)).IsFalse();
+            await Assert.That(resolver.GetService(typeof(IScreen), Contract)).IsNull();
+            await Assert.That(resolver.GetService<IScreen>(Contract)).IsNull();
+            await Assert.That(resolver.GetServices(typeof(IScreen), Contract)).IsEmpty();
+            await Assert.That(resolver.GetServices<IScreen>(Contract)).IsEmpty();
+        }
+    }
+
+    /// <summary>The resolver must keep two implementations registered under different contracts apart.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_DifferentContracts_ResolveDistinctServices()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+        var left = new ViewModelOne();
+        var right = new ViewModelOne();
+
+        resolver.Register<IViewModelOne>(() => left, LeftContract);
+        resolver.Register<IViewModelOne>(() => right, RightContract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.GetService<IViewModelOne>(LeftContract)).IsSameReferenceAs(left);
+            await Assert.That(resolver.GetService<IViewModelOne>(RightContract)).IsSameReferenceAs(right);
+        }
+    }
+
+    /// <summary>The resolver's non-generic Register with a contract should resolve under that contract.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterByTypeWithContract_ResolvesUnderThatContract()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+        var instance = new ViewModelOne();
+
+        resolver.Register((Func<object?>)(() => instance), typeof(IViewModelOne), Contract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.HasRegistration(typeof(IViewModelOne), Contract)).IsTrue();
+            await Assert.That(resolver.GetService(typeof(IViewModelOne), Contract)).IsSameReferenceAs(instance);
+        }
+    }
+
+    /// <summary>The resolver's service/implementation Register with a contract should resolve under that contract.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterServiceImplementationWithContract_ResolvesUnderThatContract()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+
+        resolver.Register<IViewModelOne, ViewModelOne>(Contract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.GetService<IViewModelOne>(Contract)).IsTypeOf<ViewModelOne>();
+            await Assert.That(resolver.HasRegistration(typeof(IViewModelOne))).IsFalse();
+        }
+    }
+
+    /// <summary>The resolver's RegisterConstant with a contract should resolve the same instance under that contract.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterConstantWithContract_ResolvesUnderThatContract()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+        var instance = new ViewModelOne();
+
+        resolver.RegisterConstant(instance, Contract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.GetService<ViewModelOne>(Contract)).IsSameReferenceAs(instance);
+            await Assert.That(resolver.HasRegistration(typeof(ViewModelOne))).IsFalse();
+        }
+    }
+
+    /// <summary>The resolver's RegisterLazySingleton with a contract should resolve the same instance every time.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterLazySingletonWithContract_ResolvesSameInstance()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+        resolver.RegisterLazySingleton(static () => new ViewModelOne(), Contract);
+
+        var first = resolver.GetService<ViewModelOne>(Contract);
+        var second = resolver.GetService<ViewModelOne>(Contract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(first).IsNotNull();
+            await Assert.That(second).IsSameReferenceAs(first);
+        }
+    }
+
+    /// <summary>The resolver's GetServices with a contract should return every registration made under it, in order.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_GetServicesWithContract_ReturnsEveryContractRegistration()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+        var first = new ViewModelOne();
+        var second = new ViewModelOne();
+        resolver.Register<IViewModelOne>(() => first, Contract);
+        resolver.Register<IViewModelOne>(() => second, Contract);
+
+        var services = resolver.GetServices<IViewModelOne>(Contract).ToList();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(services).Count().IsEqualTo(ExpectedContractServiceCount);
+            await Assert.That(services[0]).IsSameReferenceAs(first);
+            await Assert.That(services[1]).IsSameReferenceAs(second);
+        }
+    }
+
+    /// <summary>The resolver's contract lookups should return nothing when the contract was never registered.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_GetServiceWithUnknownContract_ReturnsNull()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+        resolver.Register<IViewModelOne>(static () => new ViewModelOne(), LeftContract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.GetService<IViewModelOne>(RightContract)).IsNull();
+            await Assert.That(resolver.GetService(typeof(IViewModelOne), RightContract)).IsNull();
+        }
+    }
+
+    /// <summary>The resolver's contract registrations should reject a null factory instead of accepting it silently.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterWithContract_NullFactory_Throws()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(() => resolver.Register(null!, typeof(IViewModelOne), Contract)).Throws<ArgumentNullException>();
+            await Assert.That(() => resolver.Register((Func<IViewModelOne?>)null!, Contract)).Throws<ArgumentNullException>();
+            await Assert.That(() => resolver.RegisterLazySingleton((Func<ViewModelOne?>)null!, Contract)).Throws<ArgumentNullException>();
+            await Assert.That(() => resolver.RegisterConstant((ViewModelOne?)null, Contract)).Throws<ArgumentNullException>();
+        }
+    }
+
+    /// <summary>A null contract on the resolver means "no contract" and must register into the container.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterWithNullContract_RegistersWithoutContract()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+        var instance = new ViewModelOne();
+
+        resolver.Register((Func<object?>)(() => instance), typeof(IViewModelOne), null);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.HasRegistration(typeof(IViewModelOne), null)).IsTrue();
+            await Assert.That(resolver.GetService(typeof(IViewModelOne), null)).IsSameReferenceAs(instance);
+            await Assert.That(resolver.GetServices(typeof(IViewModelOne), null)).IsNotEmpty();
+        }
+    }
+
+    /// <summary>The resolver's generic registrations with a null contract must land on the contract-less path.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterGenericWithNullContract_RegistersWithoutContract()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+        var instance = new ViewModelOne();
+
+        resolver.Register<IViewModelOne>(() => instance, null);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.HasRegistration<IViewModelOne>(null)).IsTrue();
+            await Assert.That(resolver.GetService<IViewModelOne>(null)).IsSameReferenceAs(instance);
+            await Assert.That(resolver.GetServices<IViewModelOne>(null)).IsNotEmpty();
+        }
+    }
+
+    /// <summary>The resolver's constant and singleton registrations with a null contract must land on the contract-less path.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterConstantWithNullContract_RegistersWithoutContract()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+        var instance = new ViewModelOne();
+
+        resolver.RegisterConstant(instance, null);
+
+        await Assert.That(resolver.GetService<ViewModelOne>()).IsSameReferenceAs(instance);
+    }
+
+    /// <summary>The resolver's lazy singleton with a null contract must land on the contract-less path.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterLazySingletonWithNullContract_RegistersWithoutContract()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+
+        resolver.RegisterLazySingleton(static () => new ViewModelOne(), null);
+
+        var first = resolver.GetService<ViewModelOne>();
+        var second = resolver.GetService<ViewModelOne>();
+
+        await Assert.That(first).IsSameReferenceAs(second);
+    }
+
+    /// <summary>The resolver's service/implementation registration with a null contract must land on the contract-less path.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterServiceImplementationWithNullContract_RegistersWithoutContract()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+
+        resolver.Register<IViewModelOne, ViewModelOne>(null);
+
+        await Assert.That(resolver.GetService<IViewModelOne>()).IsTypeOf<ViewModelOne>();
+    }
+
+    /// <summary>A contract registration on the resolver under a null service type should round-trip through the NullServiceType wrapper.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterByNullTypeWithContract_ResolvesNullServiceTypeWrapper()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+        var instance = new ViewModelOne();
+
+        resolver.Register((Func<object?>)(() => instance), (Type?)null, Contract);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.HasRegistration((Type?)null, Contract)).IsTrue();
+            await Assert.That(resolver.GetService((Type?)null, Contract)).IsTypeOf<NullServiceType>();
+            await Assert.That(resolver.GetServices((Type?)null, Contract)).IsNotEmpty();
+        }
+    }
+
+    /// <summary>The initializer's contract registrations should reject a null factory instead of accepting it silently.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_RegisterWithContract_NullFactory_Throws()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(() => initializer.Register((Func<IViewModelOne?>)null!, Contract)).Throws<ArgumentNullException>();
+            await Assert.That(() => initializer.RegisterLazySingleton((Func<ViewModelOne?>)null!, Contract)).Throws<ArgumentNullException>();
+            await Assert.That(() => initializer.RegisterConstant((ViewModelOne?)null, Contract)).Throws<ArgumentNullException>();
+        }
+    }
+}

--- a/src/tests/Splat.SimpleInjector.Tests/DependencyResolverTests.cs
+++ b/src/tests/Splat.SimpleInjector.Tests/DependencyResolverTests.cs
@@ -112,6 +112,20 @@ public class DependencyResolverTests
         await Assert.That(views).IsNotNull();
     }
 
+    /// <summary>A registration made through the resolver once the locator is wired up must win over Splat's default.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterAfterWiringLocator_ReplacesSplatDefaultLogManager()
+    {
+        await using var container = new Container();
+        container.UseSimpleInjectorDependencyResolver(new());
+        var logManager = new FuncLogManager(static _ => new WrappingFullLogger(new DebugLogger()));
+
+        AppLocator.CurrentMutable.Register<ILogManager>(() => logManager);
+
+        await Assert.That(AppLocator.Current.GetService<ILogManager>()).IsSameReferenceAs(logManager);
+    }
+
     /// <summary>The initializer's non-generic Register overload should store every factory and expose them from GetServices.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]
@@ -193,19 +207,6 @@ public class DependencyResolverTests
         await Assert.That(second).IsSameReferenceAs(first);
     }
 
-    /// <summary>The resolver's service/implementation Register overload with a contract is a compatibility no-op that registers nothing.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorDependencyResolver_RegisterServiceImplementationWithContract_DoesNotRegister()
-    {
-        const string contract = "contract";
-        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
-
-        resolver.Register<IViewModelOne, ViewModelOne>(contract);
-
-        await Assert.That(resolver.HasRegistration(typeof(IViewModelOne))).IsFalse();
-    }
-
     /// <summary>The resolver's RegisterLazySingleton should resolve the same singleton instance on repeated resolutions.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]
@@ -237,19 +238,28 @@ public class DependencyResolverTests
         await Assert.That(service).IsSameReferenceAs(second);
     }
 
-    /// <summary>The initializer's non-generic GetService with a contract should ignore the contract and resolve normally.</summary>
+    /// <summary>The initializer's non-generic GetService should return null rather than throw when nothing is registered.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]
-    public async Task SimpleInjectorInitializer_GetServiceByTypeWithContract_IgnoresContract()
+    public async Task SimpleInjectorInitializer_GetServiceByType_WithoutRegistration_ReturnsNull()
     {
-        const string contract = "contract";
         using var initializer = new SimpleInjectorInitializer();
-        var instance = new ViewModelOne();
-        initializer.Register((Func<object?>)(() => instance), typeof(IViewModelOne));
 
-        var service = initializer.GetService(typeof(IViewModelOne), contract);
+        var service = initializer.GetService(typeof(IViewModelOne));
 
-        await Assert.That(service).IsSameReferenceAs(instance);
+        await Assert.That(service).IsNull();
+    }
+
+    /// <summary>The initializer's non-generic GetServices should return an empty sequence rather than throw when nothing is registered.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_GetServicesByType_WithoutRegistration_ReturnsEmpty()
+    {
+        using var initializer = new SimpleInjectorInitializer();
+
+        var services = initializer.GetServices(typeof(IViewModelOne)).ToList();
+
+        await Assert.That(services).Count().IsEqualTo(0);
     }
 
     /// <summary>Registering under a null service type should round-trip through the NullServiceType wrapper via the non-generic GetService.</summary>
@@ -266,21 +276,6 @@ public class DependencyResolverTests
         await Assert.That(service).IsTypeOf<NullServiceType>();
     }
 
-    /// <summary>The initializer's generic GetService with a contract should ignore the contract and resolve normally.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorInitializer_GetServiceGenericWithContract_IgnoresContract()
-    {
-        const string contract = "contract";
-        using var initializer = new SimpleInjectorInitializer();
-        var instance = new ViewModelOne();
-        initializer.Register<IViewModelOne>(() => instance);
-
-        var service = initializer.GetService<IViewModelOne>(contract);
-
-        await Assert.That(service).IsSameReferenceAs(instance);
-    }
-
     /// <summary>The initializer's generic GetService should return the default value when nothing is registered.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]
@@ -291,25 +286,6 @@ public class DependencyResolverTests
         var service = initializer.GetService<IViewModelOne>();
 
         await Assert.That(service).IsNull();
-    }
-
-    /// <summary>The initializer's non-generic GetServices with a contract should ignore the contract and resolve normally.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorInitializer_GetServicesByTypeWithContract_IgnoresContract()
-    {
-        const string contract = "contract";
-        using var initializer = new SimpleInjectorInitializer();
-        var instance = new ViewModelOne();
-        initializer.Register((Func<object?>)(() => instance), typeof(IViewModelOne));
-
-        var services = initializer.GetServices(typeof(IViewModelOne), contract).ToList();
-
-        using (Assert.Multiple())
-        {
-            await Assert.That(services).Count().IsEqualTo(1);
-            await Assert.That(services[0]).IsSameReferenceAs(instance);
-        }
     }
 
     /// <summary>Registering under a null service type should be resolvable through the non-generic GetServices.</summary>
@@ -327,25 +303,6 @@ public class DependencyResolverTests
         {
             await Assert.That(services).Count().IsEqualTo(1);
             await Assert.That(services[0]).IsTypeOf<NullServiceType>();
-        }
-    }
-
-    /// <summary>The initializer's generic GetServices with a contract should ignore the contract and resolve normally.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorInitializer_GetServicesGenericWithContract_IgnoresContract()
-    {
-        const string contract = "contract";
-        using var initializer = new SimpleInjectorInitializer();
-        var instance = new ViewModelOne();
-        initializer.Register<IViewModelOne>(() => instance);
-
-        var services = initializer.GetServices<IViewModelOne>(contract).ToList();
-
-        using (Assert.Multiple())
-        {
-            await Assert.That(services).Count().IsEqualTo(1);
-            await Assert.That(services[0]).IsSameReferenceAs(instance);
         }
     }
 
@@ -377,75 +334,6 @@ public class DependencyResolverTests
         var result = initializer.HasRegistration((Type?)null);
 
         await Assert.That(result).IsFalse();
-    }
-
-    /// <summary>The initializer's non-generic HasRegistration with a contract should ignore the contract.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorInitializer_HasRegistrationByTypeWithContract_IgnoresContract()
-    {
-        const string contract = "contract";
-        using var initializer = new SimpleInjectorInitializer();
-        initializer.Register((Func<object?>)(static () => new ViewModelOne()), typeof(IViewModelOne));
-
-        var result = initializer.HasRegistration(typeof(IViewModelOne), contract);
-
-        await Assert.That(result).IsTrue();
-    }
-
-    /// <summary>The initializer's generic HasRegistration with a contract should ignore the contract.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorInitializer_HasRegistrationGenericWithContract_IgnoresContract()
-    {
-        const string contract = "contract";
-        using var initializer = new SimpleInjectorInitializer();
-        initializer.Register<IViewModelOne, ViewModelOne>();
-
-        var result = initializer.HasRegistration<IViewModelOne>(contract);
-
-        await Assert.That(result).IsTrue();
-    }
-
-    /// <summary>The initializer's non-generic Register with a contract should ignore the contract and still register the factory.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorInitializer_RegisterByTypeWithContract_IgnoresContractAndRegisters()
-    {
-        const string contract = "contract";
-        using var initializer = new SimpleInjectorInitializer();
-        var instance = new ViewModelOne();
-
-        initializer.Register((Func<object?>)(() => instance), typeof(IViewModelOne), contract);
-
-        await Assert.That(initializer.GetService(typeof(IViewModelOne))).IsSameReferenceAs(instance);
-    }
-
-    /// <summary>The initializer's generic Register with a contract should ignore the contract and still register the factory.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorInitializer_RegisterGenericWithContract_IgnoresContractAndRegisters()
-    {
-        const string contract = "contract";
-        using var initializer = new SimpleInjectorInitializer();
-        var instance = new ViewModelOne();
-
-        initializer.Register<IViewModelOne>(() => instance, contract);
-
-        await Assert.That(initializer.GetService<IViewModelOne>()).IsSameReferenceAs(instance);
-    }
-
-    /// <summary>The initializer's service/implementation Register with a contract should ignore the contract and resolve the implementation.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorInitializer_RegisterServiceImplementationWithContract_IgnoresContract()
-    {
-        const string contract = "contract";
-        using var initializer = new SimpleInjectorInitializer();
-
-        initializer.Register<IViewModelOne, ViewModelOne>(contract);
-
-        await Assert.That(initializer.GetService<IViewModelOne>()).IsTypeOf<ViewModelOne>();
     }
 
     /// <summary>The initializer does not support unregistering the current registration by type.</summary>
@@ -516,20 +404,6 @@ public class DependencyResolverTests
         await Assert.That(initializer.HasRegistration((Type?)null)).IsFalse();
     }
 
-    /// <summary>The initializer's non-generic UnregisterAll with a contract should ignore the contract and remove registrations.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorInitializer_UnregisterAllByTypeWithContract_RemovesRegistrations()
-    {
-        const string contract = "contract";
-        using var initializer = new SimpleInjectorInitializer();
-        initializer.Register((Func<object?>)(static () => new ViewModelOne()), typeof(IViewModelOne));
-
-        initializer.UnregisterAll(typeof(IViewModelOne), contract);
-
-        await Assert.That(initializer.HasRegistration(typeof(IViewModelOne))).IsFalse();
-    }
-
     /// <summary>The initializer's generic UnregisterAll should remove every factory for the type.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]
@@ -539,20 +413,6 @@ public class DependencyResolverTests
         initializer.Register<IViewModelOne, ViewModelOne>();
 
         initializer.UnregisterAll<IViewModelOne>();
-
-        await Assert.That(initializer.HasRegistration<IViewModelOne>()).IsFalse();
-    }
-
-    /// <summary>The initializer's generic UnregisterAll with a contract should ignore the contract and remove registrations.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorInitializer_UnregisterAllGenericWithContract_RemovesRegistrations()
-    {
-        const string contract = "contract";
-        using var initializer = new SimpleInjectorInitializer();
-        initializer.Register<IViewModelOne, ViewModelOne>();
-
-        initializer.UnregisterAll<IViewModelOne>(contract);
 
         await Assert.That(initializer.HasRegistration<IViewModelOne>()).IsFalse();
     }
@@ -599,34 +459,96 @@ public class DependencyResolverTests
         await Assert.That(() => initializer.ServiceRegistrationCallback<IViewModelOne>(contract, static _ => { })).Throws<NotSupportedException>();
     }
 
-    /// <summary>The initializer's RegisterConstant with a contract should ignore the contract and register the constant.</summary>
+    /// <summary>The resolver's non-generic Register should put the factory into the container so the service resolves.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]
-    public async Task SimpleInjectorInitializer_RegisterConstantWithContract_IgnoresContract()
+    public async Task SimpleInjectorDependencyResolver_RegisterByType_MakesServiceResolvable()
     {
-        const string contract = "contract";
-        using var initializer = new SimpleInjectorInitializer();
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
         var instance = new ViewModelOne();
 
-        initializer.RegisterConstant(instance, contract);
+        resolver.Register((Func<object?>)(() => instance), typeof(IViewModelOne));
 
-        await Assert.That(initializer.GetService<ViewModelOne>()).IsSameReferenceAs(instance);
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.HasRegistration(typeof(IViewModelOne))).IsTrue();
+            await Assert.That(resolver.GetService(typeof(IViewModelOne))).IsSameReferenceAs(instance);
+        }
     }
 
-    /// <summary>The initializer's RegisterLazySingleton with a contract should ignore the contract and resolve the same instance.</summary>
+    /// <summary>The resolver's generic Register should put the factory into the container so the service resolves.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]
-    public async Task SimpleInjectorInitializer_RegisterLazySingletonWithContract_IgnoresContract()
+    public async Task SimpleInjectorDependencyResolver_RegisterGeneric_MakesServiceResolvable()
     {
-        const string contract = "contract";
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+        var instance = new ViewModelOne();
+
+        resolver.Register<IViewModelOne>(() => instance);
+
+        await Assert.That(resolver.GetService<IViewModelOne>()).IsSameReferenceAs(instance);
+    }
+
+    /// <summary>The resolver's non-generic Register should resolve the most recently registered factory.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterByType_ResolvesLastRegisteredFactory()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+        var first = new ViewModelOne();
+        var second = new ViewModelOne();
+
+        resolver.Register((Func<object?>)(() => first), typeof(IViewModelOne));
+        resolver.Register((Func<object?>)(() => second), typeof(IViewModelOne));
+
+        await Assert.That(resolver.GetService(typeof(IViewModelOne))).IsSameReferenceAs(second);
+    }
+
+    /// <summary>The resolver's non-generic Register should wrap a null service type in the NullServiceType marker.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterByNullType_ResolvesNullServiceTypeWrapper()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+        var instance = new ViewModelOne();
+
+        resolver.Register((Func<object?>)(() => instance), (Type?)null);
+
+        await Assert.That(resolver.GetService((Type?)null)).IsTypeOf<NullServiceType>();
+    }
+
+    /// <summary>The resolver's non-generic Register should reject a null factory instead of accepting it silently.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterByType_NullFactory_Throws()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+
+        await Assert.That(() => resolver.Register(null!, typeof(IViewModelOne))).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>SimpleInjector locks its container on the first resolution, so a later registration must fail loudly rather than be dropped.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_RegisterByType_AfterFirstResolution_Throws()
+    {
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
+        _ = resolver.GetService(typeof(IViewModelOne));
+
+        await Assert.That(() => resolver.Register((Func<object?>)(static () => new ViewModelOne()), typeof(IViewModelOne)))
+            .Throws<InvalidOperationException>();
+    }
+
+    /// <summary>The resolver should report the registrations the initializer staged into the container.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_HasRegistrationByType_SeesInitializerRegistrations()
+    {
         using var initializer = new SimpleInjectorInitializer();
-        initializer.RegisterLazySingleton(static () => new ViewModelOne(), contract);
+        initializer.Register((Func<object?>)(static () => new ViewModelOne()), typeof(IViewModelOne));
+        using var resolver = new SimpleInjectorDependencyResolver(new Container(), initializer);
 
-        var first = initializer.GetService<ViewModelOne>();
-        var second = initializer.GetService<ViewModelOne>();
-
-        await Assert.That(first).IsNotNull();
-        await Assert.That(second).IsSameReferenceAs(first);
+        await Assert.That(resolver.HasRegistration(typeof(IViewModelOne))).IsTrue();
     }
 
     /// <summary>The resolver's non-generic GetService should fall back to the registered collection when no single registration exists.</summary>
@@ -668,36 +590,6 @@ public class DependencyResolverTests
         await Assert.That(service).IsNull();
     }
 
-    /// <summary>The resolver's non-generic GetService with a contract should ignore the contract and resolve normally.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorDependencyResolver_GetServiceByTypeWithContract_IgnoresContract()
-    {
-        const string contract = "contract";
-        var container = new Container();
-        container.RegisterSingleton<IScreen, MockScreen>();
-        using var resolver = new SimpleInjectorDependencyResolver(container, new SimpleInjectorInitializer());
-
-        var service = resolver.GetService(typeof(IScreen), contract);
-
-        await Assert.That(service).IsTypeOf<MockScreen>();
-    }
-
-    /// <summary>The resolver's generic GetService with a contract should ignore the contract and resolve normally.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorDependencyResolver_GetServiceGenericWithContract_IgnoresContract()
-    {
-        const string contract = "contract";
-        var container = new Container();
-        container.RegisterSingleton<IScreen, MockScreen>();
-        using var resolver = new SimpleInjectorDependencyResolver(container, new SimpleInjectorInitializer());
-
-        var service = resolver.GetService<IScreen>(contract);
-
-        await Assert.That(service).IsTypeOf<MockScreen>();
-    }
-
     /// <summary>The resolver's non-generic GetServices should return the single registration when no collection registration exists.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]
@@ -729,79 +621,6 @@ public class DependencyResolverTests
         await Assert.That(services).Count().IsEqualTo(0);
     }
 
-    /// <summary>The resolver's non-generic GetServices with a contract should ignore the contract and resolve normally.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorDependencyResolver_GetServicesByTypeWithContract_IgnoresContract()
-    {
-        const string contract = "contract";
-        const int expectedCount = 1;
-        var container = new Container();
-        container.RegisterSingleton<IScreen, MockScreen>();
-        using var resolver = new SimpleInjectorDependencyResolver(container, new SimpleInjectorInitializer());
-
-        var services = resolver.GetServices(typeof(IScreen), contract).ToList();
-
-        await Assert.That(services).Count().IsEqualTo(expectedCount);
-    }
-
-    /// <summary>The resolver's generic GetServices with a contract should ignore the contract and resolve normally.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorDependencyResolver_GetServicesGenericWithContract_IgnoresContract()
-    {
-        const string contract = "contract";
-        const int expectedCount = 1;
-        var container = new Container();
-        container.RegisterSingleton<IScreen, MockScreen>();
-        using var resolver = new SimpleInjectorDependencyResolver(container, new SimpleInjectorInitializer());
-
-        var services = resolver.GetServices<IScreen>(contract).ToList();
-
-        await Assert.That(services).Count().IsEqualTo(expectedCount);
-    }
-
-    /// <summary>The resolver's generic GetServices should return the container's registrations typed.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorDependencyResolver_GetServicesGeneric_ReturnsTypedRegistrations()
-    {
-        const int expectedCount = 1;
-        var container = new Container();
-        container.RegisterSingleton<IScreen, MockScreen>();
-        using var resolver = new SimpleInjectorDependencyResolver(container, new SimpleInjectorInitializer());
-
-        var services = resolver.GetServices<IScreen>().ToList();
-
-        using (Assert.Multiple())
-        {
-            await Assert.That(services).Count().IsEqualTo(expectedCount);
-            await Assert.That(services[0]).IsTypeOf<MockScreen>();
-        }
-    }
-
-    /// <summary>The initializer should report no service when the registered factory list for a type is empty.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorInitializer_GetServiceByType_WithEmptyFactoryList_ReturnsNull()
-    {
-        var initializer = new SimpleInjectorInitializer();
-        initializer.RegisteredFactories[typeof(IScreen)] = [];
-
-        await Assert.That(initializer.GetService(typeof(IScreen))).IsNull();
-    }
-
-    /// <summary>The initializer's generic GetService should report no service when the registered factory list is empty.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorInitializer_GetServiceGeneric_WithEmptyFactoryList_ReturnsDefault()
-    {
-        var initializer = new SimpleInjectorInitializer();
-        initializer.RegisteredFactories[typeof(IScreen)] = [];
-
-        await Assert.That(initializer.GetService<IScreen>()).IsNull();
-    }
-
     /// <summary>The resolver's non-generic HasRegistration should reflect whether the container has a registration for a type.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]
@@ -826,32 +645,6 @@ public class DependencyResolverTests
         using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
 
         await Assert.That(resolver.HasRegistration((Type?)null)).IsFalse();
-    }
-
-    /// <summary>The resolver's non-generic HasRegistration with a contract should ignore the contract.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorDependencyResolver_HasRegistrationByTypeWithContract_IgnoresContract()
-    {
-        const string contract = "contract";
-        var container = new Container();
-        container.RegisterSingleton<IScreen, MockScreen>();
-        using var resolver = new SimpleInjectorDependencyResolver(container, new SimpleInjectorInitializer());
-
-        await Assert.That(resolver.HasRegistration(typeof(IScreen), contract)).IsTrue();
-    }
-
-    /// <summary>The resolver's generic HasRegistration with a contract should ignore the contract.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorDependencyResolver_HasRegistrationGenericWithContract_IgnoresContract()
-    {
-        const string contract = "contract";
-        var container = new Container();
-        container.RegisterSingleton<IScreen, MockScreen>();
-        using var resolver = new SimpleInjectorDependencyResolver(container, new SimpleInjectorInitializer());
-
-        await Assert.That(resolver.HasRegistration<IScreen>(contract)).IsTrue();
     }
 
     /// <summary>The resolver's service/implementation Register overload should register directly into the container and resolve the implementation.</summary>
@@ -992,32 +785,6 @@ public class DependencyResolverTests
         await Assert.That(() => resolver.ServiceRegistrationCallback<IViewModelOne>(contract, static _ => { })).Throws<NotSupportedException>();
     }
 
-    /// <summary>The resolver's RegisterConstant with a contract is a compatibility no-op that registers nothing.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorDependencyResolver_RegisterConstantWithContract_DoesNotRegister()
-    {
-        const string contract = "contract";
-        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
-
-        resolver.RegisterConstant(new ViewModelOne(), contract);
-
-        await Assert.That(resolver.HasRegistration(typeof(ViewModelOne))).IsFalse();
-    }
-
-    /// <summary>The resolver's RegisterLazySingleton with a contract is a compatibility no-op that registers nothing.</summary>
-    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-    [Test]
-    public async Task SimpleInjectorDependencyResolver_RegisterLazySingletonWithContract_DoesNotRegister()
-    {
-        const string contract = "contract";
-        using var resolver = new SimpleInjectorDependencyResolver(new Container(), new SimpleInjectorInitializer());
-
-        resolver.RegisterLazySingleton(static () => new ViewModelOne(), contract);
-
-        await Assert.That(resolver.HasRegistration(typeof(ViewModelOne))).IsFalse();
-    }
-
     /// <summary>Disposing the resolver without disposing managed resources should leave the underlying container usable.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]
@@ -1030,6 +797,47 @@ public class DependencyResolverTests
         resolver.InvokeDispose(false);
 
         await Assert.That(container.GetInstance<ViewModelOne>()).IsNotNull();
+    }
+
+    /// <summary>The resolver's generic GetServices should return the container's registrations typed.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorDependencyResolver_GetServicesGeneric_ReturnsTypedRegistrations()
+    {
+        const int expectedCount = 1;
+        var container = new Container();
+        container.RegisterSingleton<IScreen, MockScreen>();
+        using var resolver = new SimpleInjectorDependencyResolver(container, new SimpleInjectorInitializer());
+
+        var services = resolver.GetServices<IScreen>().ToList();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(services).Count().IsEqualTo(expectedCount);
+            await Assert.That(services[0]).IsTypeOf<MockScreen>();
+        }
+    }
+
+    /// <summary>The initializer should report no service when the registered factory list for a type is empty.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_GetServiceByType_WithEmptyFactoryList_ReturnsNull()
+    {
+        var initializer = new SimpleInjectorInitializer();
+        initializer.RegisteredFactories[typeof(IScreen)] = [];
+
+        await Assert.That(initializer.GetService(typeof(IScreen))).IsNull();
+    }
+
+    /// <summary>The initializer's generic GetService should report no service when the registered factory list is empty.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SimpleInjectorInitializer_GetServiceGeneric_WithEmptyFactoryList_ReturnsDefault()
+    {
+        var initializer = new SimpleInjectorInitializer();
+        initializer.RegisteredFactories[typeof(IScreen)] = [];
+
+        await Assert.That(initializer.GetService<IScreen>()).IsNull();
     }
 
     /// <summary>Test-only resolver that exposes the protected dispose to exercise the non-managed dispose branch.</summary>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

- Contracts are honored across the adapter. A contract registration answers only lookups for the same contract, never shadows the contract-less registration, and two contracts for one service type stay distinct.
- `Register` on the resolver takes effect instead of doing nothing, so a registration made after the locator is wired up applies, or reports Simple Injector's own error once the container has been locked by a resolution.

## What is the current behavior?

- Every contract overload discarded its contract and behaved as the contract-less call, so registering two implementations under different contracts silently returned whichever one won. Closes #240.
- The resolver's `Register` was an empty method, so a registration made after the resolver was wired up vanished with no error.
- The initializer's non-generic lookups threw when asked for a type that was never registered, rather than reporting no service.

## What might this PR break?

- `Register` on the resolver now registers. Code that called it expecting nothing to happen will now add a registration, and calling it after the first resolution surfaces the container's locked-container exception rather than being silently ignored.
- A lookup passing a contract no longer falls back to the contract-less registration, so a caller that relied on that fallback will now get nothing.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

Simple Injector has no keyed registrations, so contracts are held in a table beside the container and are deliberately not injectable by the container itself; this is documented in the class remarks and the package readme. The container-locking behaviour the design depends on was verified directly rather than assumed. 412 tests pass across the seven target frameworks.
