### PR TITLE
feat(skiasharp): add a Skia bitmap loader package

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -28,6 +28,9 @@
     <PackageVersion Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.31.0.145097" />
     <PackageVersion Include="SimpleInjector" Version="5.6.0" />
+    <PackageVersion Include="SkiaSharp" Version="4.151.0" />
+    <!-- SkiaSharp brings only the macOS and Win32 native assets on the plain .NET target frameworks. -->
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="4.151.0" />
     <!-- StyleSharp.Analyzers, PerformanceSharp.Analyzers and SecuritySharp.Analyzers ship from the
          same release pipeline and always share a version. -->
     <PackageVersion Include="StyleSharp.Analyzers" Version="3.40.1" />

--- a/src/Splat.SkiaSharp/BitmapMixins.cs
+++ b/src/Splat.SkiaSharp/BitmapMixins.cs
@@ -1,0 +1,40 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using SkiaSharp;
+
+namespace Splat.SkiaSharp;
+
+/// <summary>Converts between <see cref="IBitmap"/> and the Skia bitmap behind it.</summary>
+/// <remarks>
+/// Skia is not the host's imaging stack, and these conversions do not pretend otherwise: what comes
+/// back is an <see cref="SKBitmap"/>, not a platform bitmap type.
+/// </remarks>
+public static class BitmapMixins
+{
+    /// <summary>Extension members for <see cref="IBitmap"/>.</summary>
+    /// <param name="value">The value the extension members operate on.</param>
+    extension(IBitmap value)
+    {
+        /// <summary>Gets the Skia bitmap behind an <see cref="IBitmap"/> this package produced.</summary>
+        /// <returns>The Skia bitmap, which the <see cref="IBitmap"/> still owns.</returns>
+        /// <exception cref="InvalidOperationException">The bitmap has been disposed.</exception>
+        /// <exception cref="InvalidCastException">The bitmap came from a different loader.</exception>
+        public SKBitmap ToNative()
+        {
+            ArgumentExceptionHelper.ThrowIfNull(value);
+
+            return ((SkiaBitmap)value).Inner ?? throw new InvalidOperationException("The bitmap has been disposed");
+        }
+    }
+
+    /// <summary>Extension members for <see cref="SKBitmap"/>.</summary>
+    /// <param name="value">The value the extension members operate on.</param>
+    extension(SKBitmap value)
+    {
+        /// <summary>Wraps a Skia bitmap as an <see cref="IBitmap"/>, taking ownership of it.</summary>
+        /// <returns>The wrapped bitmap.</returns>
+        public IBitmap FromNative() => new SkiaBitmap(value);
+    }
+}

--- a/src/Splat.SkiaSharp/Builder/SkiaSharpSplatModule.cs
+++ b/src/Splat.SkiaSharp/Builder/SkiaSharpSplatModule.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using SkiaSharp;
+
+using Splat.SkiaSharp;
+
+namespace Splat.Builder;
+
+/// <summary>Registers Skia as the bitmap loader when the application is built.</summary>
+/// <remarks>
+/// Registration is a plain method call rather than assembly scanning, so it survives trimming and
+/// ahead-of-time compilation.
+/// </remarks>
+/// <param name="sampling">The sampling to resize with, or <see langword="null"/> for the loader's default.</param>
+public sealed class SkiaSharpSplatModule(SKSamplingOptions? sampling) : IModule
+{
+    /// <summary>Initializes a new instance of the <see cref="SkiaSharpSplatModule"/> class.</summary>
+    public SkiaSharpSplatModule()
+        : this(null)
+    {
+    }
+
+    /// <inheritdoc />
+    public void Configure(IMutableDependencyResolver resolver)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(resolver);
+
+        if (sampling is null)
+        {
+            resolver.UseSkiaSharpBitmapLoader();
+            return;
+        }
+
+        resolver.UseSkiaSharpBitmapLoader(sampling.Value);
+    }
+}

--- a/src/Splat.SkiaSharp/MutableDependencyResolverExtensions.cs
+++ b/src/Splat.SkiaSharp/MutableDependencyResolverExtensions.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using SkiaSharp;
+
+namespace Splat.SkiaSharp;
+
+/// <summary>Registers Skia as the bitmap loader Splat resolves.</summary>
+/// <remarks>
+/// The plain .NET target frameworks register no bitmap loader of their own, so <see cref="BitmapLoader.Current"/>
+/// throws until something is registered. Registration is explicit: nothing scans assemblies for it.
+/// </remarks>
+public static class MutableDependencyResolverExtensions
+{
+    /// <summary>Extension members for <see cref="IMutableDependencyResolver"/>.</summary>
+    /// <param name="instance">An instance of Mutable Dependency Resolver.</param>
+    extension(IMutableDependencyResolver instance)
+    {
+        /// <summary>Registers <see cref="SkiaBitmapLoader"/> as the <see cref="IBitmapLoader"/>.</summary>
+        /// <example>
+        /// <c>AppLocator.CurrentMutable.UseSkiaSharpBitmapLoader();</c>
+        /// </example>
+        public void UseSkiaSharpBitmapLoader()
+        {
+            ArgumentExceptionHelper.ThrowIfNull(instance);
+
+            instance.RegisterLazySingleton(static () => new SkiaBitmapLoader(), typeof(IBitmapLoader));
+        }
+
+        /// <summary>Registers <see cref="SkiaBitmapLoader"/> as the <see cref="IBitmapLoader"/>, resizing with the given sampling.</summary>
+        /// <param name="sampling">The sampling to resize with.</param>
+        /// <example>
+        /// <c>AppLocator.CurrentMutable.UseSkiaSharpBitmapLoader(new SKSamplingOptions(SKFilterMode.Nearest));</c>
+        /// </example>
+        public void UseSkiaSharpBitmapLoader(SKSamplingOptions sampling)
+        {
+            ArgumentExceptionHelper.ThrowIfNull(instance);
+
+            instance.RegisterLazySingleton(() => new SkiaBitmapLoader(sampling), typeof(IBitmapLoader));
+        }
+    }
+}

