### PR TITLE
fix(drawing): honour the requested size when decoding on Android and Cocoa

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,7 +18,10 @@ jobs:
       sonarProjectKey: reactiveui_splat
       sonarOrganization: reactiveui
       sonarExclusions: '**/tests/**,**/Benchmarks/**,**/benchmarks/**,**/TestResults/**'
-      sonarCoverageExclusions: '**/tests/**,**/Benchmarks/**,**/benchmarks/**,**/*Tests/**,**/*Tests.cs,**/Polyfills/**,**/Generated/**'
+      # The Android, Cocoa and .NET Framework platform folders compile only into target frameworks no
+      # test project builds, so nothing loads them on any machine or CI leg and they can never report
+      # coverage. Logic that needs covering is kept out of them.
+      sonarCoverageExclusions: '**/tests/**,**/Benchmarks/**,**/benchmarks/**,**/*Tests/**,**/*Tests.cs,**/Polyfills/**,**/Generated/**,**/Platforms/Android/**,**/Platforms/Cocoa/**,**/Platforms/net4/**'
       # *.TypedArguments.cs holds the overload matrix each logging contract dictates - one overload per
       # argument count, per level - so the repetition is the contract, not a copy that should be shared.
       sonarCpdExclusions: '**/tests/**,**/Benchmarks/**,**/benchmarks/**,**/Polyfills/**,**/*.TypedArguments.cs'

