### PR TITLE
fix(core): confine WithResolver to the calling flow

### DIFF
--- a/src/Benchmarks/src/AppLocatorAccessBenchmarks.cs
+++ b/src/Benchmarks/src/AppLocatorAccessBenchmarks.cs
@@ -1,0 +1,134 @@
+// Copyright (c) 2025 ReactiveUI. All rights reserved.
+// Licensed to ReactiveUI under one or more agreements.
+// ReactiveUI licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace Splat.Benchmarks;
+
+/// <summary>
+/// Benchmarks for the ambient service-location entry points that sit in front of every resolution:
+/// <c>AppLocator.Current</c>, <c>AppLocator.CurrentMutable</c> and <c>AppLocator.GetLocator()</c>.
+/// The "WithinScope" variants measure the same accessors while a <c>WithResolver</c> scope is installed.
+/// </summary>
+[SimpleJob(RuntimeMoniker.Net10_0)]
+[MemoryDiagnoser]
+[MarkdownExporterAttribute.GitHub]
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Benchmarks its fine")]
+public class AppLocatorAccessBenchmarks
+{
+    private InstanceGenericFirstDependencyResolver _scopedResolver = null!;
+
+    [Params(BenchmarkConstants.LargeIterations)]
+    public int Iterations { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        AppLocator.CurrentMutable.Register(() => new ViewModel());
+
+        _scopedResolver = new InstanceGenericFirstDependencyResolver();
+        _scopedResolver.Register(() => new ViewModel());
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _scopedResolver.Dispose();
+
+    [Benchmark(Baseline = true)]
+    [BenchmarkCategory("Current")]
+    public int Current()
+    {
+        var accumulator = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            accumulator += AppLocator.Current is null ? 0 : 1;
+        }
+
+        return accumulator;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("CurrentMutable")]
+    public int CurrentMutable()
+    {
+        var accumulator = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            accumulator += AppLocator.CurrentMutable is null ? 0 : 1;
+        }
+
+        return accumulator;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("GetLocator")]
+    public int GetLocator()
+    {
+        var accumulator = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            accumulator += AppLocator.GetLocator() is null ? 0 : 1;
+        }
+
+        return accumulator;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("GetService")]
+    public int GetService()
+    {
+        var accumulator = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            accumulator += AppLocator.GetService<ViewModel>() is null ? 0 : 1;
+        }
+
+        return accumulator;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("Current", "WithinScope")]
+    public int Current_WithinResolverScope()
+    {
+        using var scope = _scopedResolver.WithResolver();
+
+        var accumulator = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            accumulator += AppLocator.Current is null ? 0 : 1;
+        }
+
+        return accumulator;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("GetService", "WithinScope")]
+    public int GetService_WithinResolverScope()
+    {
+        using var scope = _scopedResolver.WithResolver();
+
+        var accumulator = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            accumulator += AppLocator.GetService<ViewModel>() is null ? 0 : 1;
+        }
+
+        return accumulator;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory("WithResolver")]
+    public int WithResolver_EnterAndExit()
+    {
+        var accumulator = 0;
+        for (var i = 0; i < Iterations; i++)
+        {
+            using var scope = _scopedResolver.WithResolver();
+            accumulator += AppLocator.Current is null ? 0 : 1;
+        }
+
+        return accumulator;
+    }
+}

--- a/src/Splat.Core/ServiceLocation/AppLocator.cs
+++ b/src/Splat.Core/ServiceLocation/AppLocator.cs
@@ -63,14 +63,15 @@ public static class AppLocator
 
     /// <summary>Sets the dependency resolver to be used by the application.</summary>
     /// <remarks>Call this method at application startup to configure the global dependency resolver.