--- a/src/Splat.SkiaSharp/PublicAPI/net10.0/PublicAPI.txt
+++ b/src/Splat.SkiaSharp/PublicAPI/net10.0/PublicAPI.txt
@@ -1,0 +1,53 @@
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.SkiaSharp.Tests")]
+namespace Splat.Builder
+{
+    public sealed class SkiaSharpSplatModule : Splat.Builder.IModule
+    {
+        public SkiaSharpSplatModule() { }
+        public SkiaSharpSplatModule(SkiaSharp.SKSamplingOptions? sampling) { }
+        public void Configure(Splat.IMutableDependencyResolver resolver) { }
+    }
+}
+namespace Splat.SkiaSharp
+{
+    public static class BitmapMixins
+    {
+        extension(SkiaSharp.SKBitmap value)
+        {
+            public Splat.IBitmap FromNative() { }
+        }
+        extension(Splat.IBitmap value)
+        {
+            public SkiaSharp.SKBitmap ToNative() { }
+        }
+    }
+    public static class MutableDependencyResolverExtensions
+    {
+        extension(Splat.IMutableDependencyResolver instance)
+        {
+            public void UseSkiaSharpBitmapLoader() { }
+            public void UseSkiaSharpBitmapLoader(SkiaSharp.SKSamplingOptions sampling) { }
+        }
+    }
+    public sealed class SkiaBitmap : Splat.IBitmap
+    {
+        public SkiaBitmap(SkiaSharp.SKBitmap bitmap) { }
+        public SkiaBitmap(SkiaSharp.SKBitmap bitmap, SkiaSharp.SKEncodedOrigin encodedOrigin) { }
+        public SkiaSharp.SKEncodedOrigin EncodedOrigin { get; }
+        public float Height { get; }
+        public SkiaSharp.SKBitmap? Inner { get; }
+        public float Width { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task Save(SkiaSharp.SKEncodedImageFormat format, float quality, System.IO.Stream target) { }
+        public System.Threading.Tasks.Task Save(Splat.CompressedBitmapFormat format, float quality, System.IO.Stream target) { }
+    }
+    public sealed class SkiaBitmapLoader : Splat.IBitmapLoader
+    {
+        public SkiaBitmapLoader() { }
+        public SkiaBitmapLoader(SkiaSharp.SKSamplingOptions sampling) { }
+        public SkiaSharp.SKSamplingOptions Sampling { get; }
+        public Splat.IBitmap Create(float width, float height) { }
+        public System.Threading.Tasks.Task<Splat.IBitmap?> Load(System.IO.Stream sourceStream, float? desiredWidth, float? desiredHeight) { }
+        public System.Threading.Tasks.Task<Splat.IBitmap?> LoadFromResource(string source, float? desiredWidth, float? desiredHeight) { }
+    }
+}

--- a/src/Splat.SkiaSharp/PublicAPI/net11.0/PublicAPI.txt
+++ b/src/Splat.SkiaSharp/PublicAPI/net11.0/PublicAPI.txt
@@ -1,0 +1,53 @@
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.SkiaSharp.Tests")]
+namespace Splat.Builder
+{
+    public sealed class SkiaSharpSplatModule : Splat.Builder.IModule
+    {
+        public SkiaSharpSplatModule() { }
+        public SkiaSharpSplatModule(SkiaSharp.SKSamplingOptions? sampling) { }
+        public void Configure(Splat.IMutableDependencyResolver resolver) { }
+    }
+}
+namespace Splat.SkiaSharp
+{
+    public static class BitmapMixins
+    {
+        extension(SkiaSharp.SKBitmap value)
+        {
+            public Splat.IBitmap FromNative() { }
+        }
+        extension(Splat.IBitmap value)
+        {
+            public SkiaSharp.SKBitmap ToNative() { }
+        }
+    }
+    public static class MutableDependencyResolverExtensions
+    {
+        extension(Splat.IMutableDependencyResolver instance)
+        {
+            public void UseSkiaSharpBitmapLoader() { }
+            public void UseSkiaSharpBitmapLoader(SkiaSharp.SKSamplingOptions sampling) { }
+        }
+    }
+    public sealed class SkiaBitmap : Splat.IBitmap
+    {
+        public SkiaBitmap(SkiaSharp.SKBitmap bitmap) { }
+        public SkiaBitmap(SkiaSharp.SKBitmap bitmap, SkiaSharp.SKEncodedOrigin encodedOrigin) { }
+        public SkiaSharp.SKEncodedOrigin EncodedOrigin { get; }
+        public float Height { get; }
+        public SkiaSharp.SKBitmap? Inner { get; }
+        public float Width { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task Save(SkiaSharp.SKEncodedImageFormat format, float quality, System.IO.Stream target) { }
+        public System.Threading.Tasks.Task Save(Splat.CompressedBitmapFormat format, float quality, System.IO.Stream target) { }
+    }
+    public sealed class SkiaBitmapLoader : Splat.IBitmapLoader
+    {
+        public SkiaBitmapLoader() { }
+        public SkiaBitmapLoader(SkiaSharp.SKSamplingOptions sampling) { }
+        public SkiaSharp.SKSamplingOptions Sampling { get; }
+        public Splat.IBitmap Create(float width, float height) { }
+        public System.Threading.Tasks.Task<Splat.IBitmap?> Load(System.IO.Stream sourceStream, float? desiredWidth, float? desiredHeight) { }
+        public System.Threading.Tasks.Task<Splat.IBitmap?> LoadFromResource(string source, float? desiredWidth, float? desiredHeight) { }
+    }
+}

--- a/src/Splat.SkiaSharp/PublicAPI/net8.0/PublicAPI.txt
+++ b/src/Splat.SkiaSharp/PublicAPI/net8.0/PublicAPI.txt
@@ -1,0 +1,53 @@
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.SkiaSharp.Tests")]
+namespace Splat.Builder
+{
+    public sealed class SkiaSharpSplatModule : Splat.Builder.IModule
+    {
+        public SkiaSharpSplatModule() { }
+        public SkiaSharpSplatModule(SkiaSharp.SKSamplingOptions? sampling) { }
+        public void Configure(Splat.IMutableDependencyResolver resolver) { }
+    }
+}
+namespace Splat.SkiaSharp
+{
+    public static class BitmapMixins
+    {
+        extension(SkiaSharp.SKBitmap value)
+        {
+            public Splat.IBitmap FromNative() { }
+        }
+        extension(Splat.IBitmap value)
+        {
+            public SkiaSharp.SKBitmap ToNative() { }
+        }
+    }
+    public static class MutableDependencyResolverExtensions
+    {
+        extension(Splat.IMutableDependencyResolver instance)
+        {
+            public void UseSkiaSharpBitmapLoader() { }
+            public void UseSkiaSharpBitmapLoader(SkiaSharp.SKSamplingOptions sampling) { }
+        }
+    }
+    public sealed class SkiaBitmap : Splat.IBitmap
+    {
+        public SkiaBitmap(SkiaSharp.SKBitmap bitmap) { }
+        public SkiaBitmap(SkiaSharp.SKBitmap bitmap, SkiaSharp.SKEncodedOrigin encodedOrigin) { }
+        public SkiaSharp.SKEncodedOrigin EncodedOrigin { get; }
+        public float Height { get; }
+        public SkiaSharp.SKBitmap? Inner { get; }
+        public float Width { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task Save(SkiaSharp.SKEncodedImageFormat format, float quality, System.IO.Stream target) { }
+        public System.Threading.Tasks.Task Save(Splat.CompressedBitmapFormat format, float quality, System.IO.Stream target) { }
+    }
+    public sealed class SkiaBitmapLoader : Splat.IBitmapLoader
+    {
+        public SkiaBitmapLoader() { }
+        public SkiaBitmapLoader(SkiaSharp.SKSamplingOptions sampling) { }
+        public SkiaSharp.SKSamplingOptions Sampling { get; }
+        public Splat.IBitmap Create(float width, float height) { }
+        public System.Threading.Tasks.Task<Splat.IBitmap?> Load(System.IO.Stream sourceStream, float? desiredWidth, float? desiredHeight) { }
+        public System.Threading.Tasks.Task<Splat.IBitmap?> LoadFromResource(string source, float? desiredWidth, float? desiredHeight) { }
+    }
+}

--- a/src/Splat.SkiaSharp/PublicAPI/net9.0/PublicAPI.txt
+++ b/src/Splat.SkiaSharp/PublicAPI/net9.0/PublicAPI.txt
@@ -1,0 +1,53 @@
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Splat.SkiaSharp.Tests")]
+namespace Splat.Builder
+{
+    public sealed class SkiaSharpSplatModule : Splat.Builder.IModule
+    {
+        public SkiaSharpSplatModule() { }
+        public SkiaSharpSplatModule(SkiaSharp.SKSamplingOptions? sampling) { }
+        public void Configure(Splat.IMutableDependencyResolver resolver) { }
+    }
+}
+namespace Splat.SkiaSharp
+{
+    public static class BitmapMixins
+    {
+        extension(SkiaSharp.SKBitmap value)
+        {
+            public Splat.IBitmap FromNative() { }
+        }
+        extension(Splat.IBitmap value)
+        {
+            public SkiaSharp.SKBitmap ToNative() { }
+        }
+    }
+    public static class MutableDependencyResolverExtensions
+    {
+        extension(Splat.IMutableDependencyResolver instance)
+        {
+            public void UseSkiaSharpBitmapLoader() { }
+            public void UseSkiaSharpBitmapLoader(SkiaSharp.SKSamplingOptions sampling) { }
+        }
+    }
+    public sealed class SkiaBitmap : Splat.IBitmap
+    {
+        public SkiaBitmap(SkiaSharp.SKBitmap bitmap) { }
+        public SkiaBitmap(SkiaSharp.SKBitmap bitmap, SkiaSharp.SKEncodedOrigin encodedOrigin) { }
+        public SkiaSharp.SKEncodedOrigin EncodedOrigin { get; }
+        public float Height { get; }
+        public SkiaSharp.SKBitmap? Inner { get; }
+        public float Width { get; }
+        public void Dispose() { }
+        public System.Threading.Tasks.Task Save(SkiaSharp.SKEncodedImageFormat format, float quality, System.IO.Stream target) { }
+        public System.Threading.Tasks.Task Save(Splat.CompressedBitmapFormat format, float quality, System.IO.Stream target) { }
+    }
+    public sealed class SkiaBitmapLoader : Splat.IBitmapLoader
+    {
+        public SkiaBitmapLoader() { }
+        public SkiaBitmapLoader(SkiaSharp.SKSamplingOptions sampling) { }
+        public SkiaSharp.SKSamplingOptions Sampling { get; }
+        public Splat.IBitmap Create(float width, float height) { }
+        public System.Threading.Tasks.Task<Splat.IBitmap?> Load(System.IO.Stream sourceStream, float? desiredWidth, float? desiredHeight) { }
+        public System.Threading.Tasks.Task<Splat.IBitmap?> LoadFromResource(string source, float? desiredWidth, float? desiredHeight) { }
+    }
+}

--- a/src/Splat.SkiaSharp/SkiaBitmap.cs
+++ b/src/Splat.SkiaSharp/SkiaBitmap.cs
@@ -1,0 +1,104 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO;
+
+using SkiaSharp;
+
+namespace Splat.SkiaSharp;
+
+/// <summary>An <see cref="IBitmap"/> whose pixels are held by Skia.</summary>
+/// <remarks>
+/// The instance owns the bitmap it is given and releases it on <see cref="Dispose"/>, so a caller
+/// that wants to keep drawing with the Skia bitmap afterwards has to hand over a copy.
+/// </remarks>
+public sealed class SkiaBitmap : IBitmap
+{
+    /// <summary>The percentage Skia's encoders express quality in.</summary>
+    private const float EncoderQualityScale = 100F;
+
+    /// <summary>The bitmap being wrapped, cleared once it has been disposed.</summary>
+    private SKBitmap? _inner;
+
+    /// <summary>Initializes a new instance of the <see cref="SkiaBitmap"/> class.</summary>
+    /// <param name="bitmap">The bitmap to take ownership of.</param>
+    public SkiaBitmap(SKBitmap bitmap)
+        : this(bitmap, SKEncodedOrigin.TopLeft)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="SkiaBitmap"/> class.</summary>
+    /// <param name="bitmap">The bitmap to take ownership of, already in its upright orientation.</param>
+    /// <param name="encodedOrigin">The orientation the source image recorded.</param>
+    public SkiaBitmap(SKBitmap bitmap, SKEncodedOrigin encodedOrigin)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(bitmap);
+
+        _inner = bitmap;
+        EncodedOrigin = encodedOrigin;
+    }
+
+    /// <inheritdoc />
+    public float Width => _inner?.Width ?? 0;
+
+    /// <inheritdoc />
+    public float Height => _inner?.Height ?? 0;
+
+    /// <summary>Gets the orientation the source image recorded, which the loader has already applied to the pixels.</summary>
+    /// <remarks>
+    /// Anything other than <see cref="SKEncodedOrigin.TopLeft"/> means the encoded pixels were stored rotated or
+    /// mirrored; the value is kept so a caller re-encoding the image can decide what orientation to record.
+    /// </remarks>
+    public SKEncodedOrigin EncodedOrigin { get; }
+
+    /// <summary>Gets the Skia bitmap backing this instance, or <see langword="null"/> once it has been disposed.</summary>
+    public SKBitmap? Inner => _inner;
+
+    /// <inheritdoc />
+    public Task Save(CompressedBitmapFormat format, float quality, Stream target) =>
+        Save(format == CompressedBitmapFormat.Jpeg ? SKEncodedImageFormat.Jpeg : SKEncodedImageFormat.Png, quality, target);
+
+    /// <summary>Saves the image in any format Skia can encode, rather than only the two <see cref="CompressedBitmapFormat"/> names.</summary>
+    /// <param name="format">The encoder to use. Which ones are built into the native library varies by platform.</param>
+    /// <param name="quality">A factor between 0 and 1, where 1 is the best quality. Lossless encoders ignore it.</param>
+    /// <param name="target">The stream to write the encoded image to.</param>
+    /// <returns>A task that completes once the encoded image has been written.</returns>
+    /// <exception cref="BitmapLoaderException">The native library has no encoder for the requested format.</exception>
+    public Task Save(SKEncodedImageFormat format, float quality, Stream target)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(target);
+
+        var bitmap = _inner;
+        ObjectDisposedExceptionHelper.ThrowIf(bitmap is null, this);
+
+        return SaveCore(bitmap, format, quality, target);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        _inner?.Dispose();
+        _inner = null;
+    }
+
+    /// <summary>Encodes the bitmap and writes it to the target stream.</summary>
+    /// <param name="bitmap">The bitmap to encode.</param>
+    /// <param name="format">The encoder to use.</param>
+    /// <param name="quality">A factor between 0 and 1, where 1 is the best quality.</param>
+    /// <param name="target">The stream to write the encoded image to.</param>
+    /// <returns>A task that completes once the encoded image has been written.</returns>
+    private static async Task SaveCore(SKBitmap bitmap, SKEncodedImageFormat format, float quality, Stream target)
+    {
+        using var data = bitmap.Encode(format, ToEncoderQuality(quality))
+            ?? throw new BitmapLoaderException($"The native library has no encoder for {format}.");
+        await using var source = data.AsStream();
+
+        await source.CopyToAsync(target).ConfigureAwait(false);
+    }
+
+    /// <summary>Converts the interface's 0-to-1 quality factor to the percentage Skia's encoders take.</summary>
+    /// <param name="quality">The quality factor to convert.</param>
+    /// <returns>The quality as a percentage.</returns>
+    private static int ToEncoderQuality(float quality) => (int)MathF.Round(Math.Clamp(quality, 0F, 1F) * EncoderQualityScale);
+}

--- a/src/Splat.SkiaSharp/SkiaBitmapLoader.cs
+++ b/src/Splat.SkiaSharp/SkiaBitmapLoader.cs
@@ -1,0 +1,264 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO;
+
+using SkiaSharp;
+
+namespace Splat.SkiaSharp;
+
+/// <summary>An <see cref="IBitmapLoader"/> that decodes and encodes through Skia.</summary>
+/// <remarks>
+/// The plain .NET target frameworks have no imaging stack of their own, so this is the loader for
+/// server, console, container and Linux hosts. It reads whatever the native library was built with
+/// - PNG, JPEG, WebP and GIF everywhere, and more besides on some platforms.
+/// </remarks>
+public sealed class SkiaBitmapLoader : IBitmapLoader
+{
+    /// <summary>The buffer size used when opening a file, matching the framework's own default.</summary>
+    private const int FileBufferSize = 4096;
+
+    /// <summary>The sampling used for resizing when the caller does not choose one.</summary>
+    private static readonly SKSamplingOptions _defaultSampling = new(SKFilterMode.Linear, SKMipmapMode.Linear);
+
+    /// <summary>The sampling this loader resizes with.</summary>
+    private readonly SKSamplingOptions _sampling;
+
+    /// <summary>Initializes a new instance of the <see cref="SkiaBitmapLoader"/> class.</summary>
+    public SkiaBitmapLoader()
+        : this(_defaultSampling)
+    {
+    }
+
+    /// <summary>Initializes a new instance of the <see cref="SkiaBitmapLoader"/> class.</summary>
+    /// <param name="sampling">The sampling to resize with. Skia offers nearest, linear and cubic resamplers.</param>
+    public SkiaBitmapLoader(SKSamplingOptions sampling) => _sampling = sampling;
+
+    /// <summary>Gets the sampling this loader resizes with.</summary>
+    public SKSamplingOptions Sampling => _sampling;
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Supplying both dimensions fits the image inside that box without distorting it; supplying one
+    /// derives the other from the image's proportions. Only some codecs - JPEG in practice - can decode
+    /// straight to a smaller size, so the rest are decoded whole and then resized.
+    /// </remarks>
+    public async Task<IBitmap?> Load(Stream sourceStream, float? desiredWidth, float? desiredHeight)
+    {
+        ArgumentExceptionHelper.ThrowIfNull(sourceStream);
+
+        using var data = await ReadAsync(sourceStream).ConfigureAwait(false);
+
+        return Decode(data, desiredWidth, desiredHeight, _sampling);
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// There is no bundle or resource URI scheme on these target frameworks, so the source names a file:
+    /// either an absolute path, or one relative to the directory the application was loaded from.
+    /// </remarks>
+    public async Task<IBitmap?> LoadFromResource(string source, float? desiredWidth, float? desiredHeight)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(source);
+
+        var path = Path.IsPathRooted(source) ? source : Path.Combine(AppContext.BaseDirectory, source);
+
+        await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read, FileBufferSize, FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+        return await Load(stream, desiredWidth, desiredHeight).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public IBitmap Create(float width, float height)
+    {
+        ArgumentOutOfRangeExceptionHelper.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeExceptionHelper.ThrowIfNegativeOrZero(height);
+
+        return new SkiaBitmap(new SKBitmap(Math.Max(1, (int)width), Math.Max(1, (int)height)));
+    }
+
+    /// <summary>Works out the size to decode to, honouring the image's proportions.</summary>
+    /// <remarks>
+    /// Supplying both dimensions asks for a fit rather than a stretch, so the constraint that produces the
+    /// smaller scale factor binds and the other is derived from it.
+    /// </remarks>
+    /// <param name="source">The size of the image as it will be displayed.</param>
+    /// <param name="desiredWidth">The requested width, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <param name="desiredHeight">The requested height, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <returns>The size to produce, never smaller than one pixel in either direction.</returns>
+    internal static SKSizeI ChooseTargetSize(SKSizeI source, float? desiredWidth, float? desiredHeight)
+    {
+        var width = desiredWidth is null ? 0 : Math.Max(1, (int)desiredWidth.Value);
+        var height = desiredHeight is null ? 0 : Math.Max(1, (int)desiredHeight.Value);
+
+        if (width == 0 && height == 0)
+        {
+            return source;
+        }
+
+        if (width == 0)
+        {
+            return new(ScaleDimension(source.Width, height, source.Height), height);
+        }
+
+        if (height == 0)
+        {
+            return new(width, ScaleDimension(source.Height, width, source.Width));
+        }
+
+        return (double)width / source.Width <= (double)height / source.Height
+            ? new SKSizeI(width, ScaleDimension(source.Height, width, source.Width))
+            : new SKSizeI(ScaleDimension(source.Width, height, source.Height), height);
+    }
+
+    /// <summary>Reports whether an orientation exchanges the image's width and height.</summary>
+    /// <param name="origin">The orientation to test.</param>
+    /// <returns><see langword="true"/> when the upright image is the encoded one turned on its side.</returns>
+    internal static bool SwapsDimensions(SKEncodedOrigin origin) =>
+        origin is SKEncodedOrigin.LeftTop or SKEncodedOrigin.RightTop or SKEncodedOrigin.RightBottom or SKEncodedOrigin.LeftBottom;
+
+    /// <summary>Turns the decoded pixels the right way up.</summary>
+    /// <remarks>
+    /// Skia hands back the pixels exactly as they were stored and reports the orientation separately, so a
+    /// photograph taken side-on decodes side-on unless this is applied. Ownership of <paramref name="source"/>
+    /// passes to this method: it is either handed straight back or released once its pixels have been copied.
+    /// </remarks>
+    /// <param name="source">The decoded bitmap, in the orientation it was encoded in.</param>
+    /// <param name="origin">The orientation the source image recorded.</param>
+    /// <param name="sampling">The sampling to draw with.</param>
+    /// <returns>The upright bitmap.</returns>
+    internal static SKBitmap ApplyEncodedOrigin(SKBitmap source, SKEncodedOrigin origin, SKSamplingOptions sampling)
+    {
+        if (origin == SKEncodedOrigin.TopLeft)
+        {
+            return source;
+        }
+
+        var swaps = SwapsDimensions(origin);
+        var upright = new SKBitmap(source.Info.WithSize(swaps ? source.Height : source.Width, swaps ? source.Width : source.Height));
+        var matrix = CreateOriginMatrix(origin, source.Width, source.Height);
+
+        using (source)
+        {
+            using var canvas = new SKCanvas(upright);
+            canvas.SetMatrix(in matrix);
+            canvas.DrawBitmap(source, 0, 0, sampling);
+        }
+
+        return upright;
+    }
+
+    /// <summary>Builds the transform that maps encoded pixel positions to upright ones.</summary>
+    /// <remarks>
+    /// The eight orientations are the four rotations and their mirror images, so each is a signed
+    /// permutation of the two axes with a translation that brings the result back into the first quadrant.
+    /// </remarks>
+    /// <param name="origin">The orientation the source image recorded.</param>
+    /// <param name="width">The encoded width.</param>
+    /// <param name="height">The encoded height.</param>
+    /// <returns>The transform to draw the encoded pixels through.</returns>
+    internal static SKMatrix CreateOriginMatrix(SKEncodedOrigin origin, int width, int height) => origin switch
+    {
+        SKEncodedOrigin.TopRight => new(-1, 0, width, 0, 1, 0, 0, 0, 1),
+        SKEncodedOrigin.BottomRight => new(-1, 0, width, 0, -1, height, 0, 0, 1),
+        SKEncodedOrigin.BottomLeft => new(1, 0, 0, 0, -1, height, 0, 0, 1),
+        SKEncodedOrigin.LeftTop => new(0, 1, 0, 1, 0, 0, 0, 0, 1),
+        SKEncodedOrigin.RightTop => new(0, -1, height, 1, 0, 0, 0, 0, 1),
+        SKEncodedOrigin.RightBottom => new(0, -1, height, -1, 0, width, 0, 0, 1),
+        SKEncodedOrigin.LeftBottom => new(0, 1, 0, -1, 0, width, 0, 0, 1),
+        _ => SKMatrix.CreateIdentity(),
+    };
+
+    /// <summary>Decodes encoded image data to the requested size.</summary>
+    /// <param name="data">The encoded image.</param>
+    /// <param name="desiredWidth">The requested width, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <param name="desiredHeight">The requested height, or <see langword="null"/> when the caller did not constrain it.</param>
+    /// <param name="sampling">The sampling to resize with.</param>
+    /// <returns>The decoded image, or <see langword="null"/> when no codec recognised the data.</returns>
+    internal static SkiaBitmap? Decode(SKData data, float? desiredWidth, float? desiredHeight, SKSamplingOptions sampling)
+    {
+        using var codec = CreateCodec(data);
+        if (codec is null)
+        {
+            return null;
+        }
+
+        var origin = codec.EncodedOrigin;
+        var encoded = codec.Info.Size;
+        var oriented = SwapsDimensions(origin) ? new SKSizeI(encoded.Height, encoded.Width) : encoded;
+        var target = ChooseTargetSize(oriented, desiredWidth, desiredHeight);
+
+        var decoded = DecodeAtLeast(codec, encoded, oriented, target);
+
+        return new(ResizeTo(ApplyEncodedOrigin(decoded, origin, sampling), target, sampling), origin);
+    }
+
+    /// <summary>Creates a codec for encoded image data.</summary>
+    /// <remarks>
+    /// Skia annotates this as always succeeding, but it hands back nothing at all when no codec recognises
+    /// the data, which is the ordinary answer for a stream that does not hold an image.
+    /// </remarks>
+    /// <param name="data">The encoded image.</param>
+    /// <returns>The codec, or <see langword="null"/> when no codec recognised the data.</returns>
+    private static SKCodec? CreateCodec(SKData data) => SKCodec.Create(data);
+
+    /// <summary>Decodes at the closest size at or above the target that the codec can produce directly.</summary>
+    /// <remarks>
+    /// Only some codecs - JPEG in practice - support a scaled decode; the rest report their full size and
+    /// are resized afterwards. Asking for a size the codec did not offer makes it refuse to decode at all,
+    /// so the size has to come from the codec rather than from the caller.
+    /// </remarks>
+    /// <param name="codec">The codec to decode with.</param>
+    /// <param name="encoded">The encoded pixel dimensions.</param>
+    /// <param name="oriented">The encoded dimensions as they will be displayed.</param>
+    /// <param name="target">The size wanted, in display orientation.</param>
+    /// <returns>The decoded bitmap.</returns>
+    private static SKBitmap DecodeAtLeast(SKCodec codec, SKSizeI encoded, SKSizeI oriented, SKSizeI target)
+    {
+        // Orientation only exchanges the two axes, so the linear scale factor is the same either way round.
+        var scale = (float)target.Width / oriented.Width;
+        var scaled = scale >= 1F ? encoded : codec.GetScaledDimensions(scale);
+
+        return SKBitmap.Decode(codec, codec.Info.WithSize(scaled));
+    }
+
+    /// <summary>Resizes to the target size, when the bitmap is not already that size.</summary>
+    /// <remarks>Ownership of <paramref name="source"/> passes to this method.</remarks>
+    /// <param name="source">The bitmap to resize.</param>
+    /// <param name="target">The size wanted.</param>
+    /// <param name="sampling">The sampling to resize with.</param>
+    /// <returns>The bitmap at the target size.</returns>
+    private static SKBitmap ResizeTo(SKBitmap source, SKSizeI target, SKSamplingOptions sampling)
+    {
+        if (source.Width == target.Width && source.Height == target.Height)
+        {
+            return source;
+        }
+
+        using (source)
+        {
+            return source.Resize(target, sampling);
+        }
+    }
+
+    /// <summary>Reads a stream into memory Skia can decode from.</summary>
+    /// <param name="source">The stream to read.</param>
+    /// <returns>The stream's remaining content.</returns>
+    private static async Task<SKData> ReadAsync(Stream source)
+    {
+        await using var buffer = new MemoryStream();
+
+        await source.CopyToAsync(buffer).ConfigureAwait(false);
+
+        return SKData.CreateCopy(buffer.GetBuffer().AsSpan(0, (int)buffer.Length));
+    }
+
+    /// <summary>Scales one dimension by the ratio another was scaled by.</summary>
+    /// <param name="value">The dimension to scale.</param>
+    /// <param name="numerator">The scaled size of the other dimension.</param>
+    /// <param name="denominator">The original size of the other dimension.</param>
+    /// <returns>The scaled dimension, never below one pixel.</returns>
+    private static int ScaleDimension(int value, int numerator, int denominator) =>
+        Math.Max(1, (int)Math.Round((double)value * numerator / denominator));
+}

--- a/src/Splat.SkiaSharp/Splat.SkiaSharp.csproj
+++ b/src/Splat.SkiaSharp/Splat.SkiaSharp.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(SplatModernTargets)</TargetFrameworks>
+    <AssemblyName>Splat.SkiaSharp</AssemblyName>
+    <RootNamespace>Splat</RootNamespace>
+    <Authors>.NET Foundation and Contributors</Authors>
+    <Description>SkiaSharp bitmap loading and saving for Splat on the plain .NET target frameworks, which have no platform imaging stack of their own</Description>
+    <PackageId>Splat.SkiaSharp</PackageId>
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" />
+    <!-- SkiaSharp itself only brings the macOS and Win32 native assets on the plain .NET target
+         frameworks, so Linux has to be asked for by name: without this the package restores
+         cleanly and then fails to load its native library on exactly the hosts this package
+         exists to serve. The build with no external shared-library dependencies is the one that
+         runs in a bare container; a consumer that also rasterises text can replace it with
+         SkiaSharp.NativeAssets.Linux, which links against fontconfig. -->
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Splat.Drawing\Splat.Drawing.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="Splat.SkiaSharp.Tests" />
+  </ItemGroup>
+  <!-- Shipped to consumers, and imported here so this repository's own output matches theirs. -->
+  <ItemGroup>
+    <None Include="build\Splat.SkiaSharp.targets" Pack="true" PackagePath="buildTransitive\Splat.SkiaSharp.targets" />
+  </ItemGroup>
+  <Import Project="build\Splat.SkiaSharp.targets" />
+</Project>

--- a/src/Splat.SkiaSharp/Splat.SkiaSharp.csproj
+++ b/src/Splat.SkiaSharp/Splat.SkiaSharp.csproj
@@ -10,13 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="SkiaSharp" />
-    <!-- SkiaSharp itself only brings the macOS and Win32 native assets on the plain .NET target
-         frameworks, so Linux has to be asked for by name: without this the package restores
-         cleanly and then fails to load its native library on exactly the hosts this package
-         exists to serve. The build with no external shared-library dependencies is the one that
-         runs in a bare container; a consumer that also rasterises text can replace it with
-         SkiaSharp.NativeAssets.Linux, which links against fontconfig. -->
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Splat.Drawing\Splat.Drawing.csproj" />

--- a/src/Splat.SkiaSharp/build/Splat.SkiaSharp.targets
+++ b/src/Splat.SkiaSharp/build/Splat.SkiaSharp.targets
@@ -1,0 +1,34 @@
+<Project>
+
+  <!--
+    The Skia native packages ship a debug symbol file next to each Windows native library, and each
+    one is roughly seven times the size of the library it describes. Nothing resolves them at run
+    time, but the SDK copies every native asset it finds, so leaving them in place adds hundreds of
+    megabytes to the build and publish output of any project that references this package. Set
+    SplatSkiaSharpIncludeNativeSymbols to true to keep them for native debugging.
+  -->
+  <PropertyGroup>
+    <SplatSkiaSharpIncludeNativeSymbols Condition="'$(SplatSkiaSharpIncludeNativeSymbols)' == ''">false</SplatSkiaSharpIncludeNativeSymbols>
+  </PropertyGroup>
+
+  <Target Name="SplatSkiaSharpRemoveNativeSymbolsFromOutput"
+          AfterTargets="ResolveReferences"
+          Condition="'$(SplatSkiaSharpIncludeNativeSymbols)' != 'true'">
+    <ItemGroup>
+      <ReferenceCopyLocalPaths Remove="@(ReferenceCopyLocalPaths)"
+                               Condition="'%(Filename)%(Extension)' == 'libSkiaSharp.pdb'" />
+      <RuntimeTargetsCopyLocalItems Remove="@(RuntimeTargetsCopyLocalItems)"
+                                    Condition="'%(Filename)%(Extension)' == 'libSkiaSharp.pdb'" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="SplatSkiaSharpRemoveNativeSymbolsFromPublish"
+          AfterTargets="ComputeResolvedFilesToPublishList"
+          Condition="'$(SplatSkiaSharpIncludeNativeSymbols)' != 'true'">
+    <ItemGroup>
+      <ResolvedFileToPublish Remove="@(ResolvedFileToPublish)"
+                             Condition="'%(Filename)%(Extension)' == 'libSkiaSharp.pdb'" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Splat.slnx
+++ b/src/Splat.slnx
@@ -11,6 +11,7 @@
     <Project Path="Splat.Core/Splat.Core.csproj" />
     <Project Path="Splat.Drawing/Splat.Drawing.csproj" />
     <Project Path="Splat.Logging/Splat.Logging.csproj" />
+    <Project Path="Splat.SkiaSharp/Splat.SkiaSharp.csproj" />
     <Project Path="Splat/Splat.csproj" />
   </Folder>
   <Folder Name="/ExtensionsAppLocator/">
@@ -38,6 +39,7 @@
     <Project Path="tests/Splat.Builder.Tests/Splat.Builder.Tests.csproj" />
     <Project Path="tests/Splat.Common.Test/Splat.Common.Test.csproj" />
     <Project Path="tests/Splat.Drawing.Tests/Splat.Drawing.Tests.csproj" />
+    <Project Path="tests/Splat.SkiaSharp.Tests/Splat.SkiaSharp.Tests.csproj" />
     <Project Path="tests/Splat.Tests/Splat.Tests.csproj" />
   </Folder>
   <Folder Name="/test/DI/">

--- a/src/tests/Splat.SkiaSharp.Tests/BitmapMixinsTests.cs
+++ b/src/tests/Splat.SkiaSharp.Tests/BitmapMixinsTests.cs
@@ -1,0 +1,93 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO;
+
+using SkiaSharp;
+
+namespace Splat.SkiaSharp.Tests;
+
+/// <summary>Unit tests for converting between <see cref="IBitmap"/> and the Skia bitmap behind it.</summary>
+public sealed class BitmapMixinsTests
+{
+    /// <summary>The width of the bitmaps the tests convert.</summary>
+    private const int BitmapWidth = 20;
+
+    /// <summary>The height of the bitmaps the tests convert.</summary>
+    private const int BitmapHeight = 10;
+
+    /// <summary>Verifies that a Skia bitmap becomes an <see cref="IBitmap"/> of the same size.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task FromNative_WrapsTheSkiaBitmap()
+    {
+        using var bitmap = TestImages.CreateCornerMarked(BitmapWidth, BitmapHeight).FromNative();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(bitmap.Width).IsEqualTo((float)BitmapWidth);
+            await Assert.That(bitmap.Height).IsEqualTo((float)BitmapHeight);
+        }
+    }
+
+    /// <summary>Verifies that the conversion hands back the very bitmap that was wrapped.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ToNative_ReturnsTheWrappedSkiaBitmap()
+    {
+        var native = TestImages.CreateCornerMarked(BitmapWidth, BitmapHeight);
+        using var bitmap = native.FromNative();
+
+        await Assert.That(bitmap.ToNative()).IsSameReferenceAs(native);
+    }
+
+    /// <summary>Verifies that a released bitmap says so rather than handing out a dangling reference.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ToNative_AfterDispose_Throws()
+    {
+        var bitmap = TestImages.CreateCornerMarked(BitmapWidth, BitmapHeight).FromNative();
+        bitmap.Dispose();
+
+        await Assert.That(bitmap.ToNative).Throws<InvalidOperationException>();
+    }
+
+    /// <summary>Verifies that a bitmap has to be supplied.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ToNative_WithoutABitmap_Throws()
+    {
+        const IBitmap bitmap = null!;
+
+        await Assert.That(static () => bitmap.ToNative()).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that a bitmap from a different loader is rejected rather than reinterpreted.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ToNative_WithAForeignBitmap_Throws()
+    {
+        using var bitmap = new ForeignBitmap();
+
+        await Assert.That(() => bitmap.ToNative()).Throws<InvalidCastException>();
+    }
+
+    /// <summary>An <see cref="IBitmap"/> from somewhere other than this package.</summary>
+    private sealed class ForeignBitmap : IBitmap
+    {
+        /// <inheritdoc />
+        public float Width => 0;
+
+        /// <inheritdoc />
+        public float Height => 0;
+
+        /// <inheritdoc />
+        public Task Save(CompressedBitmapFormat format, float quality, Stream target) => Task.CompletedTask;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/src/tests/Splat.SkiaSharp.Tests/DecodeSizeTests.cs
+++ b/src/tests/Splat.SkiaSharp.Tests/DecodeSizeTests.cs
@@ -1,0 +1,110 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using SkiaSharp;
+
+namespace Splat.SkiaSharp.Tests;
+
+/// <summary>Unit tests for the size a requested width and height decode to.</summary>
+public sealed class DecodeSizeTests
+{
+    /// <summary>The width of the image the requests are made against.</summary>
+    private const int SourceWidth = 400;
+
+    /// <summary>The height of the image the requests are made against.</summary>
+    private const int SourceHeight = 200;
+
+    /// <summary>The size of the image the requests are made against.</summary>
+    private static readonly SKSizeI _source = new(SourceWidth, SourceHeight);
+
+    /// <summary>Verifies that an unconstrained request keeps the image's own size.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ChooseTargetSize_Unconstrained_KeepsTheSourceSize() =>
+        await Assert.That(SkiaBitmapLoader.ChooseTargetSize(_source, null, null)).IsEqualTo(_source);
+
+    /// <summary>Verifies that the dimension the caller left out is derived from the image's proportions.</summary>
+    /// <param name="desiredWidth">The requested width, or a negative number for no constraint.</param>
+    /// <param name="desiredHeight">The requested height, or a negative number for no constraint.</param>
+    /// <param name="expectedWidth">The width the request should produce.</param>
+    /// <param name="expectedHeight">The height the request should produce.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(100F, -1F, 100, 50)]
+    [Arguments(-1F, 50F, 100, 50)]
+    [Arguments(300F, -1F, 300, 150)]
+    [Arguments(-1F, 150F, 300, 150)]
+    public async Task ChooseTargetSize_OneDimension_DerivesTheOther(float desiredWidth, float desiredHeight, int expectedWidth, int expectedHeight)
+    {
+        var target = SkiaBitmapLoader.ChooseTargetSize(_source, Requested(desiredWidth), Requested(desiredHeight));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(target.Width).IsEqualTo(expectedWidth);
+            await Assert.That(target.Height).IsEqualTo(expectedHeight);
+        }
+    }
+
+    /// <summary>Verifies that asking for both dimensions fits the image inside that box rather than stretching it.</summary>
+    /// <param name="desiredWidth">The requested width.</param>
+    /// <param name="desiredHeight">The requested height.</param>
+    /// <param name="expectedWidth">The width the request should produce.</param>
+    /// <param name="expectedHeight">The height the request should produce.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(100F, 100F, 100, 50)]
+    [Arguments(1000F, 50F, 100, 50)]
+    [Arguments(100F, 50F, 100, 50)]
+    [Arguments(800F, 800F, 800, 400)]
+    public async Task ChooseTargetSize_BothDimensions_FitsInsideTheBox(float desiredWidth, float desiredHeight, int expectedWidth, int expectedHeight)
+    {
+        var target = SkiaBitmapLoader.ChooseTargetSize(_source, desiredWidth, desiredHeight);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(target.Width).IsEqualTo(expectedWidth);
+            await Assert.That(target.Height).IsEqualTo(expectedHeight);
+        }
+    }
+
+    /// <summary>Verifies that a request that would round away to nothing still produces a pixel.</summary>
+    /// <param name="desiredWidth">The requested width.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(0.4F)]
+    [Arguments(0F)]
+    [Arguments(-5F)]
+    [Arguments(1F)]
+    public async Task ChooseTargetSize_BelowOnePixel_ClampsToOnePixel(float desiredWidth)
+    {
+        var target = SkiaBitmapLoader.ChooseTargetSize(_source, desiredWidth, null);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(target.Width).IsEqualTo(1);
+            await Assert.That(target.Height).IsEqualTo(1);
+        }
+    }
+
+    /// <summary>Verifies that a proportion that does not divide evenly rounds to the nearest pixel.</summary>
+    /// <param name="sourceWidth">The width of the image the request is made against.</param>
+    /// <param name="sourceHeight">The height of the image the request is made against.</param>
+    /// <param name="desiredWidth">The requested width.</param>
+    /// <param name="expectedHeight">The height the request should produce.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(3, 7, 2F, 5)]
+    [Arguments(7, 3, 2F, 1)]
+    public async Task ChooseTargetSize_UnevenProportions_RoundsToTheNearestPixel(int sourceWidth, int sourceHeight, float desiredWidth, int expectedHeight)
+    {
+        var target = SkiaBitmapLoader.ChooseTargetSize(new(sourceWidth, sourceHeight), desiredWidth, null);
+
+        await Assert.That(target.Height).IsEqualTo(expectedHeight);
+    }
+
+    /// <summary>Turns a negative test argument into the absence of a constraint.</summary>
+    /// <param name="value">The value from the test case.</param>
+    /// <returns>The requested dimension, or <see langword="null"/> when the case asked for none.</returns>
+    private static float? Requested(float value) => value < 0 ? null : value;
+}

--- a/src/tests/Splat.SkiaSharp.Tests/EncodedOrientationTests.cs
+++ b/src/tests/Splat.SkiaSharp.Tests/EncodedOrientationTests.cs
@@ -1,0 +1,90 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using SkiaSharp;
+
+namespace Splat.SkiaSharp.Tests;
+
+/// <summary>Unit tests for turning encoded pixels the right way up.</summary>
+public sealed class EncodedOrientationTests
+{
+    /// <summary>The width of the bitmap the orientations are applied to.</summary>
+    private const int SourceWidth = 4;
+
+    /// <summary>The height of the bitmap the orientations are applied to.</summary>
+    private const int SourceHeight = 2;
+
+    /// <summary>The sampling used when redrawing, chosen so a pixel keeps its exact colour.</summary>
+    private static readonly SKSamplingOptions _nearest = new(SKFilterMode.Nearest);
+
+    /// <summary>Verifies which orientations exchange the width and the height.</summary>
+    /// <param name="origin">The orientation to test.</param>
+    /// <param name="expected">Whether the orientation turns the image on its side.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(SKEncodedOrigin.TopLeft, false)]
+    [Arguments(SKEncodedOrigin.TopRight, false)]
+    [Arguments(SKEncodedOrigin.BottomRight, false)]
+    [Arguments(SKEncodedOrigin.BottomLeft, false)]
+    [Arguments(SKEncodedOrigin.LeftTop, true)]
+    [Arguments(SKEncodedOrigin.RightTop, true)]
+    [Arguments(SKEncodedOrigin.RightBottom, true)]
+    [Arguments(SKEncodedOrigin.LeftBottom, true)]
+    public async Task SwapsDimensions_ReportsTheSidewaysOrientations(SKEncodedOrigin origin, bool expected) =>
+        await Assert.That(SkiaBitmapLoader.SwapsDimensions(origin)).IsEqualTo(expected);
+
+    /// <summary>Verifies that an image already the right way up is left untouched.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task ApplyEncodedOrigin_TopLeft_ReturnsTheSameBitmap()
+    {
+        using var source = TestImages.CreateCornerMarked(SourceWidth, SourceHeight);
+
+        var upright = SkiaBitmapLoader.ApplyEncodedOrigin(source, SKEncodedOrigin.TopLeft, _nearest);
+
+        await Assert.That(upright).IsSameReferenceAs(source);
+    }
+
+    /// <summary>Verifies that an upright orientation asks for no transform at all.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task CreateOriginMatrix_TopLeft_IsTheIdentity()
+    {
+        var matrix = SkiaBitmapLoader.CreateOriginMatrix(SKEncodedOrigin.TopLeft, SourceWidth, SourceHeight);
+
+        await Assert.That(matrix).IsEqualTo(SKMatrix.CreateIdentity());
+    }
+
+    /// <summary>Verifies that each orientation moves the marked corner where the standard says it belongs.</summary>
+    /// <remarks>
+    /// The four rotations and their mirror images each send the encoded top left corner to a different
+    /// corner of the upright image, so the marker's position identifies the transform on its own.
+    /// </remarks>
+    /// <param name="origin">The orientation to apply.</param>
+    /// <param name="expectedWidth">The width the upright image should have.</param>
+    /// <param name="expectedHeight">The height the upright image should have.</param>
+    /// <param name="expectedX">The column the marked corner should end up in.</param>
+    /// <param name="expectedY">The row the marked corner should end up in.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(SKEncodedOrigin.TopLeft, SourceWidth, SourceHeight, 0, 0)]
+    [Arguments(SKEncodedOrigin.TopRight, SourceWidth, SourceHeight, 3, 0)]
+    [Arguments(SKEncodedOrigin.BottomRight, SourceWidth, SourceHeight, 3, 1)]
+    [Arguments(SKEncodedOrigin.BottomLeft, SourceWidth, SourceHeight, 0, 1)]
+    [Arguments(SKEncodedOrigin.LeftTop, SourceHeight, SourceWidth, 0, 0)]
+    [Arguments(SKEncodedOrigin.RightTop, SourceHeight, SourceWidth, 1, 0)]
+    [Arguments(SKEncodedOrigin.RightBottom, SourceHeight, SourceWidth, 1, 3)]
+    [Arguments(SKEncodedOrigin.LeftBottom, SourceHeight, SourceWidth, 0, 3)]
+    public async Task ApplyEncodedOrigin_MovesTheMarkedCorner(SKEncodedOrigin origin, int expectedWidth, int expectedHeight, int expectedX, int expectedY)
+    {
+        using var upright = SkiaBitmapLoader.ApplyEncodedOrigin(TestImages.CreateCornerMarked(SourceWidth, SourceHeight), origin, _nearest);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(upright.Width).IsEqualTo(expectedWidth);
+            await Assert.That(upright.Height).IsEqualTo(expectedHeight);
+            await Assert.That(TestImages.FindMarker(upright)).IsEqualTo((expectedX, expectedY));
+        }
+    }
+}