--- a/src/Splat.Drawing/Bitmaps/BitmapDecodeSize.cs
+++ b/src/Splat.Drawing/Bitmaps/BitmapDecodeSize.cs
@@ -1,0 +1,149 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Splat;
+
+/// <summary>
+/// Works out the pixel dimensions a platform decoder has to be asked for so that a caller-supplied width and height
+/// are honoured.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A requested width and height describe a box the image has to fit inside, not a shape it has to be stretched to.
+/// When both are supplied the edge that produces the smaller scale factor binds and the other edge follows from the
+/// source proportions; when one is supplied the other is derived the same way. That contract is shared by every
+/// platform loader so callers see one behaviour.
+/// </para>
+/// <para>
+/// Nothing here touches a platform imaging API, so the arithmetic is exercised directly by the tests while the
+/// platform loaders stay thin wrappers around it.
+/// </para>
+/// </remarks>
+internal static class BitmapDecodeSize
+{
+    /// <summary>The factor between one subsampling step and the next; decoders only accept powers of two.</summary>
+    private const int SubsamplingStep = 2;
+
+    /// <summary>The lowest orientation code, as recorded by an image container, that transposes the stored pixels.</summary>
+    private const int FirstTransposingOrientation = 5;
+
+    /// <summary>The highest orientation code, as recorded by an image container, that transposes the stored pixels.</summary>
+    private const int LastTransposingOrientation = 8;
+
+    /// <summary>Works out the exact pixel size to produce so the source fits the requested box without distortion.</summary>
+    /// <param name="sourceWidth">The width of the source image, in pixels.</param>
+    /// <param name="sourceHeight">The height of the source image, in pixels.</param>
+    /// <param name="desiredWidth">The requested width, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <param name="desiredHeight">The requested height, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <returns>
+    /// The dimensions to produce, or <see langword="null"/> when the image should be produced at its source size
+    /// because nothing was requested or because the source could not be measured.
+    /// </returns>
+    internal static (int Width, int Height)? ChooseFittedSize(int sourceWidth, int sourceHeight, float? desiredWidth, float? desiredHeight)
+    {
+        if (desiredWidth is null && desiredHeight is null)
+        {
+            return null;
+        }
+
+        if (Math.Min(sourceWidth, sourceHeight) <= 0)
+        {
+            return null;
+        }
+
+        var width = ToWholePixels(desiredWidth);
+        var height = ToWholePixels(desiredHeight);
+
+        // The edge that shrinks the image the most is the one that keeps all of it inside the requested box; cross
+        // multiplying compares the two scale factors without dividing.
+        return height is null || (width is { } requestedWidth && (long)requestedWidth * sourceHeight <= (long)height.Value * sourceWidth)
+            ? (width!.Value, DeriveOppositeEdge(sourceHeight, width.Value, sourceWidth))
+            : (DeriveOppositeEdge(sourceWidth, height.Value, sourceHeight), height.Value);
+    }
+
+    /// <summary>
+    /// Works out the largest power-of-two subsampling factor a decoder can apply while still producing at least the
+    /// requested dimensions.
+    /// </summary>
+    /// <remarks>
+    /// Subsampling happens inside the decode, so the full-size pixels are never materialised. It only lands on powers
+    /// of two, which is why an exact size still needs a final scale of whatever this leaves behind.
+    /// </remarks>
+    /// <param name="sourceWidth">The width of the source image, in pixels.</param>
+    /// <param name="sourceHeight">The height of the source image, in pixels.</param>
+    /// <param name="targetWidth">The width wanted from the decode, in pixels.</param>
+    /// <param name="targetHeight">The height wanted from the decode, in pixels.</param>
+    /// <returns>The subsampling factor, which is always at least one.</returns>
+    internal static int ChooseSampleSize(int sourceWidth, int sourceHeight, int targetWidth, int targetHeight)
+    {
+        if (Math.Min(sourceWidth, sourceHeight) <= 0 || Math.Min(targetWidth, targetHeight) <= 0)
+        {
+            return 1;
+        }
+
+        var sampleSize = 1;
+        while (sourceWidth / (sampleSize * SubsamplingStep) >= targetWidth
+               && sourceHeight / (sampleSize * SubsamplingStep) >= targetHeight)
+        {
+            sampleSize *= SubsamplingStep;
+        }
+
+        return sampleSize;
+    }
+
+    /// <summary>Works out the longest edge a thumbnail decoder may produce so the image fits the requested box.</summary>
+    /// <remarks>
+    /// A thumbnail decoder is constrained by a single number bounding the longer edge, and it keeps the proportions
+    /// itself, so the fitted box collapses to whichever of its edges is longer.
+    /// </remarks>
+    /// <param name="sourceWidth">The width of the source image, in pixels.</param>
+    /// <param name="sourceHeight">The height of the source image, in pixels.</param>
+    /// <param name="desiredWidth">The requested width, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <param name="desiredHeight">The requested height, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <returns>The longest permitted edge, or <see langword="null"/> when the image should be decoded at its source size.</returns>
+    internal static int? ChooseThumbnailPixelSize(int sourceWidth, int sourceHeight, float? desiredWidth, float? desiredHeight) =>
+        ChooseFittedSize(sourceWidth, sourceHeight, desiredWidth, desiredHeight) is { } fitted
+            ? Math.Max(fitted.Width, fitted.Height)
+            : null;
+
+    /// <summary>Reports the dimensions an image presents once the orientation recorded alongside its pixels is applied.</summary>
+    /// <remarks>
+    /// A container may store a photograph rotated a quarter turn and record how to put it back. A decoder that applies
+    /// that rotation hands back transposed dimensions, so the box has to be fitted against the transposed size rather
+    /// than the stored one.
+    /// </remarks>
+    /// <param name="pixelWidth">The width of the stored pixels.</param>
+    /// <param name="pixelHeight">The height of the stored pixels.</param>
+    /// <param name="orientation">The orientation code recorded by the container.</param>
+    /// <returns>The dimensions the image presents once oriented.</returns>
+    internal static (int Width, int Height) OrientedPixelSize(int pixelWidth, int pixelHeight, int orientation) =>
+        orientation is >= FirstTransposingOrientation and <= LastTransposingOrientation
+            ? (pixelHeight, pixelWidth)
+            : (pixelWidth, pixelHeight);
+
+    /// <summary>Reduces a requested edge to a whole number of pixels that a decoder can act on.</summary>
+    /// <param name="requested">The requested edge, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <returns>The edge in whole pixels, never below one, or <see langword="null"/> when nothing was requested.</returns>
+    private static int? ToWholePixels(float? requested)
+    {
+        if (requested is not { } value)
+        {
+            return null;
+        }
+
+        return value >= int.MaxValue ? int.MaxValue : Math.Max(1, (int)value);
+    }
+
+    /// <summary>Derives the edge that was not requested from the one that binds, keeping the source proportions.</summary>
+    /// <param name="sourceOppositeEdge">The source edge being derived, in pixels.</param>
+    /// <param name="boundEdge">The requested edge that binds the result, in pixels.</param>
+    /// <param name="sourceBoundEdge">The source edge matching <paramref name="boundEdge"/>, in pixels.</param>
+    /// <returns>The derived edge, in whole pixels and never below one.</returns>
+    private static int DeriveOppositeEdge(int sourceOppositeEdge, int boundEdge, int sourceBoundEdge)
+    {
+        // Rounding down keeps the result inside the requested box rather than a fraction of a pixel outside it.
+        var scaled = (long)sourceOppositeEdge * boundEdge / sourceBoundEdge;
+        return (int)Math.Min(int.MaxValue, Math.Max(1, scaled));
+    }
+}

--- a/src/Splat.Drawing/Platforms/Android/Bitmaps/PlatformBitmapLoaderHelpers.cs
+++ b/src/Splat.Drawing/Platforms/Android/Bitmaps/PlatformBitmapLoaderHelpers.cs
@@ -47,20 +47,7 @@ internal static class PlatformBitmapLoaderHelpers
             AttemptStreamByteCorrection(sourceStream, logger);
         }
 