-    /// Subsequent calls will replace the existing resolver.</remarks>
+    /// Subsequent calls will replace the existing resolver. Inside a <c>WithResolver</c> scope the new resolver is
+    /// confined to the calling async flow and is discarded when that scope ends.</remarks>
     /// <param name="dependencyResolver">The dependency resolver instance that provides service resolution for the application. Cannot be null.</param>
     public static void SetLocator(IDependencyResolver dependencyResolver) => InternalLocator.SetLocator(dependencyResolver);
 
     /// <summary>Gets the current dependency resolver instance used by the application.</summary>
-    /// <remarks>The returned resolver provides access to registered services and dependencies. The same
-    /// instance is returned on each call. This method is intended for advanced scenarios where direct access to the
-    /// dependency resolver is required.</remarks>
+    /// <remarks>The returned resolver provides access to registered services and dependencies. Callers inside a
+    /// <c>WithResolver</c> scope get that scope's resolver; everyone else gets the process-wide one. This method is
+    /// intended for advanced scenarios where direct access to the dependency resolver is required.</remarks>
     /// <returns>An <see cref="IDependencyResolver"/> representing the application's current dependency resolver.</returns>
     [SuppressMessage("Design", "CA1024:Use properties where appropriate", Justification = "Existing API")]
     public static IDependencyResolver GetLocator() => InternalLocator.Internal;

--- a/src/Splat.Core/ServiceLocation/DependencyResolverMixins.cs
+++ b/src/Splat.Core/ServiceLocation/DependencyResolverMixins.cs
@@ -2,8 +2,6 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-using ReactiveUI.Primitives.Disposables;
-
 namespace Splat;
 
 /// <summary>
@@ -20,40 +18,32 @@ public static class DependencyResolverMixins
     extension(IDependencyResolver resolver)
     {
         /// <summary>
-        /// Temporarily replaces the current application dependency resolver with the specified resolver, restoring the
-        /// original resolver when the returned object is disposed.
+        /// Resolves through the specified resolver for the calling async flow, restoring the resolver the flow was
+        /// using when the returned object is disposed.
         /// </summary>
-        /// <remarks>Use this method to temporarily override the application's dependency resolver within a
-        /// specific scope. This is useful for testing or for scenarios where a different resolver is needed temporarily.
-        /// Ensure that the returned IDisposable is properly disposed to avoid leaving the application in an inconsistent
-        /// state.</remarks>
-        /// <returns>An IDisposable that, when disposed, restores the original dependency resolver and re-enables notifications.</returns>
+        /// <remarks>Use this method to temporarily override the dependency resolver within a specific scope. The
+        /// override travels with the async flow - across awaits and thread hops - and is invisible to every other
+        /// flow, so tests running concurrently can each hold their own resolver without interfering. Ensure that the
+        /// returned IDisposable is properly disposed to avoid leaving the flow in an inconsistent state.</remarks>
+        /// <returns>An IDisposable that, when disposed, restores the resolver the flow was previously using.</returns>
         public IDisposable WithResolver() => resolver.WithResolver(true);
 
         /// <summary>
-        /// Temporarily replaces the current application dependency resolver with the specified resolver, restoring the
-        /// original resolver when the returned object is disposed.
+        /// Resolves through the specified resolver for the calling async flow, restoring the resolver the flow was
+        /// using when the returned object is disposed.
         /// </summary>
-        /// <remarks>Use this method to temporarily override the application's dependency resolver within a
-        /// specific scope. This is useful for testing or for scenarios where a different resolver is needed temporarily.
-        /// Ensure that the returned IDisposable is properly disposed to avoid leaving the application in an inconsistent
-        /// state.</remarks>
-        /// <param name="suppressResolverCallback">true to suppress resolver callback changed notifications while the resolver is replaced; otherwise, false.</param>
-        /// <returns>An IDisposable that, when disposed, restores the original dependency resolver and re-enables notifications if
+        /// <remarks>Use this method to temporarily override the dependency resolver within a specific scope. The
+        /// override travels with the async flow - across awaits and thread hops - and is invisible to every other
+        /// flow, so tests running concurrently can each hold their own resolver without interfering. Ensure that the
+        /// returned IDisposable is properly disposed to avoid leaving the flow in an inconsistent state.</remarks>
+        /// <param name="suppressResolverCallback">true to suppress resolver callback changed notifications for the calling flow while the resolver is replaced; otherwise, false.</param>
+        /// <returns>An IDisposable that, when disposed, restores the resolver the flow was previously using and re-enables notifications if
         /// they were suppressed.</returns>
         public IDisposable WithResolver(bool suppressResolverCallback)
         {
             ArgumentExceptionHelper.ThrowIfNull(resolver);
 
-            var origResolver = AppLocator.GetLocator();
-
-            // Start suppression BEFORE changing the locator if requested.
-            var notificationDisposable = suppressResolverCallback ? AppLocator.SuppressResolverCallbackChangedNotifications() : EmptyDisposable.Instance;
-
-            // Now change the locator while suppression is active.
-            AppLocator.SetLocator(resolver);
-
-            return new MultipleDisposable(new ActionDisposable(() => AppLocator.SetLocator(origResolver)), notificationDisposable);
+            return AppLocator.InternalLocator.WithResolver(resolver, suppressResolverCallback);
         }
     }
 