--- a/src/tests/Splat.SkiaSharp.Tests/SkiaBitmapLoaderTests.cs
+++ b/src/tests/Splat.SkiaSharp.Tests/SkiaBitmapLoaderTests.cs
@@ -1,0 +1,294 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO;
+
+using SkiaSharp;
+
+namespace Splat.SkiaSharp.Tests;
+
+/// <summary>Unit tests for <see cref="SkiaBitmapLoader"/>.</summary>
+public sealed class SkiaBitmapLoaderTests
+{
+    /// <summary>The width of the images the tests decode.</summary>
+    private const int SourceWidth = 400;
+
+    /// <summary>The height of the images the tests decode.</summary>
+    private const int SourceHeight = 200;
+
+    /// <summary>How far a decoded image's proportions may drift from the source's.</summary>
+    private const float AspectTolerance = 0.01F;
+
+    /// <summary>Verifies that a decode with no requested size keeps the image's own dimensions.</summary>
+    /// <param name="format">The encoder the fixture is written with.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(SKEncodedImageFormat.Png)]
+    [Arguments(SKEncodedImageFormat.Jpeg)]
+    [Arguments(SKEncodedImageFormat.Webp)]
+    public async Task Load_WithoutADesiredSize_KeepsTheImageSize(SKEncodedImageFormat format)
+    {
+        var loader = new SkiaBitmapLoader();
+        await using var source = TestImages.OpenStream(SourceWidth, SourceHeight, format);
+
+        using var bitmap = await loader.Load(source, null, null);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(bitmap!.Width).IsEqualTo((float)SourceWidth);
+            await Assert.That(bitmap.Height).IsEqualTo((float)SourceHeight);
+        }
+    }
+
+    /// <summary>Verifies that a requested size is honoured without distorting the image.</summary>
+    /// <remarks>
+    /// A PNG has to be decoded whole and resized, while a JPEG can be decoded straight to a smaller
+    /// size, so both encoders are exercised through the same expectations.
+    /// </remarks>
+    /// <param name="format">The encoder the fixture is written with.</param>
+    /// <param name="desiredWidth">The requested width, or a negative number for no constraint.</param>
+    /// <param name="desiredHeight">The requested height, or a negative number for no constraint.</param>
+    /// <param name="expectedWidth">The width the decode should produce.</param>
+    /// <param name="expectedHeight">The height the decode should produce.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(SKEncodedImageFormat.Png, 100F, 100F, 100, 50)]
+    [Arguments(SKEncodedImageFormat.Png, 100F, -1F, 100, 50)]
+    [Arguments(SKEncodedImageFormat.Png, -1F, 50F, 100, 50)]
+    [Arguments(SKEncodedImageFormat.Png, 1000F, 50F, 100, 50)]
+    [Arguments(SKEncodedImageFormat.Png, 800F, 800F, 800, 400)]
+    [Arguments(SKEncodedImageFormat.Jpeg, 100F, 100F, 100, 50)]
+    [Arguments(SKEncodedImageFormat.Jpeg, 200F, -1F, 200, 100)]
+    [Arguments(SKEncodedImageFormat.Jpeg, -1F, 25F, 50, 25)]
+    [Arguments(SKEncodedImageFormat.Webp, 60F, 60F, 60, 30)]
+    public async Task Load_WithADesiredSize_KeepsTheAspectRatio(
+        SKEncodedImageFormat format,
+        float desiredWidth,
+        float desiredHeight,
+        int expectedWidth,
+        int expectedHeight)
+    {
+        var loader = new SkiaBitmapLoader();
+        await using var source = TestImages.OpenStream(SourceWidth, SourceHeight, format);
+
+        using var bitmap = await loader.Load(source, Requested(desiredWidth), Requested(desiredHeight));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(bitmap!.Width).IsEqualTo((float)expectedWidth);
+            await Assert.That(bitmap.Height).IsEqualTo((float)expectedHeight);
+            await Assert.That(bitmap.Width / bitmap.Height).IsEqualTo((float)SourceWidth / SourceHeight).Within(AspectTolerance);
+        }
+    }
+
+    /// <summary>Verifies that an image stored on its side comes back the right way up.</summary>
+    /// <remarks>
+    /// A camera records the orientation rather than rotating the pixels, so the decoded size is the
+    /// encoded one with its axes exchanged, and a requested size describes the upright image.
+    /// </remarks>
+    /// <param name="orientation">The orientation to record, numbered as the metadata standard numbers them.</param>
+    /// <param name="expectedOrigin">The orientation the decoded bitmap should report.</param>
+    /// <param name="desiredWidth">The requested width, or a negative number for no constraint.</param>
+    /// <param name="expectedWidth">The width the decode should produce.</param>
+    /// <param name="expectedHeight">The height the decode should produce.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(1, SKEncodedOrigin.TopLeft, -1F, 400, 200)]
+    [Arguments(3, SKEncodedOrigin.BottomRight, -1F, 400, 200)]
+    [Arguments(6, SKEncodedOrigin.RightTop, -1F, 200, 400)]
+    [Arguments(6, SKEncodedOrigin.RightTop, 100F, 100, 200)]
+    [Arguments(8, SKEncodedOrigin.LeftBottom, 50F, 50, 100)]
+    public async Task Load_WithARecordedOrientation_TurnsTheImageUpright(
+        int orientation,
+        SKEncodedOrigin expectedOrigin,
+        float desiredWidth,
+        int expectedWidth,
+        int expectedHeight)
+    {
+        var loader = new SkiaBitmapLoader();
+        await using var source = new MemoryStream(TestImages.EncodeWithOrientation(SourceWidth, SourceHeight, orientation));
+
+        using var bitmap = await loader.Load(source, Requested(desiredWidth), null);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(bitmap!.Width).IsEqualTo((float)expectedWidth);
+            await Assert.That(bitmap.Height).IsEqualTo((float)expectedHeight);
+            await Assert.That(((SkiaBitmap)bitmap).EncodedOrigin).IsEqualTo(expectedOrigin);
+        }
+    }
+
+    /// <summary>Verifies that a stream holding no image reports nothing rather than failing.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Load_WithoutAnImage_ReturnsNothing()
+    {
+        var loader = new SkiaBitmapLoader();
+        await using var source = new MemoryStream("this is not an image"u8.ToArray());
+
+        var bitmap = await loader.Load(source, null, null);
+
+        await Assert.That(bitmap).IsNull();
+    }
+
+    /// <summary>Verifies that the loader rejects a missing stream.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Load_WithoutAStream_Throws()
+    {
+        var loader = new SkiaBitmapLoader();
+
+        await Assert.That(async () => await loader.Load(null!, null, null)).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that the sampling the loader was built with is the one it reports.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Sampling_ReportsTheChosenResampler()
+    {
+        var chosen = new SKSamplingOptions(SKFilterMode.Nearest);
+        var fallback = new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.Linear);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(new SkiaBitmapLoader(chosen).Sampling).IsEqualTo(chosen);
+            await Assert.That(new SkiaBitmapLoader().Sampling).IsEqualTo(fallback);
+        }
+    }
+
+    /// <summary>Verifies that a resource path relative to the application directory is resolved.</summary>
+    /// <param name="desiredWidth">The requested width.</param>
+    /// <param name="expectedWidth">The width the decode should produce.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(100F, 100)]
+    public async Task LoadFromResource_WithARelativePath_ResolvesAgainstTheApplicationDirectory(float desiredWidth, int expectedWidth)
+    {
+        var name = $"{Guid.NewGuid():N}.png";
+        var path = Path.Combine(AppContext.BaseDirectory, name);
+        await File.WriteAllBytesAsync(path, TestImages.Encode(SourceWidth, SourceHeight, SKEncodedImageFormat.Png));
+
+        try
+        {
+            var loader = new SkiaBitmapLoader();
+
+            using var bitmap = await loader.LoadFromResource(name, desiredWidth, null);
+
+            await Assert.That(bitmap!.Width).IsEqualTo((float)expectedWidth);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>Verifies that a resource named by an absolute path is read from that path.</summary>
+    /// <param name="desiredHeight">The requested height.</param>
+    /// <param name="expectedWidth">The width the decode should produce.</param>
+    /// <param name="expectedHeight">The height the decode should produce.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(50F, 100, 50)]
+    public async Task LoadFromResource_WithAnAbsolutePath_ReadsThatFile(float desiredHeight, int expectedWidth, int expectedHeight)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.png");
+        await File.WriteAllBytesAsync(path, TestImages.Encode(SourceWidth, SourceHeight, SKEncodedImageFormat.Png));
+
+        try
+        {
+            var loader = new SkiaBitmapLoader();
+
+            using var bitmap = await loader.LoadFromResource(path, null, desiredHeight);
+
+            using (Assert.Multiple())
+            {
+                await Assert.That(bitmap!.Width).IsEqualTo((float)expectedWidth);
+                await Assert.That(bitmap.Height).IsEqualTo((float)expectedHeight);
+            }
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    /// <summary>Verifies that the loader rejects a resource name that identifies nothing.</summary>
+    /// <param name="source">The resource name to reject.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(null)]
+    [Arguments("")]
+    [Arguments("   ")]
+    public async Task LoadFromResource_WithoutAName_Throws(string? source)
+    {
+        var loader = new SkiaBitmapLoader();
+
+        await Assert.That(async () => await loader.LoadFromResource(source!, null, null)).Throws<ArgumentException>();
+    }
+
+    /// <summary>Verifies that an empty canvas is created at the requested size.</summary>
+    /// <param name="width">The width to ask for.</param>
+    /// <param name="height">The height to ask for.</param>
+    /// <param name="expectedWidth">The width the canvas should have.</param>
+    /// <param name="expectedHeight">The height the canvas should have.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(64F, 32F, 64, 32)]
+    [Arguments(0.5F, 0.5F, 1, 1)]
+    public async Task Create_ProducesACanvasOfTheRequestedSize(float width, float height, int expectedWidth, int expectedHeight)
+    {
+        var loader = new SkiaBitmapLoader();
+
+        using var bitmap = loader.Create(width, height);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(bitmap.Width).IsEqualTo((float)expectedWidth);
+            await Assert.That(bitmap.Height).IsEqualTo((float)expectedHeight);
+        }
+    }
+
+    /// <summary>Verifies that a canvas with no area is rejected rather than silently produced.</summary>
+    /// <param name="width">The width to ask for.</param>
+    /// <param name="height">The height to ask for.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(0F, 10F)]
+    [Arguments(10F, 0F)]
+    [Arguments(-1F, 10F)]
+    [Arguments(10F, -1F)]
+    public async Task Create_WithoutAnArea_Throws(float width, float height)
+    {
+        var loader = new SkiaBitmapLoader();
+
+        await Assert.That(() => loader.Create(width, height)).Throws<ArgumentOutOfRangeException>();
+    }
+
+    /// <summary>Verifies that a bitmap decoded from a stream reaches call sites through the static accessor.</summary>
+    /// <param name="desiredWidth">The requested width.</param>
+    /// <param name="expectedWidth">The width the decode should produce.</param>
+    /// <param name="expectedHeight">The height the decode should produce.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(40F, 40, 20)]
+    [NotInParallel] // Mutates the global BitmapLoader.Current static state.
+    public async Task BitmapLoaderCurrent_OnceRegistered_DecodesThroughThisLoader(float desiredWidth, int expectedWidth, int expectedHeight)
+    {
+        BitmapLoader.Current = new SkiaBitmapLoader();
+        await using var source = TestImages.OpenStream(SourceWidth, SourceHeight, SKEncodedImageFormat.Png);
+
+        using var bitmap = await BitmapLoader.Current.Load(source, desiredWidth, null);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(bitmap!.Width).IsEqualTo((float)expectedWidth);
+            await Assert.That(bitmap.Height).IsEqualTo((float)expectedHeight);
+        }
+    }
+
+    /// <summary>Turns a negative test argument into the absence of a constraint.</summary>
+    /// <param name="value">The value from the test case.</param>
+    /// <returns>The requested dimension, or <see langword="null"/> when the case asked for none.</returns>
+    private static float? Requested(float value) => value < 0 ? null : value;
+}

