### PR TITLE
fix(drawing): report design mode correctly for nested WPF user controls

### DIFF
--- a/src/Splat.Drawing/DefaultPlatformModeDetector.cs
+++ b/src/Splat.Drawing/DefaultPlatformModeDetector.cs
@@ -2,45 +2,47 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
+#if !MONO
 using System.Diagnostics.CodeAnalysis;
+#endif
 using System.IO;
+#if NETFRAMEWORK
 using System.Reflection;
+#endif
 
 namespace Splat;
 
-/// <summary>
-/// Provides a default implementation for detecting whether the application is running in design mode across supported
-/// platforms.
-/// </summary>
-/// <remarks>This class is typically used to determine if code is executing within a designer environment, such as
-/// Visual Studio or Blend, to enable or disable design-time specific logic. It supports multiple platforms and design
-/// environments, including WPF, Silverlight, and UWP, by checking for known design mode indicators. The detection
-/// result may be cached for performance. Thread safety is not guaranteed.</remarks>
+/// <summary>Provides a default implementation for detecting whether the application is running in design mode.</summary>
+/// <remarks>
+/// <para>This class is typically used to determine if code is executing within a designer environment, such as
+/// Visual Studio or Blend, to enable or disable design-time specific logic. The detection result is memoized, so a
+/// process that starts outside a designer never re-runs the probes. Thread safety is not guaranteed.</para>
+/// <para>Which probes are compiled depends on the target framework. Splat.Drawing sets <c>UseWPF</c> and
+/// <c>UseWindowsForms</c> for the .NET Framework and Windows-specific targets, so those builds call the WPF designer
+/// API directly instead of reflecting over it. The target-framework-neutral builds keep a reflective probe, because a
+/// Windows desktop application resolves to them when its own platform version predates the Windows-specific targets.
+/// The Android and Apple targets cannot host a XAML designer at all and compile no designer probe.</para>
+/// </remarks>
 public class DefaultPlatformModeDetector : IPlatformModeDetector
 {
-    /// <summary>Assembly-qualified name of the Silverlight/XAML <c>DesignerProperties</c> type probed for design mode.</summary>
-    private const string XamlDesignPropertiesType = "System.ComponentModel.DesignerProperties, System.Windows, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e";
-
-    /// <summary>Assembly-qualified name of the XAML <c>Border</c> control used as the dependency object for the design-mode probe.</summary>
-    private const string XamlControlBorderType = "System.Windows.Controls.Border, System.Windows, Version=2.0.5.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e";
-
-    /// <summary>Name of the XAML <c>DesignerProperties</c> method that reports design mode.</summary>
-    private const string XamlDesignPropertiesDesignModeMethodName = "GetIsInDesignMode";
-
+#if !NETFRAMEWORK && !WINDOWS && !MONO
     /// <summary>Assembly-qualified name of the WPF <c>DesignerProperties</c> type probed for design mode.</summary>
     private const string WpfDesignerPropertiesType = "System.ComponentModel.DesignerProperties, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
 
     /// <summary>Name of the WPF <c>DesignerProperties</c> method that reports design mode.</summary>
     private const string WpfDesignerPropertiesDesignModeMethod = "GetIsInDesignMode";
 
-    /// <summary>Assembly-qualified name of the WPF <c>DependencyObject</c> type used as the dependency object for the design-mode probe.</summary>
-    private const string WpfDependencyPropertyType = "System.Windows.DependencyObject, WindowsBase, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
+    /// <summary>Assembly-qualified name of the WPF element type the designer raises the design-mode default for.</summary>
+    private const string WpfFrameworkElementType = "System.Windows.FrameworkElement, PresentationFramework, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35";
+#endif
 
-    /// <summary>Assembly-qualified name of the WinRT <c>DesignMode</c> type probed for design mode.</summary>
-    private const string WinFormsDesignerPropertiesType = "Windows.ApplicationModel.DesignMode, Windows, ContentType=WindowsRuntime";
+#if !MONO
+    /// <summary>Assembly-qualified name of the Windows Runtime <c>DesignMode</c> type probed for design mode.</summary>
+    private const string WinRtDesignModeType = "Windows.ApplicationModel.DesignMode, Windows, ContentType=WindowsRuntime";
 
-    /// <summary>Name of the WinRT <c>DesignMode</c> property that reports design mode.</summary>
-    private const string WinFormsDesignerPropertiesDesignModeMethod = "DesignModeEnabled";
+    /// <summary>Name of the Windows Runtime <c>DesignMode</c> property that reports design mode.</summary>
+    private const string WinRtDesignModeEnabledProperty = "DesignModeEnabled";
+#endif
 
     /// <summary>Executable names of known design-time host processes used as a fallback design-mode signal.</summary>
     private static readonly string[] _designEnvironments = ["BLEND.EXE", "XDESPROC.EXE"];
@@ -48,24 +50,41 @@ public class DefaultPlatformModeDetector : IPlatformModeDetector
     /// <summary>Memoizes the design-mode detection result; <see langword="null"/> until first computed.</summary>
     private static bool? _cachedInDesignModeResult;
 
+    /// <summary>Gets the path of the executable hosting the current process, or <see langword="null"/> when it is unavailable.</summary>
+    /// <remarks>This is the executable file, not the directory the assembly was loaded from. A design-time host is
+    /// recognised by its process name, and a directory path yields no executable name to compare.</remarks>
+    internal static string? HostExecutablePath =>
+#if NETFRAMEWORK
+        Assembly.GetEntryAssembly()?.Location;
+#else
+        Environment.ProcessPath;
+#endif
+
     /// <inheritdoc />
-    public bool? InDesignMode() => DetectDesignMode();
+    public bool? InDesignMode() => _cachedInDesignModeResult ??= DetectDesignMode(HostExecutablePath);
 
     /// <summary>Determines whether the supplied host entry-point path names a known design-environment executable.</summary>
     /// <param name="entry">The host entry-point path, or <see langword="null"/> when it is unavailable.</param>
     /// <returns><see langword="true"/> when the entry path names a known design environment; otherwise <see langword="false"/>.</returns>
+    /// <remarks>The executable name has to match a known design host exactly. A containment test reports a false
+    /// positive for every name that is a fragment of one, including the empty name a directory path yields.</remarks>
     internal static bool IsDesignEnvironmentEntry(string? entry)
     {
-        if (entry is null)
+        if (string.IsNullOrEmpty(entry))
         {
             return false;
         }
 
-        var exeName = new FileInfo(entry).Name;
+        var executableName = new FileInfo(entry).Name;
 
-        foreach (var designEnv in _designEnvironments)
+        if (executableName.Length == 0)
         {
-            if (IsDesignEnvironment(designEnv, exeName))
+            return false;
+        }
+
+        foreach (var knownHost in _designEnvironments)
+        {
+            if (string.Equals(knownHost, executableName, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
@@ -74,118 +93,85 @@ public class DefaultPlatformModeDetector : IPlatformModeDetector
         return false;
     }
 
-    /// <summary>Runs the design-mode probes in priority order and returns (and caches) the result.</summary>
-    /// <returns>A value indicating whether the application is running in design mode.</returns>
-    private static bool? DetectDesignMode()
-    {
-        if (_cachedInDesignModeResult.HasValue)
-        {
-            return _cachedInDesignModeResult.Value;
-        }
-
-        // Probe each platform in priority order; the first detected platform wins,
-        // mirroring the original else-if chain. The cached result is then reset to
-        // false below, preserving the original behaviour.
-        RunDesignModeProbes();
-
-        _cachedInDesignModeResult = false;
-
-        return _cachedInDesignModeResult;
-    }
-
-    /// <summary>Runs the platform design-mode probes in priority order.</summary>
-    /// <remarks>None of the Silverlight, WPF, or WinRT host types resolve on the supported .NET targets, so the
-    /// short-circuiting branches that fire when one of those probes reports a platform are unreachable off their
-    /// native hosts.</remarks>
-    [ExcludeFromCodeCoverage]
-    private static void RunDesignModeProbes() =>
-        _ = ProbeXamlDesignProperties()
-            || ProbeWpfDesignerProperties()
-            || ProbeWinRtDesignMode()
-            || ProbeDesignEnvironmentExecutable();
-
-    /// <summary>Probes for the Silverlight / Windows Phone 8 design-mode indicator.</summary>
-    /// <returns><see langword="true"/> if the platform was detected; otherwise <see langword="false"/>.</returns>
-    [ExcludeFromCodeCoverage] // Off-platform reflection: the Silverlight/XAML type never resolves on supported targets; only the type-null guard runs.
-    private static bool ProbeXamlDesignProperties()
-    {
-        var type = Type.GetType(XamlDesignPropertiesType, false);
-        if (type is null)
-        {
-            return false;
-        }
-
-        var methodInfo = type.GetMethod(XamlDesignPropertiesDesignModeMethodName);
-        var dependencyObject = Type.GetType(XamlControlBorderType, false);
-
-        if (methodInfo is null || dependencyObject is null)
-        {
-            return true;
-        }
-
-        _cachedInDesignModeResult = (bool)(methodInfo.Invoke(null, [Activator.CreateInstance(dependencyObject)]) ?? false);
-        return true;
-    }
-
-    /// <summary>Probes for the WPF designer design-mode indicator.</summary>
-    /// <returns><see langword="true"/> if the platform was detected; otherwise <see langword="false"/>.</returns>
-    [ExcludeFromCodeCoverage] // Off-platform reflection: the WPF type never resolves on supported targets; only the type-null guard runs.
-    private static bool ProbeWpfDesignerProperties()
-    {
-        var type = Type.GetType(WpfDesignerPropertiesType, false);
-        if (type is null)
-        {
-            return false;
-        }
-
-        var methodInfo = type.GetMethod(WpfDesignerPropertiesDesignModeMethod);
-        var dependencyObject = Type.GetType(WpfDependencyPropertyType, false);
-        if (methodInfo is null || dependencyObject is null)
-        {
-            return true;
-        }
-
-        _cachedInDesignModeResult = (bool)(methodInfo.Invoke(null, [Activator.CreateInstance(dependencyObject)]) ?? false);
-        return true;
-    }
-
-    /// <summary>Probes for the WinRT design-mode indicator.</summary>
-    /// <returns><see langword="true"/> if the platform was detected; otherwise <see langword="false"/>.</returns>
-    [ExcludeFromCodeCoverage] // Off-platform reflection: the WinRT type never resolves on supported targets; only the type-null guard runs.
-    private static bool ProbeWinRtDesignMode()
-    {
-        var type = Type.GetType(WinFormsDesignerPropertiesType, false);
-        if (type is null)
-        {
-            return false;
-        }
-
-        _cachedInDesignModeResult = (bool)(type.GetProperty(WinFormsDesignerPropertiesDesignModeMethod)?.GetMethod?.Invoke(null, null) ?? false);
-        return true;
-    }
-
-    /// <summary>Probes for a known design-environment host executable as the fallback indicator.</summary>
-    /// <returns>Always <see langword="true"/>, as this is the terminal fallback probe.</returns>
-    private static bool ProbeDesignEnvironmentExecutable()
-    {
-#if NETFRAMEWORK
-        var entry = Assembly.GetEntryAssembly()?.Location;
+    /// <summary>Runs the design-mode probes and reports whether any of them detected a designer.</summary>
+    /// <param name="hostExecutablePath">The path of the executable hosting the current process, or <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> when a designer is hosting the application; otherwise <see langword="false"/>.</returns>
+    internal static bool DetectDesignMode(string? hostExecutablePath) =>
+#if MONO
+        IsDesignEnvironmentEntry(hostExecutablePath);
 #else
-        var entry = AppContext.BaseDirectory;
+        ResolveDesignMode(ProbeWpfDesignMode(), ProbeWinRtDesignMode(), hostExecutablePath);
 #endif
-        _cachedInDesignModeResult = IsDesignEnvironmentEntry(entry);
 
-        return true;
-    }
+#if !MONO
+    /// <summary>Combines the probe results into a single answer: any probe reporting a designer wins.</summary>
+    /// <param name="wpfDesignMode">Whether the WPF probe reported a designer.</param>
+    /// <param name="winRtDesignMode">Whether the Windows Runtime probe reported a designer.</param>
+    /// <param name="hostExecutablePath">The path of the executable hosting the current process, or <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> when a designer is hosting the application; otherwise <see langword="false"/>.</returns>
+    internal static bool ResolveDesignMode(bool wpfDesignMode, bool winRtDesignMode, string? hostExecutablePath) =>
+        wpfDesignMode || winRtDesignMode || IsDesignEnvironmentEntry(hostExecutablePath);
+#endif
 
-    /// <summary>Determines whether the host executable name corresponds to a known design environment.</summary>
-    /// <param name="designEnvironment">The known design-environment executable name.</param>
-    /// <param name="exeName">The current host executable name.</param>
-    /// <returns><see langword="true"/> when the host is the supplied design environment.</returns>
-    private static bool IsDesignEnvironment(string designEnvironment, string exeName) =>
-#if NETFRAMEWORK
-        designEnvironment.IndexOf(exeName, StringComparison.InvariantCultureIgnoreCase) != -1;
+    /// <summary>Gets the memoized design-mode result. Used by test scopes.</summary>
+    /// <returns>The memoized result, or <see langword="null"/> when the probes have not run yet.</returns>
+    internal static bool? GetState() => _cachedInDesignModeResult;
+
+    /// <summary>Restores the memoized design-mode result. Used by test scopes.</summary>
+    /// <param name="state">The memoized result to restore.</param>
+    internal static void RestoreState(bool? state) => _cachedInDesignModeResult = state;
+
+    /// <summary>Discards the memoized design-mode result so the next query re-runs the probes. Used by test scopes.</summary>
+    internal static void ResetState() => _cachedInDesignModeResult = null;
+
+#if !MONO
+#if NETFRAMEWORK || WINDOWS
+    /// <summary>Reads the design-mode default that the WPF designer raises for the elements it loads.</summary>
+    /// <returns><see langword="true"/> when a XAML designer is hosting the application; otherwise <see langword="false"/>.</returns>
+    /// <remarks>The designer raises the default that <c>FrameworkElement</c> reports for the <c>IsInDesignMode</c>
+    /// attached property, which is what makes every element it loads answer <see langword="true"/>. Asking
+    /// <c>DesignerProperties.GetIsInDesignMode</c> about a freshly constructed, unparented <c>DependencyObject</c>
+    /// reads the unraised base default instead, so it answers <see langword="false"/> for any control the designer did
+    /// not set the attached property on directly - a user control nested inside another user control, for example.
+    /// Reading the metadata needs no element at all, so it also avoids creating a dispatcher-affine object.</remarks>
+    [ExcludeFromCodeCoverage] // Only a hosting designer raises this default, and the call that would simulate it mutates the property metadata for the whole process.
+    private static bool ProbeWpfDesignMode() =>
+        System.ComponentModel.DesignerProperties.IsInDesignModeProperty
+            .GetMetadata(typeof(System.Windows.FrameworkElement)).DefaultValue is true;
 #else
-        designEnvironment.Contains(exeName, StringComparison.InvariantCultureIgnoreCase);
+    /// <summary>Reads the design-mode default that the WPF designer raises, when WPF is loaded into the process.</summary>
+    /// <returns><see langword="true"/> when a XAML designer is hosting the application; otherwise <see langword="false"/>.</returns>
+    /// <remarks>The element handed to <c>GetIsInDesignMode</c> is a <c>FrameworkElement</c> rather than a bare
+    /// <c>DependencyObject</c>, because the designer raises the attached property's default for
+    /// <c>FrameworkElement</c>. A bare <c>DependencyObject</c> reads the unraised base default and therefore answers
+    /// <see langword="false"/> for any control the designer did not set the attached property on directly - a user
+    /// control nested inside another user control, for example.</remarks>
+    [ExcludeFromCodeCoverage] // Off-platform reflection: PresentationFramework only resolves inside a WPF host.
+    private static bool ProbeWpfDesignMode()
+    {
+        var designerProperties = Type.GetType(WpfDesignerPropertiesType, false);
+
+        if (designerProperties is null)
+        {
+            return false;
+        }
+
+        var designModeMethod = designerProperties.GetMethod(WpfDesignerPropertiesDesignModeMethod);
+        var frameworkElement = Type.GetType(WpfFrameworkElementType, false);
+
+        return designModeMethod is not null
+            && frameworkElement is not null
+            && designModeMethod.Invoke(null, [Activator.CreateInstance(frameworkElement)]) is true;
+    }
+#endif
+
+    /// <summary>Reads the Windows Runtime design-mode indicator, when the Windows Runtime is available.</summary>
+    /// <returns><see langword="true"/> when a Windows Runtime designer is hosting the application; otherwise <see langword="false"/>.</returns>
+    [ExcludeFromCodeCoverage] // Off-platform reflection: the Windows Runtime projection only resolves inside a Windows Runtime host.
+    private static bool ProbeWinRtDesignMode() =>
+        Type.GetType(WinRtDesignModeType, false)?
+            .GetProperty(WinRtDesignModeEnabledProperty)?
+            .GetMethod?
+            .Invoke(null, null) is true;
 #endif
 }

--- a/src/Splat.Drawing/PlatformModeDetector.cs
+++ b/src/Splat.Drawing/PlatformModeDetector.cs
@@ -55,16 +55,19 @@ public static class PlatformModeDetector
     }
 
     /// <summary>Gets the current state for test isolation. Used by test scopes.</summary>
-    /// <returns>A tuple containing the current detector and cached result.</returns>
-    internal static (IPlatformModeDetector detector, bool? cachedResult) GetState() =>
-        (Current, _cachedInDesignModeResult);
+    /// <returns>A tuple containing the current detector, the cached result, and the default detector's own cached result.</returns>
+    /// <remarks><see cref="DefaultPlatformModeDetector"/> memoizes separately, so its cache has to travel with this
+    /// state; otherwise a test that leaves a design-mode value behind there leaks into every later test.</remarks>
+    internal static (IPlatformModeDetector detector, bool? cachedResult, bool? defaultDetectorCachedResult) GetState() =>
+        (Current, _cachedInDesignModeResult, DefaultPlatformModeDetector.GetState());
 
     /// <summary>Restores the state for test isolation. Used by test scopes.</summary>
     /// <param name="state">The state to restore.</param>
-    internal static void RestoreState((IPlatformModeDetector detector, bool? cachedResult) state)
+    internal static void RestoreState((IPlatformModeDetector detector, bool? cachedResult, bool? defaultDetectorCachedResult) state)
     {
         Current = state.detector;
         _cachedInDesignModeResult = state.cachedResult;
+        DefaultPlatformModeDetector.RestoreState(state.defaultDetectorCachedResult);
     }
 
     /// <summary>Resets the state to default for test isolation. Used by test scopes.</summary>
@@ -72,5 +75,6 @@ public static class PlatformModeDetector
     {
         Current = new DefaultPlatformModeDetector();
         _cachedInDesignModeResult = null;
+        DefaultPlatformModeDetector.ResetState();
     }
 }

--- a/src/tests/Splat.Common.Test/PlatformModeDetectorScope.cs
+++ b/src/tests/Splat.Common.Test/PlatformModeDetectorScope.cs
@@ -26,13 +26,17 @@ public sealed class PlatformModeDetectorScope : IDisposable
     /// <summary>The cached platform-mode-detection result captured on construction.</summary>
     private readonly bool? _savedCachedResult;
 
+    /// <summary>The default detector's own cached design-mode result captured on construction.</summary>
+    private readonly bool? _savedDefaultDetectorCachedResult;
+
     /// <summary>Initializes a new instance of the <see cref="PlatformModeDetectorScope"/> class. Saves the current PlatformModeDetector state and resets it to default.</summary>
     public PlatformModeDetectorScope()
     {
-        (_savedDetector, _savedCachedResult) = PlatformModeDetector.GetState();
+        (_savedDetector, _savedCachedResult, _savedDefaultDetectorCachedResult) = PlatformModeDetector.GetState();
         PlatformModeDetector.ResetState();
     }
 
     /// <summary>Restores the PlatformModeDetector to its previous state.</summary>
-    public void Dispose() => PlatformModeDetector.RestoreState((_savedDetector, _savedCachedResult));
+    public void Dispose() =>
+        PlatformModeDetector.RestoreState((_savedDetector, _savedCachedResult, _savedDefaultDetectorCachedResult));
 }