-        sourceStream.Position = 0;
-        Bitmap? bitmap = null;
-
-        if (desiredWidth is null || desiredHeight is null)
-        {
-            bitmap = await Task.Run(() => BitmapFactory.DecodeStream(sourceStream)).ConfigureAwait(false);
-        }
-        else
-        {
-            using var opts = new BitmapFactory.Options { OutWidth = (int)desiredWidth.Value, OutHeight = (int)desiredHeight.Value };
-
-            using var noPadding = new Rect(0, 0, 0, 0);
-            bitmap = await Task.Run(() => BitmapFactory.DecodeStream(sourceStream, noPadding, opts)).ConfigureAwait(true);
-        }
+        var bitmap = await Task.Run(() => Decode(sourceStream, desiredWidth, desiredHeight)).ConfigureAwait(false);
 
         return bitmap switch
         {
@@ -131,5 +118,75 @@ internal static class PlatformBitmapLoaderHelpers
             sourceStream.Position = sourceStream.Length;
             sourceStream.Write([JpegEndOfImageMarkerByte1, JpegEndOfImageMarkerByte2]);
         }
+    }
+
+    /// <summary>Decodes the stream, shrinking the image inside the decode when a size was asked for.</summary>
+    /// <remarks>
+    /// The source dimensions are read from the header first so the decode can subsample: that keeps the full-size
+    /// pixels from ever being allocated, which is several times cheaper than decoding everything and scaling after.
+    /// Subsampling only lands on powers of two, so a final scale settles the image on the exact fitted size.
+    /// </remarks>
+    /// <param name="sourceStream">The stream to decode the bitmap from.</param>
+    /// <param name="desiredWidth">The requested width, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <param name="desiredHeight">The requested height, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <returns>The decoded bitmap, or <see langword="null"/> when the stream does not hold an image the decoder accepts.</returns>
+    private static Bitmap? Decode(Stream sourceStream, float? desiredWidth, float? desiredHeight)
+    {
+        var (sourceWidth, sourceHeight) = ReadPixelSize(sourceStream);
+
+        if (BitmapDecodeSize.ChooseFittedSize(sourceWidth, sourceHeight, desiredWidth, desiredHeight) is not { } target)
+        {
+            return DecodeStream(sourceStream, null);
+        }
+
+        var sampleSize = BitmapDecodeSize.ChooseSampleSize(sourceWidth, sourceHeight, target.Width, target.Height);
+
+        using var options = new BitmapFactory.Options { InSampleSize = sampleSize };
+
+        var decoded = DecodeStream(sourceStream, options);
+
+        return decoded is null ? null : ScaleToFittedSize(decoded, target);
+    }
+
+    /// <summary>Reads the source dimensions from the stream's header without allocating any pixels.</summary>
+    /// <param name="sourceStream">The stream to inspect.</param>
+    /// <returns>The source dimensions, which the decoder reports as non-positive when it cannot read the header.</returns>
+    private static (int Width, int Height) ReadPixelSize(Stream sourceStream)
+    {
+        using var bounds = new BitmapFactory.Options { InJustDecodeBounds = true };
+
+        // A bounds-only decode reports the dimensions through the options and hands back no bitmap.
+        DecodeStream(sourceStream, bounds)?.Dispose();
+
+        return (bounds.OutWidth, bounds.OutHeight);
+    }
+
+    /// <summary>Rewinds the stream and hands it to the decoder.</summary>
+    /// <param name="sourceStream">The stream to decode the bitmap from.</param>
+    /// <param name="options">The decoder options, or <see langword="null"/> to decode at the source size.</param>
+    /// <returns>The decoded bitmap, or <see langword="null"/> when the decoder produced none.</returns>
+    private static Bitmap? DecodeStream(Stream sourceStream, BitmapFactory.Options? options)
+    {
+        sourceStream.Position = 0;
+        return BitmapFactory.DecodeStream(sourceStream, null, options);
+    }
+
+    /// <summary>Settles a subsampled bitmap on the exact fitted size, releasing the intermediate.</summary>
+    /// <param name="decoded">The bitmap the decoder produced.</param>
+    /// <param name="target">The dimensions the caller's request works out to.</param>
+    /// <returns>The bitmap at the fitted size, or <see langword="null"/> when the scale produced none.</returns>
+    private static Bitmap? ScaleToFittedSize(Bitmap decoded, (int Width, int Height) target)
+    {
+        if (decoded.Width == target.Width && decoded.Height == target.Height)
+        {
+            return decoded;
+        }
+
+        var scaled = Bitmap.CreateScaledBitmap(decoded, target.Width, target.Height, true);
+
+        decoded.Recycle();
+        decoded.Dispose();
+
+        return scaled;
     }
 }

--- a/src/Splat.Drawing/Platforms/Cocoa/Bitmaps/PlatformBitmapLoader.cs
+++ b/src/Splat.Drawing/Platforms/Cocoa/Bitmaps/PlatformBitmapLoader.cs
@@ -2,13 +2,15 @@
 // ReactiveUI Association Incorporated licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for full license information.
 
-#if UIKIT
+using CoreGraphics;
+
 using Foundation;
 
+using ImageIO;
+
+#if UIKIT
 using UIKit;
 #else
-using Foundation;
-
 using UIImage = AppKit.NSImage;
 #endif
 