--- a/src/tests/Splat.SkiaSharp.Tests/SkiaBitmapTests.cs
+++ b/src/tests/Splat.SkiaSharp.Tests/SkiaBitmapTests.cs
@@ -1,0 +1,182 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO;
+
+using SkiaSharp;
+
+namespace Splat.SkiaSharp.Tests;
+
+/// <summary>Unit tests for <see cref="SkiaBitmap"/>.</summary>
+public sealed class SkiaBitmapTests
+{
+    /// <summary>The width of the bitmaps the tests encode.</summary>
+    private const int BitmapWidth = 20;
+
+    /// <summary>The height of the bitmaps the tests encode.</summary>
+    private const int BitmapHeight = 10;
+
+    /// <summary>Verifies that the wrapper reports the dimensions of the bitmap it holds.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Dimensions_ComeFromTheWrappedBitmap()
+    {
+        using var bitmap = new SkiaBitmap(TestImages.CreateCornerMarked(BitmapWidth, BitmapHeight));
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(bitmap.Width).IsEqualTo((float)BitmapWidth);
+            await Assert.That(bitmap.Height).IsEqualTo((float)BitmapHeight);
+        }
+    }
+
+    /// <summary>Verifies that a disposed bitmap reports no size and hands out nothing.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Dispose_ReleasesTheWrappedBitmap()
+    {
+        var bitmap = new SkiaBitmap(TestImages.CreateCornerMarked(BitmapWidth, BitmapHeight));
+
+        bitmap.Dispose();
+        bitmap.Dispose();
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(bitmap.Width).IsEqualTo(0F);
+            await Assert.That(bitmap.Height).IsEqualTo(0F);
+            await Assert.That(bitmap.Inner).IsNull();
+        }
+    }
+
+    /// <summary>Verifies that a bitmap has to be supplied.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Constructor_WithoutABitmap_Throws() =>
+        await Assert.That(static () => new SkiaBitmap(null!)).Throws<ArgumentNullException>();
+
+    /// <summary>Verifies that a bitmap with no recorded orientation reports the upright one.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task EncodedOrigin_DefaultsToUpright()
+    {
+        using var bitmap = new SkiaBitmap(TestImages.CreateCornerMarked(BitmapWidth, BitmapHeight));
+
+        await Assert.That(bitmap.EncodedOrigin).IsEqualTo(SKEncodedOrigin.TopLeft);
+    }
+
+    /// <summary>Verifies that the orientation the source recorded is kept.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task EncodedOrigin_KeepsWhatTheSourceRecorded()
+    {
+        using var bitmap = new SkiaBitmap(TestImages.CreateCornerMarked(BitmapWidth, BitmapHeight), SKEncodedOrigin.RightTop);
+
+        await Assert.That(bitmap.EncodedOrigin).IsEqualTo(SKEncodedOrigin.RightTop);
+    }
+
+    /// <summary>Verifies that the two <see cref="CompressedBitmapFormat"/> names produce readable images.</summary>
+    /// <param name="format">The format to save in.</param>
+    /// <param name="quality">The quality factor to save with.</param>
+    /// <param name="expected">The encoder the saved bytes should identify as.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(CompressedBitmapFormat.Png, 0.8F, SKEncodedImageFormat.Png)]
+    [Arguments(CompressedBitmapFormat.Jpeg, 0.8F, SKEncodedImageFormat.Jpeg)]
+    public async Task Save_WritesTheRequestedCompressedFormat(CompressedBitmapFormat format, float quality, SKEncodedImageFormat expected)
+    {
+        using var bitmap = new SkiaBitmap(TestImages.CreateCornerMarked(BitmapWidth, BitmapHeight));
+        await using var target = new MemoryStream();
+
+        await bitmap.Save(format, quality, target);
+
+        await AssertRoundTrips(target, expected);
+    }
+
+    /// <summary>Verifies that the additive overload reaches formats the shared enumeration has no name for.</summary>
+    /// <param name="format">The encoder to save with.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(SKEncodedImageFormat.Webp)]
+    [Arguments(SKEncodedImageFormat.Png)]
+    [Arguments(SKEncodedImageFormat.Jpeg)]
+    public async Task Save_WritesAnyFormatTheNativeLibraryCanEncode(SKEncodedImageFormat format)
+    {
+        using var bitmap = new SkiaBitmap(TestImages.CreateCornerMarked(BitmapWidth, BitmapHeight));
+        await using var target = new MemoryStream();
+
+        await bitmap.Save(format, 1F, target);
+
+        await AssertRoundTrips(target, format);
+    }
+
+    /// <summary>Verifies that a quality outside the interface's range is brought back into it.</summary>
+    /// <param name="quality">The quality factor to save with.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(-1F)]
+    [Arguments(0F)]
+    [Arguments(0.5F)]
+    [Arguments(1F)]
+    [Arguments(5F)]
+    public async Task Save_WithAQualityOutsideTheRange_StillEncodes(float quality)
+    {
+        using var bitmap = new SkiaBitmap(TestImages.CreateCornerMarked(BitmapWidth, BitmapHeight));
+        await using var target = new MemoryStream();
+
+        await bitmap.Save(CompressedBitmapFormat.Jpeg, quality, target);
+
+        await AssertRoundTrips(target, SKEncodedImageFormat.Jpeg);
+    }
+
+    /// <summary>Verifies that a format the native library only reads is reported rather than written empty.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Save_WithoutAnEncoder_Throws()
+    {
+        using var bitmap = new SkiaBitmap(TestImages.CreateCornerMarked(BitmapWidth, BitmapHeight));
+        await using var target = new MemoryStream();
+
+        await Assert.That(async () => await bitmap.Save(SKEncodedImageFormat.Astc, 1F, target)).Throws<BitmapLoaderException>();
+    }
+
+    /// <summary>Verifies that a target stream has to be supplied.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Save_WithoutATarget_Throws()
+    {
+        using var bitmap = new SkiaBitmap(TestImages.CreateCornerMarked(BitmapWidth, BitmapHeight));
+
+        await Assert.That(async () => await bitmap.Save(CompressedBitmapFormat.Png, 1F, null!)).Throws<ArgumentNullException>();
+    }
+
+    /// <summary>Verifies that saving a released bitmap says so rather than writing nothing.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Save_AfterDispose_Throws()
+    {
+        var bitmap = new SkiaBitmap(TestImages.CreateCornerMarked(BitmapWidth, BitmapHeight));
+        bitmap.Dispose();
+
+        await using var target = new MemoryStream();
+
+        await Assert.That(async () => await bitmap.Save(CompressedBitmapFormat.Png, 1F, target)).Throws<ObjectDisposedException>();
+    }
+
+    /// <summary>Asserts that the written bytes decode back to the bitmap that was saved.</summary>
+    /// <param name="target">The stream the image was written to.</param>
+    /// <param name="expected">The encoder the bytes should identify as.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    private static async Task AssertRoundTrips(MemoryStream target, SKEncodedImageFormat expected)
+    {
+        using var data = SKData.CreateCopy(target.GetBuffer().AsSpan(0, (int)target.Length));
+        using var codec = SKCodec.Create(data);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(codec.EncodedFormat).IsEqualTo(expected);
+            await Assert.That(codec.Info.Width).IsEqualTo(BitmapWidth);
+            await Assert.That(codec.Info.Height).IsEqualTo(BitmapHeight);
+        }
+    }
+}