--- a/src/tests/Splat.Drawing.Tests/DefaultPlatformModeDetectorCoverageTests.cs
+++ b/src/tests/Splat.Drawing.Tests/DefaultPlatformModeDetectorCoverageTests.cs
@@ -5,6 +5,7 @@
 namespace Splat.Drawing.Tests;
 
 /// <summary>Unit tests covering <see cref="DefaultPlatformModeDetector"/>.</summary>
+[NotInParallel] // Reads the memoized design-mode result, which is static state.
 public sealed class DefaultPlatformModeDetectorCoverageTests
 {
     /// <summary>An entry-point path whose executable name matches a known design-environment host.</summary>

--- a/src/tests/Splat.Drawing.Tests/DesignModeDetectionTests.cs
+++ b/src/tests/Splat.Drawing.Tests/DesignModeDetectionTests.cs
@@ -1,0 +1,139 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO;
+
+namespace Splat.Drawing.Tests;
+
+/// <summary>Unit tests covering how <see cref="DefaultPlatformModeDetector"/> decides that a designer is hosting the application.</summary>
+[NotInParallel] // Mutates the memoized design-mode result, which is static state.
+public sealed class DesignModeDetectionTests
+{
+    /// <summary>An entry-point path whose executable name matches a known design-environment host.</summary>
+    private const string DesignHostPath = "/apps/design/BLEND.EXE";
+
+    /// <summary>An entry-point path whose executable name does not match any known design environment.</summary>
+    private const string ApplicationHostPath = "/apps/myapp/MyApp.dll";
+
+    /// <summary>Verifies that a probe reporting a design environment is what the detector reports, rather than being discarded.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DetectDesignMode_WithDesignHostExecutable_ReportsDesignMode() =>
+        await Assert.That(DefaultPlatformModeDetector.DetectDesignMode(DesignHostPath)).IsTrue();
+
+    /// <summary>Verifies that an ordinary application host is not reported as a designer.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DetectDesignMode_WithApplicationExecutable_ReportsRuntime() =>
+        await Assert.That(DefaultPlatformModeDetector.DetectDesignMode(ApplicationHostPath)).IsFalse();
+
+    /// <summary>Verifies that an unavailable host path is not reported as a designer.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DetectDesignMode_WithUnavailableHostPath_ReportsRuntime() =>
+        await Assert.That(DefaultPlatformModeDetector.DetectDesignMode(null)).IsFalse();
+
+    /// <summary>Verifies that a WPF designer signal is reported even when nothing else indicates design mode.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ResolveDesignMode_WhenWpfProbeReportsDesigner_ReportsDesignMode() =>
+        await Assert.That(DefaultPlatformModeDetector.ResolveDesignMode(true, false, ApplicationHostPath)).IsTrue();
+
+    /// <summary>Verifies that a Windows Runtime designer signal is reported even when nothing else indicates design mode.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ResolveDesignMode_WhenWinRtProbeReportsDesigner_ReportsDesignMode() =>
+        await Assert.That(DefaultPlatformModeDetector.ResolveDesignMode(false, true, ApplicationHostPath)).IsTrue();
+
+    /// <summary>Verifies that the host executable decides when neither designer probe reports anything.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ResolveDesignMode_WhenNoProbeReportsDesigner_FallsBackToHostExecutable() =>
+        await Assert.That(DefaultPlatformModeDetector.ResolveDesignMode(false, false, DesignHostPath)).IsTrue();
+
+    /// <summary>Verifies that nothing indicating design mode reports a running application.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ResolveDesignMode_WhenNothingReportsDesigner_ReportsRuntime() =>
+        await Assert.That(DefaultPlatformModeDetector.ResolveDesignMode(false, false, ApplicationHostPath)).IsFalse();
+
+    /// <summary>Verifies that the design-host match ignores case, as Windows executable names do.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task IsDesignEnvironmentEntry_WithDifferentlyCasedDesignHost_IsTrue() =>
+        await Assert.That(DefaultPlatformModeDetector.IsDesignEnvironmentEntry("/apps/design/Blend.exe")).IsTrue();
+
+    /// <summary>Verifies that a directory path, which has no executable name, is not treated as a design environment.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task IsDesignEnvironmentEntry_WithDirectoryPath_IsFalse() =>
+        await Assert.That(DefaultPlatformModeDetector.IsDesignEnvironmentEntry("/apps/myapp/bin/")).IsFalse();
+
+    /// <summary>Verifies that an empty entry path is not treated as a design environment.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task IsDesignEnvironmentEntry_WithEmptyEntry_IsFalse() =>
+        await Assert.That(DefaultPlatformModeDetector.IsDesignEnvironmentEntry(string.Empty)).IsFalse();
+
+    /// <summary>Verifies that an executable whose name is merely a fragment of a design host name is not a match.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task IsDesignEnvironmentEntry_WithNameFragmentOfDesignHost_IsFalse() =>
+        await Assert.That(DefaultPlatformModeDetector.IsDesignEnvironmentEntry("/apps/myapp/END.EXE")).IsFalse();
+
+    /// <summary>Verifies that the host path names an executable file rather than the directory it lives in.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task HostExecutablePath_NamesAnExecutableFile()
+    {
+        var hostExecutablePath = DefaultPlatformModeDetector.HostExecutablePath;
+
+        await Assert.That(hostExecutablePath).IsNotNullOrEmpty();
+        await Assert.That(new FileInfo(hostExecutablePath!).Name).IsNotEmpty();
+    }
+
+    /// <summary>Verifies that the running test host is not mistaken for a design environment.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task HostExecutablePath_IsNotADesignEnvironment() =>
+        await Assert.That(DefaultPlatformModeDetector.IsDesignEnvironmentEntry(DefaultPlatformModeDetector.HostExecutablePath)).IsFalse();
+
+    /// <summary>Verifies that the detector reports the memoized result rather than re-probing.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task InDesignMode_ReportsMemoizedResult()
+    {
+        var saved = DefaultPlatformModeDetector.GetState();
+        try
+        {
+            DefaultPlatformModeDetector.RestoreState(true);
+
+            await Assert.That(new DefaultPlatformModeDetector().InDesignMode()).IsTrue();
+        }
+        finally
+        {
+            DefaultPlatformModeDetector.RestoreState(saved);
+        }
+    }
+
+    /// <summary>Verifies that discarding the memoized result makes the detector probe again.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task InDesignMode_AfterStateReset_ProbesAgain()
+    {
+        var saved = DefaultPlatformModeDetector.GetState();
+        try
+        {
+            DefaultPlatformModeDetector.RestoreState(true);
+            DefaultPlatformModeDetector.ResetState();
+
+            await Assert.That(DefaultPlatformModeDetector.GetState()).IsNull();
+            await Assert.That(new DefaultPlatformModeDetector().InDesignMode()).IsFalse();
+        }
+        finally
+        {
+            DefaultPlatformModeDetector.RestoreState(saved);
+        }
+    }
+}

--- a/src/tests/Splat.Drawing.Tests/PlatformModeDetectorCoverageTests.cs
+++ b/src/tests/Splat.Drawing.Tests/PlatformModeDetectorCoverageTests.cs
@@ -44,6 +44,33 @@ public sealed class PlatformModeDetectorCoverageTests
         }
     }
 