--- a/src/Splat.Core/ServiceLocation/InternalLocator.cs
+++ b/src/Splat.Core/ServiceLocation/InternalLocator.cs
@@ -11,9 +11,11 @@ namespace Splat;
 /// Supports registering callbacks for resolver changes and allows controlled suppression of change notifications.
 /// </summary>
 /// <remarks>This class is intended for internal use to coordinate dependency resolution and notification logic.
-/// It enables libraries to react to resolver changes and supports isolation for testing scenarios. Thread safety is
-/// maintained for callback registration and notification suppression. Dispose the instance to release associated
-/// resources when no longer needed.</remarks>
+/// It enables libraries to react to resolver changes and supports isolation for testing scenarios. Alongside the
+/// process-wide resolver an async flow can install its own resolver through <see cref="WithResolver"/>; that override
+/// only exists for the flow that installed it, so overlapping flows never observe each other's resolver or
+/// notification suppression. Thread safety is maintained for callback registration and notification suppression.
+/// Dispose the instance to release associated resources when no longer needed.</remarks>
 internal class InternalLocator : IDisposable
 {
     /// <summary>Registration-change callbacks. A process-wide default instance is used, while still allowing isolation in unit tests.</summary>
@@ -22,8 +24,22 @@ internal class InternalLocator : IDisposable
     /// <summary>Subscription that raises registration-change notifications; disposed with this instance.</summary>
     private readonly IDisposable _resolverChangedNotification;
 
-    /// <summary>Reentrancy counter; while greater than zero, change notifications are suppressed.</summary>
+    /// <summary>The resolver installed for the calling async flow, if that flow entered a <see cref="WithResolver"/> scope.</summary>
+    private readonly AsyncLocal<ResolverOverride?> _flowOverride = new();
+
+    /// <summary>
+    /// Number of <see cref="WithResolver"/> scopes alive anywhere in the process; while zero, reads skip the flow
+    /// lookup entirely. Either stale answer is still correct: a stale zero can only be seen by a flow that installed
+    /// no scope of its own (a flow that installed one incremented before it reads), and a stale non-zero merely costs
+    /// the flow lookup, which then finds nothing.
+    /// </summary>
+    private int _flowOverrideCount;
+
+    /// <summary>Reentrancy counter; while greater than zero, change notifications are suppressed process wide.</summary>
     private int _resolverChangedNotificationSuspendCount;
+
+    /// <summary>The resolver used by every flow that has not installed one of its own.</summary>
+    private IDependencyResolver _processWide;
 
     /// <summary>Guards against running the dispose logic more than once.</summary>
     private bool _disposedValue;
@@ -31,9 +47,9 @@ internal class InternalLocator : IDisposable
     /// <summary>Initializes a new instance of the <see cref="InternalLocator"/> class.</summary>
     internal InternalLocator()
     {
-        Internal = new InstanceGenericFirstDependencyResolver();
+        _processWide = new InstanceGenericFirstDependencyResolver();
 
-        // CurrentMutable returns the non-nullable Internal resolver (set in this constructor and only ever replaced via the null-guarded SetLocator), so it is never null here.
+        // CurrentMutable returns the non-nullable process-wide resolver (set above and only ever replaced via the null-guarded SetLocator), so it is never null here.
         _resolverChangedNotification = RegisterResolverCallbackChanged(() => AppLocator.ReInit(CurrentMutable));
     }
 
@@ -55,7 +71,19 @@ internal class InternalLocator : IDisposable
     internal IMutableDependencyResolver CurrentMutable => Internal;
 
     /// <summary>Gets or sets the dependency resolver used internally by the component.</summary>
-    internal IDependencyResolver Internal { get; set; }
+    /// <value>
+    /// Reads return the resolver installed by the calling flow's <see cref="WithResolver"/> scope when there is one,
+    /// and the process-wide resolver otherwise. The setter always replaces the process-wide resolver; use
+    /// <see cref="SetLocator"/> to write through to whichever resolver the calling flow is actually using.
+    /// </value>
+    internal IDependencyResolver Internal
+    {
+        get => Volatile.Read(ref _flowOverrideCount) == 0 ? _processWide : _flowOverride.Value?.Resolver ?? _processWide;
+        set => _processWide = value;
+    }
+
+    /// <summary>Gets the resolver override installed by the calling async flow, or <c>null</c> when the flow uses the process-wide resolver.</summary>
+    private ResolverOverride? FlowOverride => Volatile.Read(ref _flowOverrideCount) == 0 ? null : _flowOverride.Value;
 
     /// <summary>Releases unmanaged and - optionally - managed resources.</summary>
     public void Dispose()
@@ -65,29 +93,50 @@ internal class InternalLocator : IDisposable
     }
 
     /// <summary>Allows setting the dependency resolver.</summary>