--- a/src/tests/Splat.SkiaSharp.Tests/SkiaSharpSplatModuleTests.cs
+++ b/src/tests/Splat.SkiaSharp.Tests/SkiaSharpSplatModuleTests.cs
@@ -1,0 +1,118 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using SkiaSharp;
+
+using Splat.Builder;
+
+namespace Splat.SkiaSharp.Tests;
+
+/// <summary>Unit tests for registering Skia as the bitmap loader.</summary>
+public sealed class SkiaSharpSplatModuleTests
+{
+    /// <summary>Verifies that the module registers a loader that can be resolved.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Configure_RegistersTheBitmapLoader()
+    {
+        using var resolver = new ModernDependencyResolver();
+
+        new SkiaSharpSplatModule().Configure(resolver);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(resolver.HasRegistration(typeof(IBitmapLoader))).IsTrue();
+            await Assert.That(resolver.GetService<IBitmapLoader>()).IsTypeOf<SkiaBitmapLoader>();
+        }
+    }
+
+    /// <summary>Verifies that a module built with a sampling passes it to the loader.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Configure_WithASampling_PassesItToTheLoader()
+    {
+        using var resolver = new ModernDependencyResolver();
+        var sampling = new SKSamplingOptions(SKFilterMode.Nearest);
+
+        new SkiaSharpSplatModule(sampling).Configure(resolver);
+
+        await Assert.That(((SkiaBitmapLoader)resolver.GetService<IBitmapLoader>()!).Sampling).IsEqualTo(sampling);
+    }
+
+    /// <summary>Verifies that configuring twice leaves a usable registration.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Configure_Twice_LeavesAUsableRegistration()
+    {
+        using var resolver = new ModernDependencyResolver();
+        var module = new SkiaSharpSplatModule();
+
+        module.Configure(resolver);
+        module.Configure(resolver);
+
+        await Assert.That(resolver.GetService<IBitmapLoader>()).IsNotNull();
+    }
+
+    /// <summary>Verifies that the module rejects a missing resolver.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task Configure_WithoutAResolver_Throws() =>
+        await Assert.That(static () => new SkiaSharpSplatModule().Configure(null!)).Throws<ArgumentNullException>();
+
+    /// <summary>Verifies that the registration extension registers a loader that can be resolved.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task UseSkiaSharpBitmapLoader_RegistersTheBitmapLoader()
+    {
+        using var resolver = new ModernDependencyResolver();
+
+        resolver.UseSkiaSharpBitmapLoader();
+
+        await Assert.That(resolver.GetService<IBitmapLoader>()).IsTypeOf<SkiaBitmapLoader>();
+    }
+
+    /// <summary>Verifies that the registration extension passes the chosen sampling to the loader.</summary>
+    /// <param name="resampler">The cubic resampler coefficient to build the sampling from.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [Arguments(0.33F)]
+    public async Task UseSkiaSharpBitmapLoader_WithASampling_PassesItToTheLoader(float resampler)
+    {
+        using var resolver = new ModernDependencyResolver();
+        var sampling = new SKSamplingOptions(new SKCubicResampler(resampler, resampler));
+
+        resolver.UseSkiaSharpBitmapLoader(sampling);
+
+        await Assert.That(((SkiaBitmapLoader)resolver.GetService<IBitmapLoader>()!).Sampling).IsEqualTo(sampling);
+    }
+
+    /// <summary>Verifies that the registration extensions reject a missing resolver.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    public async Task UseSkiaSharpBitmapLoader_WithoutAResolver_Throws()
+    {
+        const IMutableDependencyResolver resolver = null!;
+        var sampling = new SKSamplingOptions(SKFilterMode.Nearest);
+
+        using (Assert.Multiple())
+        {
+            await Assert.That(static () => resolver.UseSkiaSharpBitmapLoader()).Throws<ArgumentNullException>();
+            await Assert.That(() => resolver.UseSkiaSharpBitmapLoader(sampling)).Throws<ArgumentNullException>();
+        }
+    }
+
+    /// <summary>Verifies that the module can be composed through the application builder.</summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Test]
+    [NotInParallel] // Mutates the builder's global built state.
+    public async Task UsingModule_RegistersTheBitmapLoaderOnTheBuildersResolver()
+    {
+        using var resolver = new ModernDependencyResolver();
+        AppBuilder.ResetBuilderStateForTests();
+
+        _ = new AppBuilder(resolver).UsingModule(new SkiaSharpSplatModule()).Build();
+
+        await Assert.That(resolver.GetService<IBitmapLoader>()).IsTypeOf<SkiaBitmapLoader>();
+    }
+}