+    /// <summary>Verifies that a repeat query reports the memoized result instead of asking the detector again.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task InDesignMode_OnRepeatQuery_ReportsMemoizedResult()
+    {
+        var saved = PlatformModeDetector.GetState();
+        try
+        {
+            var detector = new StubModeDetector(true);
+            PlatformModeDetector.OverrideModeDetector(detector);
+
+            var first = PlatformModeDetector.InDesignMode();
+            var second = PlatformModeDetector.InDesignMode();
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(first).IsTrue();
+                await Assert.That(second).IsTrue();
+                await Assert.That(detector.QueryCount).IsEqualTo(1);
+            }
+        }
+        finally
+        {
+            PlatformModeDetector.RestoreState(saved);
+        }
+    }
+
     /// <summary>Verifies that a null design-mode result falls back to false.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]
@@ -81,11 +108,18 @@ public sealed class PlatformModeDetectorCoverageTests
         }
     }
 
-    /// <summary>A stub mode detector returning a fixed design-mode value.</summary>
+    /// <summary>A stub mode detector returning a fixed design-mode value and counting how often it was asked.</summary>
     /// <param name="result">The value to return from <see cref="StubModeDetector.InDesignMode"/>.</param>
     private sealed class StubModeDetector(bool? result) : IPlatformModeDetector
     {
+        /// <summary>Gets the number of times the detector was asked for the design-mode value.</summary>
+        public int QueryCount { get; private set; }
+
         /// <inheritdoc />
-        public bool? InDesignMode() => result;
+        public bool? InDesignMode()
+        {
+            QueryCount++;
+            return result;
+        }
     }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, plus a reflection removal.