+    /// <remarks>When the calling flow is inside a <see cref="WithResolver"/> scope the new resolver replaces that
+    /// scope's resolver and is discarded when the scope ends; otherwise it replaces the process-wide resolver.</remarks>
     /// <param name="dependencyResolver">The dependency resolver to set.</param>
     internal void SetLocator(IDependencyResolver dependencyResolver)
     {
         ArgumentExceptionHelper.ThrowIfNull(dependencyResolver);
-        Internal = dependencyResolver;
 
-        if (!AreResolverCallbackChangedNotificationsEnabled())
+        var flowOverride = FlowOverride;
+        if (flowOverride is null)
         {
-            return;
+            _processWide = dependencyResolver;
+        }
+        else
+        {
+            flowOverride.Resolver = dependencyResolver;
         }
 
-        Action[] currentCallbacks;
-        lock (_resolverChanged)
+        NotifyResolverChanged();
+    }
+
+    /// <summary>Installs <paramref name="resolver"/> for the calling async flow until the returned scope is disposed.</summary>
+    /// <remarks>The override travels with the async flow - across awaits and thread hops - and is invisible to every
+    /// other flow, so tests running concurrently can each hold their own resolver. Scopes nest, and disposing one
+    /// restores the resolver the flow was using beforehand.</remarks>
+    /// <param name="resolver">The resolver the calling flow should resolve from. Must not be null.</param>
+    /// <param name="suppressResolverCallback">
+    /// <c>true</c> to keep resolver-changed notifications suppressed for this flow while the scope is open; otherwise
+    /// <c>false</c>, which raises them as the scope is entered and again as it is left.
+    /// </param>
+    /// <returns>A scope which, when disposed, restores the flow's previous resolver.</returns>
+    internal IDisposable WithResolver(IDependencyResolver resolver, bool suppressResolverCallback)
+    {
+        var previous = _flowOverride.Value;
+        var notificationsSuppressed = suppressResolverCallback || previous?.NotificationsSuppressed == true;
+
+        _ = Interlocked.Increment(ref _flowOverrideCount);
+        _flowOverride.Value = new(resolver, notificationsSuppressed);
+
+        if (!suppressResolverCallback)
         {
-            // NB: Prevent deadlocks should we reenter this setter from
-            // the callbacks
-            currentCallbacks = [.. _resolverChanged];
+            NotifyResolverChanged();
         }
 
-        foreach (var block in currentCallbacks)
-        {
-            block();
-        }
+        return new ResolverOverrideScope(this, previous, suppressResolverCallback);
     }
 
     /// <summary>