--- a/src/tests/Splat.SkiaSharp.Tests/Splat.SkiaSharp.Tests.csproj
+++ b/src/tests/Splat.SkiaSharp.Tests/Splat.SkiaSharp.Tests.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(SplatModernTargets)</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Splat.SkiaSharp\Splat.SkiaSharp.csproj" />
+  </ItemGroup>
+
+  <!-- The shipped targets do not travel over a project reference, so import them here to keep this
+       project's output the same size as a consumer's. -->
+  <Import Project="..\..\Splat.SkiaSharp\build\Splat.SkiaSharp.targets" />
+
+</Project>

--- a/src/tests/Splat.SkiaSharp.Tests/Splat.SkiaSharp.Tests.csproj
+++ b/src/tests/Splat.SkiaSharp.Tests/Splat.SkiaSharp.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\Splat.SkiaSharp\Splat.SkiaSharp.csproj" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Condition="$([MSBuild]::IsOsPlatform('Linux'))" />
   </ItemGroup>
 
   <!-- The shipped targets do not travel over a project reference, so import them here to keep this

--- a/src/tests/Splat.SkiaSharp.Tests/TestImages.cs
+++ b/src/tests/Splat.SkiaSharp.Tests/TestImages.cs
@@ -1,0 +1,117 @@
+// Copyright (c) 2019-2026 ReactiveUI Association Incorporated. All rights reserved.
+// ReactiveUI Association Incorporated licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for full license information.
+
+using System.IO;
+
+using SkiaSharp;
+
+namespace Splat.SkiaSharp.Tests;
+
+/// <summary>Builds the images the tests decode, so no binary fixtures have to be checked in.</summary>
+internal static class TestImages
+{
+    /// <summary>The encoder quality the fixtures are written at.</summary>
+    private const int FixtureQuality = 90;
+
+    /// <summary>The offset of the orientation value inside <see cref="_orientationSegment"/>.</summary>
+    private const int OrientationValueOffset = 28;
+
+    /// <summary>The offset a marker segment is spliced in at, which is just past the start-of-image marker.</summary>
+    private const int SegmentOffset = 2;
+
+    /// <summary>
+    /// A JPEG application segment holding the smallest well-formed metadata block that records an orientation:
+    /// the Exif identifier, a little-endian header, and a single directory entry for the orientation tag.
+    /// </summary>
+    private static readonly byte[] _orientationSegment =
+    [
+        0xFF, 0xE1, 0x00, 0x22,
+        0x45, 0x78, 0x69, 0x66, 0x00, 0x00,
+        0x49, 0x49, 0x2A, 0x00, 0x08, 0x00, 0x00, 0x00,
+        0x01, 0x00,
+        0x12, 0x01, 0x03, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00,
+    ];
+
+    /// <summary>Creates a white bitmap with a single red pixel in its top left corner.</summary>
+    /// <remarks>The marked corner is what makes a rotation or a mirroring visible in an assertion.</remarks>
+    /// <param name="width">The width to create.</param>
+    /// <param name="height">The height to create.</param>
+    /// <returns>The bitmap.</returns>
+    internal static SKBitmap CreateCornerMarked(int width, int height)
+    {
+        var bitmap = new SKBitmap(width, height);
+
+        using var canvas = new SKCanvas(bitmap);
+        using var paint = new SKPaint { Color = SKColors.Red };
+
+        canvas.Clear(SKColors.White);
+        canvas.DrawRect(0, 0, 1, 1, paint);
+
+        return bitmap;
+    }
+
+    /// <summary>Encodes a corner-marked bitmap.</summary>
+    /// <param name="width">The width to create.</param>
+    /// <param name="height">The height to create.</param>
+    /// <param name="format">The encoder to use.</param>
+    /// <returns>The encoded image.</returns>
+    internal static byte[] Encode(int width, int height, SKEncodedImageFormat format)
+    {
+        using var bitmap = CreateCornerMarked(width, height);
+        using var data = bitmap.Encode(format, FixtureQuality);
+
+        return data.ToArray();
+    }
+
+    /// <summary>Encodes a corner-marked JPEG that records the given orientation.</summary>
+    /// <remarks>
+    /// No encoder writes this metadata, so it is spliced in: the segment goes immediately after the
+    /// start-of-image marker, which is where a decoder looks for it.
+    /// </remarks>
+    /// <param name="width">The width to create.</param>
+    /// <param name="height">The height to create.</param>
+    /// <param name="orientation">The orientation to record, numbered as the metadata standard numbers them.</param>
+    /// <returns>The encoded image.</returns>
+    internal static byte[] EncodeWithOrientation(int width, int height, int orientation)
+    {
+        var jpeg = Encode(width, height, SKEncodedImageFormat.Jpeg);
+        var segment = _orientationSegment.AsSpan().ToArray();
+        segment[OrientationValueOffset] = (byte)orientation;
+
+        var tagged = new byte[jpeg.Length + segment.Length];
+        jpeg.AsSpan(0, SegmentOffset).CopyTo(tagged);
+        segment.CopyTo(tagged.AsSpan(SegmentOffset));
+        jpeg.AsSpan(SegmentOffset).CopyTo(tagged.AsSpan(SegmentOffset + segment.Length));
+
+        return tagged;
+    }
+
+    /// <summary>Opens a stream over an encoded corner-marked bitmap.</summary>
+    /// <param name="width">The width to create.</param>
+    /// <param name="height">The height to create.</param>
+    /// <param name="format">The encoder to use.</param>
+    /// <returns>The stream.</returns>
+    internal static MemoryStream OpenStream(int width, int height, SKEncodedImageFormat format) =>
+        new(Encode(width, height, format));
+
+    /// <summary>Finds the single red pixel a corner-marked bitmap was built with.</summary>
+    /// <param name="bitmap">The bitmap to search.</param>
+    /// <returns>The pixel position, or <see langword="null"/> when nothing in the bitmap is red.</returns>
+    internal static (int X, int Y)? FindMarker(SKBitmap bitmap)
+    {
+        for (var y = 0; y < bitmap.Height; y++)
+        {
+            for (var x = 0; x < bitmap.Width; x++)
+            {
+                if (bitmap.GetPixel(x, y) == SKColors.Red)
+                {
+                    return (x, y);
+                }
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: a new opt-in package.

## What is the new behavior?

- `Splat.SkiaSharp` provides a bitmap loader for the plain .NET targets, which have had no loader at all. A consumer calls `UseSkiaSharpBitmapLoader()`, or applies the module through the builder, and `BitmapLoader.Current` works on server, console, container and Linux.
- `ToNative()` returns the Skia bitmap honestly rather than pretending to be a platform type, and the richer capabilities the library offers sit on an additive surface: the encoded orientation, sampling options, and saving to the formats the core enum does not name.
- Orientation recorded by the camera is applied during the load, so a photograph decodes upright.

## What is the current behavior?

- On net8.0, net9.0, net10.0 and net11.0 nothing registers a loader, so `BitmapLoader.Current` throws. Those targets compile the registration away entirely.

## What might this PR break?

- Nothing existing. This is a new package that no current code references, and it changes no shipped API. A consumer that opts in takes on the native assets it brings with it.

## Checklist
- [x] I have read the [Contribute guide](https://www.reactiveui.net/contribute/index.html)
- [x] Tests have been added or updated (for bug fixes / features)
- [x] Docs have been added or updated (for bug fixes / features)
- [x] Changes target the `main` branch
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)

## Additional information

This is deliberately not sold on speed. Measured against the desktop decoder already shipped, Skia tied on a small image, won on one with transparency, and lost on a large photograph. The reason to have it is reach and capability, not throughput, and no performance claim appears in the code or the docs.

The package takes an explicit dependency on the Linux native assets. Without it the restore succeeds and the first decode throws, because the base package declares only the macOS and Windows natives for these targets, which is precisely the platform this package exists to serve. The variant chosen needs no system font libraries, so it works in the slim container images; a consumer who wants font-backed text rendering should swap in the other one, which the project file notes.

The Windows native assets ship roughly 90 MB of debugging symbols per architecture that nothing loads. The package removes them from the consumer's output and offers a property to keep them, which takes a build from 493 MB to 238 MB, and 186 MB for a package consumer.

Every file is at 100% of lines and branches with no exclusions and no suppressions. Where the orientation branch could not be reached because no encoder writes that tag, the test fixture writes the metadata by hand rather than the code being reshaped around the gap. 384 tests in the new project, and the full solution passes at 20,072.