## What is the new behavior?

- Design mode is reported from the value the designer actually raises, so a control hosted inside another control answers correctly. Closes #819.
- The target frameworks that ship the designer call it directly with no reflection, and the mobile targets compile no designer probe at all. Closes #940.

## What is the current behavior?

- The designer probe asked a freshly constructed, unparented dependency object, which never carries the attached property the designer sets, so nested user controls got the wrong answer.
- The detection result was computed and then unconditionally overwritten with false before being returned, so the probes could never affect the answer.
- The fallback probe compared against a directory rather than the host executable, so its name was empty and matched every application.
- Every target framework reached the designer through reflection, including those that cannot host a designer at all.

## What might this PR break?

- `InDesignMode()` can now return true. Code written against the previous behavior, where it always returned false, will start taking its design-time branch inside a designer.
- The probe for the Silverlight designer is gone; its assembly cannot load on any supported target framework.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

The overwrite that discarded the probe result dates back to the move of the UI code into this package, where a fallthrough default became an unconditional assignment. It was masking the directory-versus-executable defect: removing it alone would have made every application report design mode. Two of the new tests fail against the previous code for exactly that reason. The memoized result is now resettable through the existing detector state hooks, so the class is testable; both detector files reach full line and branch coverage. The nested-control behaviour itself rests on the documented metadata semantics of the designer property and has not been confirmed against a running designer.