@@ -125,6 +174,7 @@ internal class InternalLocator : IDisposable
     }
 
     /// <summary>This method will prevent resolver changed notifications from happening until the returned <see cref="IDisposable"/> is disposed.</summary>
+    /// <remarks>Suppression requested here applies process wide; use <see cref="WithResolver"/> to confine it to the calling flow.</remarks>
     /// <returns>A disposable which when disposed will indicate the change
     /// notification is no longer needed.</returns>
     internal IDisposable SuppressResolverCallbackChangedNotifications()
@@ -136,7 +186,8 @@ internal class InternalLocator : IDisposable
 
     /// <summary>Indicates if the we are notifying external classes of updates to the resolver being changed.</summary>
     /// <returns>A value indicating whether the notifications are happening.</returns>
-    internal bool AreResolverCallbackChangedNotificationsEnabled() => Volatile.Read(ref _resolverChangedNotificationSuspendCount) == 0;
+    internal bool AreResolverCallbackChangedNotificationsEnabled() =>
+        Volatile.Read(ref _resolverChangedNotificationSuspendCount) == 0 && FlowOverride?.NotificationsSuppressed != true;
 
     /// <summary>Releases the unmanaged resources used by the object and optionally releases the managed resources.</summary>
     /// <remarks>This method is called by public Dispose methods and the finalizer. When disposing is true,
@@ -152,10 +203,73 @@ internal class InternalLocator : IDisposable
 
         if (disposing)
         {
-            Internal.Dispose();
+            _processWide.Dispose();
             _resolverChangedNotification.Dispose();
         }
 
         _disposedValue = true;
+    }
+
+    /// <summary>Runs the registered resolver-changed callbacks unless notifications are currently suppressed.</summary>
+    private void NotifyResolverChanged()
+    {
+        if (!AreResolverCallbackChangedNotificationsEnabled())
+        {
+            return;
+        }
+
+        Action[] currentCallbacks;
+        lock (_resolverChanged)
+        {
+            // NB: Prevent deadlocks should we reenter this setter from
+            // the callbacks
+            currentCallbacks = [.. _resolverChanged];
+        }
+
+        foreach (var block in currentCallbacks)
+        {
+            block();
+        }
+    }
+
+    /// <summary>The resolver, and the notification state, that one async flow is using.</summary>
+    /// <param name="resolver">The resolver the flow resolves from.</param>
+    /// <param name="notificationsSuppressed">Whether resolver-changed notifications are suppressed for the flow.</param>
+    private sealed class ResolverOverride(IDependencyResolver resolver, bool notificationsSuppressed)
+    {
+        /// <summary>Gets or sets the resolver the flow resolves from.</summary>
+        public IDependencyResolver Resolver { get; set; } = resolver;
+
+        /// <summary>Gets a value indicating whether resolver-changed notifications are suppressed for the flow.</summary>
+        public bool NotificationsSuppressed { get; } = notificationsSuppressed;
+    }
+
+    /// <summary>Restores the flow's previous resolver when disposed.</summary>
+    /// <param name="locator">The locator holding the override.</param>
+    /// <param name="previous">The override the flow had before this scope was entered, if any.</param>
+    /// <param name="suppressResolverCallback">Whether the scope was entered with resolver-changed notifications suppressed.</param>
+    private sealed class ResolverOverrideScope(InternalLocator locator, ResolverOverride? previous, bool suppressResolverCallback) : IDisposable
+    {
+        /// <summary>Non-zero once the scope has been disposed, so a second dispose is a no-op.</summary>
+        private int _disposed;
+
+        /// <summary>Restores the flow's previous resolver.</summary>
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            {
+                return;
+            }
+
+            locator._flowOverride.Value = previous;
+            _ = Interlocked.Decrement(ref locator._flowOverrideCount);
+
+            if (suppressResolverCallback)
+            {
+                return;
+            }
+
+            locator.NotifyResolverChanged();
+        }
     }
 }