@@ -21,6 +23,18 @@ namespace Splat;
 /// implementation.</remarks>
 public class PlatformBitmapLoader : IBitmapLoader
 {
+    /// <summary>The index of the frame every load reads; only the primary image of a container is of interest.</summary>
+    private const int PrimaryImageIndex = 0;
+
+    /// <summary>The message logged when a stream does not yield an image.</summary>
+    private const string StreamFailureMessage = "Unable to parse bitmap from byte stream.";
+
+    /// <summary>The message logged when a resource does not yield an image.</summary>
+    private const string ResourceFailureMessage = "Unable to parse bitmap from resource.";
+
+    /// <summary>The message reported when the platform decoder does not hand back an image.</summary>
+    private const string DecodeFailureMessage = "Failed to load image";
+
     /// <inheritdoc />
     public Task<IBitmap?> Load(Stream sourceStream, float? desiredWidth, float? desiredHeight)
     {
@@ -28,40 +42,9 @@ public class PlatformBitmapLoader : IBitmapLoader
 
         var tcs = new TaskCompletionSource<IBitmap?>(TaskCreationOptions.RunContinuationsAsynchronously);
 #if UIKIT
-        NSRunLoop.InvokeInBackground(() =>
-        {
-            try
-            {
-                if (data is null)
-                {
-                    throw new InvalidOperationException("Failed to load stream");
-                }
-
-                var bitmap = UIImage.LoadFromData(data) ?? throw new InvalidOperationException("Failed to load image");
-                _ = tcs.TrySetResult(new CocoaBitmap(bitmap));
-            }
-            catch (Exception ex)
-            {
-                LogHost.Default.Debug(ex, "Unable to parse bitmap from byte stream.");
-                _ = tcs.TrySetException(ex);
-            }
-        });
+        NSRunLoop.InvokeInBackground(() => Publish(tcs, () => DecodeData(data, desiredWidth, desiredHeight), StreamFailureMessage));
 #else
-
-        try
-        {
-            if (data is null)
-            {
-                throw new InvalidOperationException("Failed to load stream");
-            }
-
-            _ = tcs.TrySetResult(new CocoaBitmap(new(data)));
-        }
-        catch (Exception ex)
-        {
-            LogHost.Default.Debug(ex, "Unable to parse bitmap from byte stream.");
-            _ = tcs.TrySetException(ex);
-        }
+        Publish(tcs, () => DecodeData(data, desiredWidth, desiredHeight), StreamFailureMessage);
 #endif
 
         return tcs.Task;
@@ -73,37 +56,163 @@ public class PlatformBitmapLoader : IBitmapLoader
         var tcs = new TaskCompletionSource<IBitmap?>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 #if UIKIT
-        NSRunLoop.InvokeInBackground(() =>
-        {
-            try
-            {
-                var bitmap = UIImage.FromBundle(source) ?? throw new InvalidOperationException($"Failed to load image from resource: {source}");
-                _ = tcs.TrySetResult(new CocoaBitmap(bitmap));
-            }
-            catch (Exception ex)
-            {
-                LogHost.Default.Debug(ex, "Unable to parse bitmap from resource.");
-                _ = tcs.TrySetException(ex);
-            }
-        });
+        NSRunLoop.InvokeInBackground(() => Publish(tcs, () => DecodeResource(source, desiredWidth, desiredHeight), ResourceFailureMessage));
 #else
-        NSRunLoop.Main.BeginInvokeOnMainThread(() =>
-        {
-            try
-            {
-                var bitmap = UIImage.ImageNamed(source) ?? throw new InvalidOperationException($"Failed to load image from resource: {source}");
-                _ = tcs.TrySetResult(new CocoaBitmap(bitmap));
-            }
-            catch (Exception ex)
-            {
-                LogHost.Default.Debug(ex, "Unable to parse bitmap from resource.");
-                _ = tcs.TrySetException(ex);
-            }
-        });
+        NSRunLoop.Main.BeginInvokeOnMainThread(() => Publish(tcs, () => DecodeResource(source, desiredWidth, desiredHeight), ResourceFailureMessage));
 #endif
         return tcs.Task;
     }
 
     /// <inheritdoc />
     public IBitmap Create(float width, float height) => throw new NotSupportedException("Creating an empty bitmap is not supported by the Cocoa platform bitmap loader.");
+
+    /// <summary>Runs a decode and hands its outcome, successful or not, to the awaiting caller.</summary>
+    /// <param name="completion">The completion source the caller is awaiting.</param>
+    /// <param name="decode">The decode to run.</param>
+    /// <param name="failureMessage">The message to log if the decode throws.</param>
+    private static void Publish(TaskCompletionSource<IBitmap?> completion, Func<UIImage> decode, string failureMessage)
+    {
+        try
+        {
+            _ = completion.TrySetResult(new CocoaBitmap(decode()));
+        }
+        catch (Exception ex)
+        {
+            LogHost.Default.Debug(ex, failureMessage);
+            _ = completion.TrySetException(ex);
+        }
+    }
+
+    /// <summary>Decodes image data, shrinking it inside the decode when a size was asked for.</summary>
+    /// <param name="data">The encoded image, or <see langword="null"/> when the stream could not be read.</param>
+    /// <param name="desiredWidth">The requested width, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <param name="desiredHeight">The requested height, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <returns>The decoded image.</returns>
+    private static UIImage DecodeData(NSData? data, float? desiredWidth, float? desiredHeight)
+    {
+        if (data is null)
+        {
+            throw new InvalidOperationException("Failed to load stream");
+        }
+
+        if (desiredWidth is null && desiredHeight is null)
+        {
+#if UIKIT
+            return UIImage.LoadFromData(data) ?? throw new InvalidOperationException(DecodeFailureMessage);
+#else
+            return new(data);
+#endif
+        }
+
+        using var imageSource = CGImageSource.FromData(data) ?? throw new InvalidOperationException(DecodeFailureMessage);
+
+        return DecodeAtSize(imageSource, desiredWidth, desiredHeight);
+    }
+
+    /// <summary>Decodes a bundled image, shrinking it inside the decode when the bundle exposes it as a file.</summary>
+    /// <remarks>
+    /// An image the bundle only offers through its asset catalogue has no file to read a header from, so it is loaded
+    /// by name at its natural size; everything else goes through the scaling decoder.
+    /// </remarks>
+    /// <param name="source">The resource to load, as a relative path or a resource name.</param>
+    /// <param name="desiredWidth">The requested width, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <param name="desiredHeight">The requested height, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <returns>The decoded image.</returns>
+    private static UIImage DecodeResource(string source, float? desiredWidth, float? desiredHeight)
+    {
+        if (desiredWidth is not null || desiredHeight is not null)
+        {
+            using var imageSource = OpenBundleResource(source);
+
+            if (imageSource is not null)
+            {
+                return DecodeAtSize(imageSource, desiredWidth, desiredHeight);
+            }
+        }
+
+#if UIKIT
+        return UIImage.FromBundle(source) ?? throw new InvalidOperationException($"Failed to load image from resource: {source}");
+#else
+        return UIImage.ImageNamed(source) ?? throw new InvalidOperationException($"Failed to load image from resource: {source}");
+#endif
+    }
+
+    /// <summary>Opens a bundled resource for decoding when the bundle exposes it as a file.</summary>
+    /// <param name="source">The resource to load, as a relative path or a resource name.</param>
+    /// <returns>The opened image, or <see langword="null"/> when the bundle has no file for the resource.</returns>
+    private static CGImageSource? OpenBundleResource(string source)
+    {
+        var url = NSBundle.MainBundle.GetUrlForResource(
+            Path.GetFileNameWithoutExtension(source),
+            Path.GetExtension(source).TrimStart('.'));
+
+        return url is null ? null : CGImageSource.FromUrl(url);
+    }
+
+    /// <summary>Decodes an image down to the size the caller's request works out to.</summary>
+    /// <remarks>
+    /// The thumbnail decoder reads the header, then produces only the pixels that survive the requested bound, so the
+    /// full-size image is never materialised. It keeps the proportions itself, which is why a single bound expresses
+    /// the whole request.
+    /// </remarks>
+    /// <param name="imageSource">The opened image to decode.</param>
+    /// <param name="desiredWidth">The requested width, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <param name="desiredHeight">The requested height, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <returns>The decoded image.</returns>
+    private static UIImage DecodeAtSize(CGImageSource imageSource, float? desiredWidth, float? desiredHeight)
+    {
+        var (sourceWidth, sourceHeight) = ReadPixelSize(imageSource);
+
+        return FromCoreGraphics(
+            BitmapDecodeSize.ChooseThumbnailPixelSize(sourceWidth, sourceHeight, desiredWidth, desiredHeight) is { } maxPixelSize
+                ? imageSource.CreateThumbnail(PrimaryImageIndex, ThumbnailOptions(maxPixelSize))
+                : imageSource.CreateImage(PrimaryImageIndex, new()));
+    }
+
+    /// <summary>Builds the instruction that bounds a thumbnail decode.</summary>
+    /// <remarks>
+    /// The decoder is told to build the thumbnail from the image itself rather than reuse one the container happens
+    /// to embed, which would be whatever size its author chose, and to apply the recorded orientation.
+    /// </remarks>
+    /// <param name="maxPixelSize">The longest edge the decoder may produce, in pixels.</param>
+    /// <returns>The decoder options.</returns>
+    private static CGImageThumbnailOptions ThumbnailOptions(int maxPixelSize) =>
+        new() { CreateThumbnailFromImageAlways = true, CreateThumbnailWithTransform = true, MaxPixelSize = maxPixelSize };
+
+    /// <summary>Reads the dimensions an image presents, from its header rather than its pixels.</summary>
+    /// <param name="imageSource">The opened image to inspect.</param>
+    /// <returns>The dimensions, which are non-positive when the header could not be read.</returns>
+    private static (int Width, int Height) ReadPixelSize(CGImageSource imageSource)
+    {
+        var properties = imageSource.GetProperties(PrimaryImageIndex);
+
+        // The decoder is asked to apply the recorded orientation, so a quarter-turned photograph comes back with its
+        // stored dimensions transposed and the box has to be fitted against that.
+        return BitmapDecodeSize.OrientedPixelSize(
+            properties?.PixelWidth ?? 0,
+            properties?.PixelHeight ?? 0,
+            (int)(properties?.Orientation ?? 0));
+    }
+
+    /// <summary>Wraps a decoded Core Graphics image in the platform's image type.</summary>
+    /// <param name="image">The decoded image, or <see langword="null"/> when the decoder produced none.</param>
+    /// <returns>The platform image.</returns>
+    private static UIImage FromCoreGraphics(CGImage? image)
+    {
+        if (image is null)
+        {
+            throw new InvalidOperationException(DecodeFailureMessage);
+        }
+
+        // The platform image retains the Core Graphics image, so this reference to it is finished with either way.
+        using (image)
+        {
+#if UIKIT
+            return new(image);
+#else
+            // An empty size tells the image to take the dimensions of the pixels it was handed.
+            return new(image, CGSize.Empty);
+#endif
+        }
+    }
 }