--- a/src/tests/Splat.Tests/ServiceLocation/DependencyResolverMixinsTests.cs
+++ b/src/tests/Splat.Tests/ServiceLocation/DependencyResolverMixinsTests.cs
@@ -92,6 +92,51 @@ public sealed class DependencyResolverMixinsTests
         await Assert.That(callbackInvoked).IsTrue();
     }
 
+    /// <summary>Verifies that a scope nested inside a suppressed scope keeps notifications suppressed.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task WithResolver_NestedInsideASuppressedScope_StaysSuppressed()
+    {
+        var notifications = 0;
+        using var subscription = AppLocator.RegisterResolverCallbackChanged(() => notifications++);
+        notifications = 0; // Reset after the immediate registration callback.
+
+        using var outerResolver = new InstanceGenericFirstDependencyResolver();
+        using var innerResolver = new InstanceGenericFirstDependencyResolver();
+
+        using (outerResolver.WithResolver(suppressResolverCallback: true))
+        using (innerResolver.WithResolver(suppressResolverCallback: false))
+        {
+            await Assert.That(AppLocator.AreResolverCallbackChangedNotificationsEnabled()).IsFalse();
+        }
+
+        await Assert.That(notifications).IsEqualTo(0);
+    }
+
+    /// <summary>Verifies that disposing a scope twice raises the change notification only once.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task WithResolver_DisposedTwice_RaisesTheChangeNotificationOnce()
+    {
+        var notifications = 0;
+        using var subscription = AppLocator.RegisterResolverCallbackChanged(() => notifications++);
+        notifications = 0; // Reset after the immediate registration callback.
+
+        var originalResolver = AppLocator.GetLocator();
+        using var testResolver = new InstanceGenericFirstDependencyResolver();
+
+        var scope = testResolver.WithResolver(suppressResolverCallback: false);
+        scope.Dispose();
+        scope.Dispose();
+
+        const int enterAndExit = 2;
+        using (Assert.Multiple())
+        {
+            await Assert.That(notifications).IsEqualTo(enterAndExit);
+            await Assert.That(AppLocator.GetLocator()).IsSameReferenceAs(originalResolver);
+        }
+    }
+
     /// <summary>Verifies that the type-based RegisterConstant throws when the resolver is null.</summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     [Test]