--- a/src/tests/Splat.Drawing.Tests/BitmapDecodeSizeCalculationTests.cs
+++ b/src/tests/Splat.Drawing.Tests/BitmapDecodeSizeCalculationTests.cs
@@ -1,0 +1,279 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+namespace Splat.Tests;
+
+/// <summary>Verifies the dimensions worked out for a caller who asks for a bitmap at a particular size.</summary>
+/// <remarks>
+/// The platform loaders each hand a decoder a different kind of instruction - a subsampling factor here, a bound on
+/// the longer edge there - but all of them derive it from this arithmetic, so pinning it down here pins down the
+/// behaviour on platforms whose decoders cannot be run in a test.
+/// </remarks>
+public sealed class BitmapDecodeSizeCalculationTests
+{
+    /// <summary>The width, in pixels, of the landscape source image the calculations are made against.</summary>
+    private const int LandscapeWidth = 4000;
+
+    /// <summary>The height, in pixels, of the landscape source image the calculations are made against.</summary>
+    private const int LandscapeHeight = 2000;
+
+    /// <summary>The edge, in pixels, of the square box the image is asked to fit inside.</summary>
+    private const int BoxEdge = 200;
+
+    /// <summary>Half the box edge; the landscape source fitted to <see cref="BoxEdge"/> lands on this height.</summary>
+    private const int HalfBoxEdge = 100;
+
+    /// <summary>A width that matches the landscape source proportions when paired with <see cref="BoxEdge"/>.</summary>
+    private const int AspectMatchingWidth = 400;
+
+    /// <summary>A request smaller than a single pixel, used to check the lower clamp.</summary>
+    private const float SubPixelWidth = 0.4F;
+
+    /// <summary>The smallest image a decoder can be asked for.</summary>
+    private const int SinglePixel = 1;
+
+    /// <summary>A requested height taller than the box is wide, so the height is what stops the subsampling.</summary>
+    private const int TallBoxHeight = 1000;
+
+    /// <summary>The subsampling factor for a box twenty times smaller than the source in both directions.</summary>
+    private const int TwentyFoldSampleSize = 16;
+
+    /// <summary>The subsampling factor for a request whose height leaves only one step of headroom.</summary>
+    private const int SingleStepSampleSize = 2;
+
+    /// <summary>The subsampling factor that keeps every pixel the decoder reads.</summary>
+    private const int NoSubsampling = 1;
+
+    /// <summary>An orientation code for pixels stored the way they are meant to be shown.</summary>
+    private const int UprightOrientation = 1;
+
+    /// <summary>An orientation code for pixels stored a quarter turn away from how they are meant to be shown.</summary>
+    private const int QuarterTurnedOrientation = 6;
+
+    /// <summary>An orientation code past the ones a container can record.</summary>
+    private const int OrientationPastTheKnownCodes = 9;
+
+    /// <summary>A degenerate source dimension, as a decoder reports when it cannot read a header.</summary>
+    private const int Unmeasurable = 0;
+
+    /// <summary>
+    /// The height derived for a landscape source whose requested width was capped at the largest addressable one;
+    /// the source is twice as wide as it is tall, so the height comes out at half the cap.
+    /// </summary>
+    private const int HalfTheLargestPixelCount = int.MaxValue / 2;
+
+    /// <summary>Verifies an unconstrained request leaves the image at its source size.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task NeitherDimensionRequested_LeavesTheSourceSize()
+    {
+        var fitted = BitmapDecodeSize.ChooseFittedSize(LandscapeWidth, LandscapeHeight, null, null);
+
+        await Assert.That(fitted).IsNull();
+    }
+
+    /// <summary>Verifies a source whose header could not be read is left at its source size.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task UnmeasurableSource_LeavesTheSourceSize()
+    {
+        var fitted = BitmapDecodeSize.ChooseFittedSize(Unmeasurable, Unmeasurable, BoxEdge, BoxEdge);
+
+        await Assert.That(fitted).IsNull();
+    }
+
+    /// <summary>Verifies a width-only request derives the height from the source proportions.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task WidthOnly_DerivesTheHeight()
+    {
+        var fitted = BitmapDecodeSize.ChooseFittedSize(LandscapeWidth, LandscapeHeight, BoxEdge, null);
+
+        await Assert.That(fitted).IsEqualTo((BoxEdge, HalfBoxEdge));
+    }
+
+    /// <summary>Verifies a height-only request derives the width from the source proportions.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task HeightOnly_DerivesTheWidth()
+    {
+        var fitted = BitmapDecodeSize.ChooseFittedSize(LandscapeWidth, LandscapeHeight, null, BoxEdge);
+
+        await Assert.That(fitted).IsEqualTo((AspectMatchingWidth, BoxEdge));
+    }
+
+    /// <summary>Verifies a source wider than the requested box is bound by its width, not stretched to both edges.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SourceWiderThanTheBox_IsBoundByWidth()
+    {
+        // 4000x2000 into a 200x200 box: the width scales by 0.05 and the height by 0.1, so the width binds and the
+        // derived height lands on 100, inside the box.
+        var fitted = BitmapDecodeSize.ChooseFittedSize(LandscapeWidth, LandscapeHeight, BoxEdge, BoxEdge);
+
+        await Assert.That(fitted).IsEqualTo((BoxEdge, HalfBoxEdge));
+    }
+
+    /// <summary>Verifies a source taller than the requested box is bound by its height.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SourceTallerThanTheBox_IsBoundByHeight()
+    {
+        // The portrait source is the landscape one rotated, so the height binds instead.
+        var fitted = BitmapDecodeSize.ChooseFittedSize(LandscapeHeight, LandscapeWidth, BoxEdge, BoxEdge);
+
+        await Assert.That(fitted).IsEqualTo((HalfBoxEdge, BoxEdge));
+    }
+
+    /// <summary>Verifies a request matching the source proportions reaches both requested edges exactly.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task RequestMatchingTheSourceProportions_ReachesBothEdges()
+    {
+        var fitted = BitmapDecodeSize.ChooseFittedSize(LandscapeWidth, LandscapeHeight, AspectMatchingWidth, BoxEdge);
+
+        await Assert.That(fitted).IsEqualTo((AspectMatchingWidth, BoxEdge));
+    }
+
+    /// <summary>Verifies a request smaller than a pixel still leaves an image a decoder can produce.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task RequestSmallerThanAPixel_LeavesASinglePixel()
+    {
+        var fitted = BitmapDecodeSize.ChooseFittedSize(LandscapeWidth, LandscapeHeight, SubPixelWidth, null);
+
+        await Assert.That(fitted).IsEqualTo((SinglePixel, SinglePixel));
+    }
+
+    /// <summary>Verifies a request larger than any addressable image is capped rather than wrapping round.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task RequestLargerThanAnyAddressableImage_IsCapped()
+    {
+        var fitted = BitmapDecodeSize.ChooseFittedSize(LandscapeWidth, LandscapeHeight, float.MaxValue, null);
+
+        await Assert.That(fitted).IsEqualTo((int.MaxValue, HalfTheLargestPixelCount));
+    }
+
+    /// <summary>Verifies a derived edge larger than any addressable image is capped as well.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task DerivedEdgeLargerThanAnyAddressableImage_IsCapped()
+    {
+        var fitted = BitmapDecodeSize.ChooseFittedSize(LandscapeHeight, LandscapeWidth, float.MaxValue, null);
+
+        await Assert.That(fitted).IsEqualTo((int.MaxValue, int.MaxValue));
+    }
+
+    /// <summary>Verifies a source whose header could not be read is decoded without subsampling.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubsamplingAnUnmeasurableSource_KeepsEveryPixel()
+    {
+        var sampleSize = BitmapDecodeSize.ChooseSampleSize(Unmeasurable, Unmeasurable, BoxEdge, HalfBoxEdge);
+
+        await Assert.That(sampleSize).IsEqualTo(NoSubsampling);
+    }
+
+    /// <summary>Verifies an empty target size is decoded without subsampling rather than sampled without end.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubsamplingToAnEmptyTarget_KeepsEveryPixel()
+    {
+        var sampleSize = BitmapDecodeSize.ChooseSampleSize(LandscapeWidth, LandscapeHeight, Unmeasurable, Unmeasurable);
+
+        await Assert.That(sampleSize).IsEqualTo(NoSubsampling);
+    }
+
+    /// <summary>Verifies a target far below the source is reached by repeated halving, stopping before it undershoots.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubsamplingToAMuchSmallerTarget_HalvesUntilAFurtherStepWouldUndershoot()
+    {
+        // Halving 4000x2000 five times would leave 125x62, below the requested 200x100, so it stops at four.
+        var sampleSize = BitmapDecodeSize.ChooseSampleSize(LandscapeWidth, LandscapeHeight, BoxEdge, HalfBoxEdge);
+
+        await Assert.That(sampleSize).IsEqualTo(TwentyFoldSampleSize);
+    }
+
+    /// <summary>Verifies the height stops the halving when it runs out of room before the width does.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubsamplingToATargetBoundByHeight_StopsOnTheHeight()
+    {
+        var sampleSize = BitmapDecodeSize.ChooseSampleSize(LandscapeWidth, LandscapeHeight, HalfBoxEdge, TallBoxHeight);
+
+        await Assert.That(sampleSize).IsEqualTo(SingleStepSampleSize);
+    }
+
+    /// <summary>Verifies a target at the source size is decoded without subsampling.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task SubsamplingToTheSourceSize_KeepsEveryPixel()
+    {
+        var sampleSize = BitmapDecodeSize.ChooseSampleSize(LandscapeWidth, LandscapeHeight, LandscapeWidth, LandscapeHeight);
+
+        await Assert.That(sampleSize).IsEqualTo(NoSubsampling);
+    }
+
+    /// <summary>Verifies an unconstrained request leaves a thumbnail decoder unbounded.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ThumbnailWithNoRequestedSize_IsUnbounded()
+    {
+        var maxPixelSize = BitmapDecodeSize.ChooseThumbnailPixelSize(LandscapeWidth, LandscapeHeight, null, null);
+
+        await Assert.That(maxPixelSize).IsNull();
+    }
+
+    /// <summary>Verifies a thumbnail of a landscape source is bounded by the fitted width.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ThumbnailOfALandscapeSource_IsBoundedByTheFittedWidth()
+    {
+        var maxPixelSize = BitmapDecodeSize.ChooseThumbnailPixelSize(LandscapeWidth, LandscapeHeight, BoxEdge, BoxEdge);
+
+        await Assert.That(maxPixelSize).IsEqualTo(BoxEdge);
+    }
+
+    /// <summary>Verifies a thumbnail of a portrait source is bounded by the fitted height.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ThumbnailOfAPortraitSource_IsBoundedByTheFittedHeight()
+    {
+        var maxPixelSize = BitmapDecodeSize.ChooseThumbnailPixelSize(LandscapeHeight, LandscapeWidth, BoxEdge, BoxEdge);
+
+        await Assert.That(maxPixelSize).IsEqualTo(BoxEdge);
+    }
+
+    /// <summary>Verifies pixels stored the way they are shown keep their dimensions.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task UprightPixels_KeepTheirDimensions()
+    {
+        var oriented = BitmapDecodeSize.OrientedPixelSize(LandscapeWidth, LandscapeHeight, UprightOrientation);
+
+        await Assert.That(oriented).IsEqualTo((LandscapeWidth, LandscapeHeight));
+    }
+
+    /// <summary>Verifies pixels stored a quarter turn away are measured the way they will be shown.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task QuarterTurnedPixels_AreTransposed()
+    {
+        var oriented = BitmapDecodeSize.OrientedPixelSize(LandscapeWidth, LandscapeHeight, QuarterTurnedOrientation);
+
+        await Assert.That(oriented).IsEqualTo((LandscapeHeight, LandscapeWidth));
+    }
+
+    /// <summary>Verifies an orientation nobody records leaves the stored dimensions alone.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task PixelsWithAnUnrecognisedOrientation_KeepTheirDimensions()
+    {
+        var oriented = BitmapDecodeSize.OrientedPixelSize(LandscapeWidth, LandscapeHeight, OrientationPastTheKnownCodes);
+
+        await Assert.That(oriented).IsEqualTo((LandscapeWidth, LandscapeHeight));
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the new behavior?

- Android and Cocoa honour the requested size. Android reads the header first, subsamples the decode to the nearest power of two, and only scales afterwards when the result is not already the requested size. Cocoa decodes through the imaging framework's thumbnail path, which scales during the decode rather than after it. Closes #419.
- A request that names both dimensions fits inside that box without distorting the image, matching the behavior the desktop loader now has.

## What is the current behavior?

- Android passed the requested size through the two fields the decoder writes its findings into, so the decoder ignored them and always returned the image at its original size.
- Cocoa named the requested dimensions in its signatures and never read them.

## What might this PR break?

- Both platforms now return a smaller image where they previously returned the original. Code that asked for a size and silently relied on getting the full-size image will see the size it asked for.
- A request whose proportions differ from the source now returns the largest undistorted image that fits, rather than the source size.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [ ] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

The size arithmetic is extracted into a type with no platform dependency, so it is unit tested on the desktop targets. This matters because the test project targets neither Android nor Apple, so nothing in those platform folders is executed by any test on any machine or in CI, which is how this survived since 2019. The extracted type is at 100% of lines and branches with no exclusions; what remains in the platform files is decoder plumbing.

Verified: the solution builds clean, both Android targets rebuild clean, 6,312 tests pass, and all eight Apple targets compile on a Windows host. Neither platform can be executed here, so both are compile-verified only.

Note for whoever merges second: this and the desktop decode-size fix each carry their own fitted-box arithmetic. They agree on the contract and do not conflict, but the desktop loader should move onto the shared helper once both have landed.