--- a/src/tests/Splat.Tests/ServiceLocation/WithResolverFlowIsolationTests.cs
+++ b/src/tests/Splat.Tests/ServiceLocation/WithResolverFlowIsolationTests.cs
@@ -1,0 +1,206 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using Splat.Common.Test;
+
+namespace Splat.Tests.ServiceLocation;
+
+/// <summary>
+/// Tests that a resolver installed with <see cref="DependencyResolverMixins.WithResolver(IDependencyResolver, bool)"/>
+/// is scoped to the async flow that installed it, so overlapping flows do not observe each other's resolver or
+/// notification suppression.
+/// </summary>
+[NotInParallel]
+public sealed class WithResolverFlowIsolationTests
+{
+    /// <summary>The locator scope created for the duration of each test.</summary>
+    private AppLocatorScope? _scope;
+
+    /// <summary>Identifies which flow registered the resolved instance.</summary>
+    private interface IFlowMarker
+    {
+        /// <summary>Gets the name of the flow that registered this marker.</summary>
+        string Flow { get; }
+    }
+
+    /// <summary>Creates a fresh locator scope before each test.</summary>
+    [Before(Test)]
+    public void SetUp() => _scope = new();
+
+    /// <summary>Disposes the locator scope after each test.</summary>
+    [After(Test)]
+    public void TearDown()
+    {
+        _scope?.Dispose();
+        _scope = null;
+    }
+
+    /// <summary>Verifies that two flows whose <c>WithResolver</c> scopes overlap in time each resolve from their own resolver.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task WithResolver_WhenScopesOverlap_EachFlowResolvesFromItsOwnResolver()
+    {
+        using var firstResolver = new InstanceGenericFirstDependencyResolver();
+        firstResolver.RegisterConstant<IFlowMarker>(new FlowMarker("first"));
+
+        using var secondResolver = new InstanceGenericFirstDependencyResolver();
+        secondResolver.RegisterConstant<IFlowMarker>(new FlowMarker("second"));
+
+        using var firstScopeEntered = new SemaphoreSlim(0, 1);
+        using var secondScopeEntered = new SemaphoreSlim(0, 1);
+        using var firstFlowResolved = new SemaphoreSlim(0, 1);
+
+        async Task<string?> ResolveInFirstFlowAsync()
+        {
+            using (firstResolver.WithResolver())
+            {
+                _ = firstScopeEntered.Release();
+                await secondScopeEntered.WaitAsync();
+
+                var flow = AppLocator.Current.GetService<IFlowMarker>()?.Flow;
+                _ = firstFlowResolved.Release();
+                return flow;
+            }
+        }
+
+        async Task<string?> ResolveInSecondFlowAsync()
+        {
+            await firstScopeEntered.WaitAsync();
+
+            using (secondResolver.WithResolver())
+            {
+                _ = secondScopeEntered.Release();
+                await firstFlowResolved.WaitAsync();
+
+                return AppLocator.Current.GetService<IFlowMarker>()?.Flow;
+            }
+        }
+
+        var resolved = await Task.WhenAll(ResolveInFirstFlowAsync(), ResolveInSecondFlowAsync());
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolved[0]).IsEqualTo("first");
+            await Assert.That(resolved[1]).IsEqualTo("second");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a flow suppressing resolver-changed notifications does not suppress them for an overlapping flow
+    /// that asked for notifications to keep flowing.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task WithResolver_WhenScopesOverlap_SuppressionDoesNotLeakIntoAnotherFlow()
+    {
+        using var suppressingResolver = new InstanceGenericFirstDependencyResolver();
+        using var notifyingResolver = new InstanceGenericFirstDependencyResolver();
+
+        using var suppressingScopeEntered = new SemaphoreSlim(0, 1);
+        using var notifyingFlowObserved = new SemaphoreSlim(0, 1);
+
+        async Task<bool> ObserveWhileSuppressingAsync()
+        {
+            using (suppressingResolver.WithResolver(suppressResolverCallback: true))
+            {
+                _ = suppressingScopeEntered.Release();
+                await notifyingFlowObserved.WaitAsync();
+
+                return AppLocator.AreResolverCallbackChangedNotificationsEnabled();
+            }
+        }
+
+        async Task<bool> ObserveWhileNotifyingAsync()
+        {
+            await suppressingScopeEntered.WaitAsync();
+
+            using (notifyingResolver.WithResolver(suppressResolverCallback: false))
+            {
+                var enabled = AppLocator.AreResolverCallbackChangedNotificationsEnabled();
+                _ = notifyingFlowObserved.Release();
+                return enabled;
+            }
+        }
+
+        var observed = await Task.WhenAll(ObserveWhileSuppressingAsync(), ObserveWhileNotifyingAsync());
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(observed[0]).IsFalse();
+            await Assert.That(observed[1]).IsTrue();
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a resolver installed inside a flow is not observable from an unrelated flow, which continues to
+    /// see the process-wide resolver.
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task WithResolver_WhileScopeIsActive_UnrelatedFlowSeesTheProcessWideResolver()
+    {
+        var processWideResolver = AppLocator.GetLocator();
+
+        using var flowResolver = new InstanceGenericFirstDependencyResolver();
+
+        using var scopeEntered = new SemaphoreSlim(0, 1);
+        using var unrelatedFlowObserved = new SemaphoreSlim(0, 1);
+
+        async Task HoldScopeAsync()
+        {
+            using (flowResolver.WithResolver())
+            {
+                _ = scopeEntered.Release();
+                await unrelatedFlowObserved.WaitAsync();
+            }
+        }
+
+        async Task<IDependencyResolver> ObserveFromUnrelatedFlowAsync()
+        {
+            await scopeEntered.WaitAsync();
+
+            var observed = AppLocator.GetLocator();
+            _ = unrelatedFlowObserved.Release();
+            return observed;
+        }
+
+        var holding = HoldScopeAsync();
+        var observedResolver = await ObserveFromUnrelatedFlowAsync();
+        await holding;
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(observedResolver).IsSameReferenceAs(processWideResolver);
+            await Assert.That(AppLocator.GetLocator()).IsSameReferenceAs(processWideResolver);
+        }
+    }
+
+    /// <summary>Verifies that replacing the locator inside a scope only affects that flow and is discarded with the scope.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SetLocator_InsideAScope_IsConfinedToTheFlow()
+    {
+        var processWideResolver = AppLocator.GetLocator();
+
+        using var flowResolver = new InstanceGenericFirstDependencyResolver();
+        using var replacementResolver = new InstanceGenericFirstDependencyResolver();
+
+        using (flowResolver.WithResolver())
+        {
+            AppLocator.SetLocator(replacementResolver);
+
+            await Assert.That(AppLocator.GetLocator()).IsSameReferenceAs(replacementResolver);
+        }
+
+        await Assert.That(AppLocator.GetLocator()).IsSameReferenceAs(processWideResolver);
+    }
+
+    /// <summary>A marker naming the flow that registered it.</summary>
+    /// <param name="flow">The name of the flow that registered this marker.</param>
+    private sealed class FlowMarker(string flow) : IFlowMarker
+    {
+        /// <inheritdoc/>
+        public string Flow { get; } = flow;
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

- A resolver installed for a scope travels with the logical call context, so overlapping tests each see their own resolver and their own suppression state. Closes #382.
- The scope is cheaper than before, allocating half as much per enter and exit, and disposing it twice is harmless.

## What is the current behavior?

- The scope replaced the process-wide resolver and incremented a process-wide suppression count, so two overlapping flows interfered: one flow's outstanding suppression stopped the other's resolver from being initialized, and each disposal restored whatever resolver it captured on entry.

## What might this PR break?

- Setting the locator inside a scope is now confined to that scope rather than escaping it. Code that opened a scope and set the locator expecting the change to outlive the scope will no longer see it.
- Resolution costs slightly more; see below.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

No public API changed. Reads short-circuit on a counter of live scopes, so an application that never opens one skips the ambient lookup entirely.

Measured on a Ryzen 7 5800X, .NET 10 x64. A full `GetService<T>()` moves from 20.05 ns to between 21.1 and 21.7 ns, so 5 to 8 percent, with no new allocations on the resolve path. The bare accessor moves from 0.29 ns to about 0.57 ns. The scope itself got faster, from about 48.4 ns to between 39.6 and 45.5 ns per enter and exit, and its allocation halved from 296 to 144 bytes. The upper end of the resolve figure exceeds what the added check alone accounts for, so some of it is code layout rather than the check itself.

The three isolation tests were confirmed to fail against the previous implementation, reporting one flow resolving from another flow's resolver, a flow observing another's suppression, and an unrelated flow seeing a scoped resolver. The full solution suite passes: 19,736 tests, 4 pre-existing skips.
